### PR TITLE
Add mini-leaderboard & styling

### DIFF
--- a/app/assets/stylesheets/leaderboard.css
+++ b/app/assets/stylesheets/leaderboard.css
@@ -1,0 +1,55 @@
+.mini-leaderboard {
+  background: #f8f9fa;
+  border-radius: 12px;
+  padding: 16px;
+  margin: 20px 0;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+.leaderboard-entries {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.leaderboard-entry {
+  display: flex;
+  align-items: center;
+  padding: 8px 12px;
+  border-radius: 8px;
+  background: white;
+  transition: transform 0.2s ease;
+}
+
+.leaderboard-entry:hover {
+  transform: translateX(4px);
+}
+
+.leaderboard-entry.current-user {
+  background: #f0f7ff;
+  border: 1px solid #cce5ff;
+}
+
+.leaderboard-entry .rank {
+  min-width: 32px;
+  font-weight: 500;
+  color: #666;
+}
+
+.leaderboard-entry .user {
+  flex: 1;
+  margin: 0 12px;
+}
+
+.leaderboard-entry .time {
+  font-family: monospace;
+  color: #444;
+  font-size: 0.9em;
+}
+
+.leaderboard-break {
+  color: #999;
+  margin: -4px 0;
+  font-weight: bold;
+  letter-spacing: 2px;
+} 

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -37,6 +37,9 @@ class StaticPagesController < ApplicationController
 
       @todays_languages = language_counts.map(&:first)
       @todays_editors = editor_counts.map(&:first)
+
+      # Get today's leaderboard
+      @leaderboard = Leaderboard.find_by(start_date: Date.current, deleted_at: nil)
     end
 
     @active_users_count = Rails.cache.fetch("active_users_last_hour", expires_in: 1.minute) do

--- a/app/views/leaderboards/_mini_leaderboard.html.erb
+++ b/app/views/leaderboards/_mini_leaderboard.html.erb
@@ -1,0 +1,46 @@
+<%
+  entries = leaderboard.entries.includes(:user).order(total_seconds: :desc)
+  if current_user
+    user_rank = entries.find_index { |entry| entry.slack_uid == current_user.slack_uid }
+    if user_rank && user_rank >= 3
+      # Show top 2 entries and immediate competition
+      top_entries = entries[0..1]
+      competition_entries = entries[[user_rank - 1, 2].max..[user_rank + 1, entries.size - 1].min]
+      mini_leaderboard_entries = top_entries + competition_entries
+      show_top_entries = false
+    else
+      # Show top 3 entries
+      mini_leaderboard_entries = entries.first(3)
+      show_top_entries = true
+    end
+  end
+%>
+
+<% if mini_leaderboard_entries&.any? %>
+  <div class="mini-leaderboard">
+    <div class="leaderboard-entries">
+      <% mini_leaderboard_entries.each_with_index do |entry, idx| %>
+        <% is_competition = !show_top_entries && idx >= 2 %>
+        <div class="leaderboard-entry <%= 'current-user' if entry.slack_uid == current_user&.slack_uid %>">
+          <% if !is_competition %>
+            <% rank_emoji = case entries.index(entry)
+               when 0 then "🥇"
+               when 1 then "🥈"
+               when 2 then "🥉"
+               end %>
+            <span class="rank"><%= rank_emoji %></span>
+          <% else %>
+            <% if idx == 2 %>
+              <div class="leaderboard-break">...</div>
+            <% end %>
+            <span class="rank"><%= (entries.index(entry) + 1).ordinalize %></span>
+          <% end %>
+          <span class="user" style="display: inline-block;">
+            <%= render "shared/user_mention", user: entry.user %>
+          </span>
+          <span class="time"><%= Time.at(entry.total_seconds).utc.strftime("%H:%M:%S") %></span>
+        </div>
+      <% end %>
+    </div>
+  </div>
+<% end %> 

--- a/app/views/static_pages/index.html.erb
+++ b/app/views/static_pages/index.html.erb
@@ -28,6 +28,10 @@
       <% end %>
     <% end %>
 
+    <% if @leaderboard %>
+      <%= render "leaderboards/mini_leaderboard", leaderboard: @leaderboard, current_user: current_user %>
+    <% end %>
+
     <%= turbo_frame_tag "activity_graph", src: activity_graph_static_pages_path do %>
       <div class="loading">
         Loading activity graph...


### PR DESCRIPTION
Adds a mini-leaderboard to the home page once you're signed in:
<img width="1205" alt="Screenshot 2025-03-12 at 14 31 37" src="https://github.com/user-attachments/assets/fe254979-2af3-4dbf-9c66-e942fb5daaa7" />

Just like every good feature, this is inspired by those mmo-mobile freemium apps. if you're not in the top 3, it'll jump to your position so you know just how much you need to pay for premium
<img width="1192" alt="Screenshot 2025-03-12 at 14 31 28" src="https://github.com/user-attachments/assets/6739a078-36f7-4300-ac38-61b6618e1114" />

