### PR TITLE
Add tracking for scrapyard pins

### DIFF
--- a/app/models/concerns/heartbeatable.rb
+++ b/app/models/concerns/heartbeatable.rb
@@ -4,7 +4,7 @@ module Heartbeatable
   included do
     # Filter heartbeats to only include those with category equal to "coding"
     scope :coding_only, -> { where(category: "coding") }
-    
+
     # This is to prevent PG timestamp overflow errors if someones gives us a
     # heartbeat with a time that is enormously far in the future.
     scope :with_valid_timestamps, -> { where("time >= 0 AND time <= ?", 253402300799) }
@@ -59,7 +59,7 @@ module Heartbeatable
 
     def duration_seconds(scope = all)
       scope = scope.coding_only.with_valid_timestamps
-      
+
       if scope.group_values.any?
         group_column = scope.group_values.first
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -187,7 +187,7 @@ class User < ApplicationRecord
     email = email_addresses&.first&.email
     return "error displaying name" unless email.present?
 
-    email.split('@')&.first + " (email sign-up)"
+    email.split("@")&.first + " (email sign-up)"
   end
 
   def project_names

--- a/app/views/scrapyard_leaderboards/index.html.erb
+++ b/app/views/scrapyard_leaderboards/index.html.erb
@@ -14,7 +14,7 @@
 
   <% @event_stats.each_with_index do |stats, index| %>
     <div class="event-card" id="event-<%= stats[:event].id %>">
-      <a href="#<%= stats[:event].id %>" class="pin-link" title="Copy link to this event">📌</a>
+      <a href="?event_pin=<%= stats[:event].id %>" class="pin-link" title="Pin this event">📌</a>
       <h2>
         <%= link_to scrapyard_leaderboard_path(stats[:event]) do %>
           <% case index %>
@@ -28,6 +28,9 @@
             <span class="ordinal"><%= (index + 1).ordinalize %></span>
           <% end %>
           <%= stats[:event].name %>
+          <% if @pinned_events.include?(stats[:event]) %>
+            <span title="Currently being watched">👀</span>
+          <% end %>
         <% end %>
       </h2>
       <div class="stats">
@@ -62,8 +65,8 @@
 <% content_for :head do %>
   <script>
     function handlePin() {
-      console.log("Handling pin");
-      const pinId = window.location.hash.substring(1);
+      const params = new URLSearchParams(window.location.search);
+      const pinId = params.get('event_pin');
       
       if (pinId) {
         const targetCard = document.getElementById('event-' + pinId);
@@ -84,28 +87,15 @@
       }
     }
 
-    // Add click handlers to pin links
-    document.addEventListener('turbo:load', function() {
-      document.querySelectorAll('.pin-link').forEach(link => {
-        link.addEventListener('click', function(e) {
-          e.preventDefault();
-          const hash = this.getAttribute('href');
-          window.location.hash = hash;
-          handlePin();
-          window.location.reload();
-        });
-      });
-    });
-
     // Handle both initial page load and subsequent Turbo navigations
     document.addEventListener('turbo:load', handlePin);
     document.addEventListener('turbo:render', handlePin);
     document.addEventListener('DOMContentLoaded', handlePin);
-    window.addEventListener('hashchange', handlePin);
 
     // Set up auto-refresh if we have a pin
     document.addEventListener('turbo:load', function() {
-      if (window.location.hash) {
+      const params = new URLSearchParams(window.location.search);
+      if (params.has('event_pin')) {
         // Clear any existing refresh interval
         if (window.refreshInterval) {
           clearInterval(window.refreshInterval);

--- a/db/migrate/20250315214819_add_index_category_time_heartbeats.rb
+++ b/db/migrate/20250315214819_add_index_category_time_heartbeats.rb
@@ -1,5 +1,5 @@
 class AddIndexCategoryTimeHeartbeats < ActiveRecord::Migration[8.0]
   def change
-    add_index :heartbeats, [:category, :time], name: 'index_heartbeats_on_category_and_time'
+    add_index :heartbeats, [ :category, :time ], name: 'index_heartbeats_on_category_and_time'
   end
 end


### PR DESCRIPTION
<img width="1469" alt="Screenshot 2025-03-15 at 21 09 14" src="https://github.com/user-attachments/assets/c5598bab-c699-4613-80e1-9b1775458cca" />

Now when you 📌 an event, it gets globally marked as being watched (👁️). This means you can tell which events are watching their leaderboard