### PR TITLE
Handle mini leaderboard edgecase for 4th place

### DIFF
--- a/app/views/leaderboards/_mini_leaderboard.html.erb
+++ b/app/views/leaderboards/_mini_leaderboard.html.erb
@@ -34,7 +34,7 @@
                end %>
             <span class="rank"><%= rank_emoji %></span>
           <% else %>
-            <% if idx == 2 %>
+            <% if idx == 2 && entries.index(entry) - entries.index(mini_leaderboard_entries[1]) > 1 %>
               <div class="leaderboard-break">...</div>
             <% end %>
             <span class="rank"><%= (entries.index(entry) + 1).ordinalize %></span>


### PR DESCRIPTION
Before (ignore the colors– just pointing out the `...` in front of the 3):

![423008292-e372177e-a7a3-4f71-a5ab-074a623b4d7f](https://github.com/user-attachments/assets/5e3254a0-6480-4205-8380-e6832b25c964)


After:

<img width="1204" alt="Screenshot 2025-03-18 at 11 50 13" src="https://github.com/user-attachments/assets/3eb19f05-197c-42d5-b95d-abf081becf3e" />
