### PR TITLE
Truncate project name

### DIFF
--- a/app/views/static_pages/_project_durations.html.erb
+++ b/app/views/static_pages/_project_durations.html.erb
@@ -7,7 +7,9 @@
       <% project_durations.each do |project| %>
         <div class="project-duration-card">
           <div class="project-header">
-            <strong><%= project[:project].presence || "Unknown" %></strong>
+            <strong title="<%= project[:project] %>">
+              <%= (project[:project].presence || "Unknown").truncate(12) %>
+            </strong>
             <% if project[:repo_url].present? %>
               <%= link_to "🔗", project[:repo_url], target: "_blank" %>
             <% end %>


### PR DESCRIPTION
Fixes #50

Before:

![423152729-1a6f87fe-6a02-42f2-bcc9-632e8cf5bdaf](https://github.com/user-attachments/assets/767e1377-e4f7-41a9-836f-33951de30fb2)

After:
<img width="611" alt="Screenshot 2025-03-18 at 12 53 01" src="https://github.com/user-attachments/assets/ae4ca8ad-5b02-4e30-bd7f-9e7b34864544" />

Truncated names are hoverable for the full name:

<img width="292" alt="Screenshot 2025-03-18 at 12 52 56" src="https://github.com/user-attachments/assets/181eeba8-4a1f-4df5-912d-a7b705ade68e" />
