### PR TITLE
set whodunnit in avo and display user prettily on versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,3 +89,5 @@ group :test do
   gem "capybara"
   gem "selenium-webdriver"
 end
+
+gem "avo-record_link_field", "~> 0.0.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,7 @@ GEM
       view_component (>= 3.7.0)
       zeitwerk (>= 2.6.12)
     avo-heroicons (0.1.1)
+    avo-record_link_field (0.0.2)
     base64 (0.2.0)
     bcrypt_pbkdf (1.1.1)
     benchmark (0.4.0)
@@ -444,6 +445,7 @@ PLATFORMS
 
 DEPENDENCIES
   avo (>= 3.2.1)
+  avo-record_link_field (~> 0.0.2)
   bootsnap
   brakeman
   capybara

--- a/app/avo/resources/version.rb
+++ b/app/avo/resources/version.rb
@@ -13,6 +13,7 @@ class Avo::Resources::Version < Avo::BaseResource
     field :item_id, as: :number
     field :event, as: :text
     field :whodunnit, as: :text
+    field :user, as: :record_link
     field :object, as: :code
     field :created_at, as: :date_time
   end

--- a/config/initializers/monkey_patches.rb
+++ b/config/initializers/monkey_patches.rb
@@ -18,4 +18,3 @@ Rails.configuration.to_prepare do
     end
   end
 end
-

--- a/config/initializers/monkey_patches.rb
+++ b/config/initializers/monkey_patches.rb
@@ -1,0 +1,21 @@
+# 🔧🐒
+
+Rails.configuration.to_prepare do
+  Avo::BaseApplicationController.class_eval do
+    before_action :set_paper_trail_whodunnit
+    def user_for_paper_trail
+      Avo::Current.user&.id
+    end
+  end
+
+  PaperTrail::Version.class_eval do
+    def user
+      begin
+        User.find(whodunnit) if whodunnit
+      rescue ActiveRecord::RecordNotFound
+        nil
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
avo seems to have built-in audit logging that integrates very neatly with papertrail!
unfortunately, that looks like it is either expen$ive or vaporware or both, so this ought to be close enough