### PR TITLE
Update the frequency of slack updates

### DIFF
--- a/app/controllers/leaderboards_controller.rb
+++ b/app/controllers/leaderboards_controller.rb
@@ -12,7 +12,7 @@ class LeaderboardsController < ApplicationController
 
       @untracked_entries = Hackatime::Heartbeat.today
         .where.not(user_id: @leaderboard.entries.select(:slack_uid))
-        .select('DISTINCT user_id')
+        .select("DISTINCT user_id")
         .count
     end
   end

--- a/app/controllers/leaderboards_controller.rb
+++ b/app/controllers/leaderboards_controller.rb
@@ -7,13 +7,13 @@ class LeaderboardsController < ApplicationController
       flash.now[:notice] = "Leaderboard is being updated..."
     else
       @entries = @leaderboard.entries
-        .includes(:user)
-        .order(total_seconds: :desc)
+                             .includes(:user)
+                             .order(total_seconds: :desc)
 
       @untracked_entries = Hackatime::Heartbeat.today
-        .where.not(user_id: @leaderboard.entries.select(:slack_uid))
-        .select("DISTINCT user_id")
-        .count
+                                               .where.not(user_id: @leaderboard.entries.select(:slack_uid))
+                                               .distinct.pluck(:user_id)
+                                               .size
     end
   end
 end

--- a/app/controllers/leaderboards_controller.rb
+++ b/app/controllers/leaderboards_controller.rb
@@ -10,11 +10,10 @@ class LeaderboardsController < ApplicationController
         .includes(:user)
         .order(total_seconds: :desc)
 
-      all_slack_uids = User.pluck(:slack_uid) - @entries.pluck(:slack_uid)
       @untracked_entries = Hackatime::Heartbeat.today
-                                               .where(user_id: all_slack_uids)
-                                               .distinct.pluck(:user_id)
-                                               .size
+        .where.not(user_id: @leaderboard.entries.select(:slack_uid))
+        .select('DISTINCT user_id')
+        .count
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -107,7 +107,7 @@ class User < ApplicationRecord
         profile: {
           status_text:,
           status_emoji:,
-          status_expiration: (Time.now + 30.minutes).to_i
+          status_expiration: (Time.now + 10.minutes).to_i
         }
       })
   end

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -5,7 +5,7 @@ Rails.application.configure do
 
   config.good_job.cron = {
     update_slack_status: {
-      cron: "*/15 * * * *",
+      cron: "*/5 * * * *",
       class: "UserSlackStatusUpdateJob"
     },
     leaderboard_update: {


### PR DESCRIPTION
Hey! I updated the frequency of Slack updates to address issue #20. 

The expiration time is 10 minutes and it updates every 5 minutes now.

Let me know if there's anything to change. Thanks!

P.S. I accidentally made the change of the leaderboard query on my main branch so it'll pop up here as well. My apologies