### PR TITLE
Fix Microsoft Install Script

### DIFF
--- a/public/hackatime/setup.ps1
+++ b/public/hackatime/setup.ps1
@@ -3,11 +3,11 @@ $configPath = "$env:USERPROFILE\.wakatime.cfg"
 New-Item -Path $configPath -Force | Out-Null
 Set-Content -Path $configPath -Value @"
 [settings]
-api_url = https://hackatime.hackclub.com/api/hackatime/v1
+api_url = $env:HACKATIME_API_URL
 api_key = $env:HACKATIME_API_KEY
 "@
 
-Write-Host "Config file created at $configPath"
+Write-Host "Config file created at $env:USERPROFILE\.wakatime.cfg"
 
 # Verify config file exists
 if (-not (Test-Path $configPath)) {
@@ -33,7 +33,7 @@ if ([string]::IsNullOrEmpty($apiUrl) -or [string]::IsNullOrEmpty($apiKey)) {
 
 Write-Host "Successfully read config:"
 Write-Host "API URL: $apiUrl"
-Write-Host "API Key: $($apiKey.Substring(0,8))..."
+Write-Host "API Key: $($apiKey.Substring(0,8))..." # Show only first 8 chars for security
 
 # Send test heartbeat using values from config
 Write-Host "Sending test heartbeat..."


### PR DESCRIPTION
This should fix the `setup.ps1` file script by changing a few small things, most importantly replacing the "" with = for parsing.

```
$config = Get-Content $configPath | Where-Object {$_ -match '='} | ForEach-Object {
  $key, $value = $_ -split '=', 2
  [PSCustomObject]@{
    Key = $key.Trim()
    Value = $value.Trim()
  }
}
```

I tested the script on a user who was having issues installing with the previous script.