### PR TITLE
Add timezone switching support

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -183,6 +183,10 @@
   margin: 0 0 0.1rem;
 }
 
+.super a {
+  color: #666;
+}
+
 .auto-scroll {
   /* flash a little bit yellow & leave a little bit of a border */
   animation: flash 1s ease-in-out;

--- a/app/assets/stylesheets/dark.css
+++ b/app/assets/stylesheets/dark.css
@@ -1,1 +1,0 @@
-/* we implement light mode by editing the color scheme of the page */

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -90,7 +90,10 @@ class StaticPagesController < ApplicationController
     return unless current_user
 
     daily_durations = Rails.cache.fetch("user_#{current_user.id}_daily_durations", expires_in: 1.minute) do
-      current_user.heartbeats.daily_durations.to_h
+      # Set the timezone for the duration of this request
+      Time.use_zone(current_user.timezone) do
+        current_user.heartbeats.daily_durations.to_h
+      end
     end
 
     # Consider 8 hours as a "full" day of coding

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -84,6 +84,6 @@ class UsersController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:uses_slack_status, :hackatime_extension_text_type)
+    params.require(:user).permit(:uses_slack_status, :hackatime_extension_text_type, :timezone)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,6 +28,8 @@ class User < ApplicationRecord
     compliment_text: 2
   }
 
+  after_save :invalidate_activity_graph_cache, if: :saved_change_to_timezone?
+
   def data_migration_jobs
     GoodJob::Job.where(
       "serialized_params->>'arguments' LIKE ?", "%#{id}%"
@@ -247,5 +249,11 @@ class User < ApplicationRecord
 
   def find_valid_token(token)
     sign_in_tokens.valid.find_by(token: token)
+  end
+
+  private
+
+  def invalidate_activity_graph_cache
+    Rails.cache.delete("user_#{id}_daily_durations")
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ class User < ApplicationRecord
   encrypts :slack_access_token
 
   validates :slack_uid, uniqueness: true, allow_nil: true
+  validates :timezone, inclusion: { in: ActiveSupport::TimeZone.all.map(&:name) }, allow_nil: false
 
   has_many :heartbeats
   has_many :email_addresses

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
   encrypts :slack_access_token
 
   validates :slack_uid, uniqueness: true, allow_nil: true
-  validates :timezone, inclusion: { in: ActiveSupport::TimeZone.all.map(&:name) }, allow_nil: false
+  validates :timezone, inclusion: { in: TZInfo::Timezone.all.map(&:identifier) }, allow_nil: false
 
   has_many :heartbeats
   has_many :email_addresses

--- a/app/views/static_pages/_activity_graph.html.erb
+++ b/app/views/static_pages/_activity_graph.html.erb
@@ -18,7 +18,7 @@
         <% end %>
       </div>
       <p class="super">
-        Calculated in <%= link_to ActiveSupport::TimeZone[current_user.timezone].to_s, my_settings_path(anchor: "user_timezone") %>
+        Calculated in <%= link_to ActiveSupport::TimeZone[current_user.timezone].to_s, my_settings_path(anchor: "user_timezone"), data: { turbo_frame: "_top" } %>
       </p>
     </div>
   <% end %>

--- a/app/views/static_pages/_activity_graph.html.erb
+++ b/app/views/static_pages/_activity_graph.html.erb
@@ -1,24 +1,25 @@
 <%= turbo_frame_tag "activity_graph" do %>
-  <%= cache ["activity_graph", current_user.id, current_user.timezone], expires_in: 5.hours do %>
+  <%= cache ["activity_graph", current_user.id, current_user.timezone], expires_in: 1.hours do %>
     <div class="activity-graph-container">
       <div class="activity-graph">
-        <% Time.use_zone(current_user.timezone) do %>
-          <% (365.days.ago.to_date..Time.current.to_date).to_a.each do |date| %>
-            <% duration = daily_durations[date] || 0 %>
-            <% # Calculate lightness from 90% (least active) to 20% (most active) %>
-            <% # if there is no duration, set lightness to 100% %>
-            <% lightness = (duration < 1.minute) ? 100 : 100 - (70.0 * duration / length_of_busiest_day) %>
-            <a class="day"
-              href="?date=<%= date %>"
-              data-turbo-frame="_top"
-              data-date="<%= date %>"
-              data-duration="<%= distance_of_time_in_words(duration) %>"
-              title="you hacked for <%= distance_of_time_in_words(duration) %> on <%= date %>"
-              style="background-color: hsl(120, 100%, <%= lightness %>%);">
-            </a>
-          <% end %>
+        <% (365.days.ago.to_date..Time.current.to_date).to_a.each do |date| %>
+          <% duration = daily_durations[date] || 0 %>
+          <% # Calculate lightness from 90% (least active) to 20% (most active) %>
+          <% # if there is no duration, set lightness to 100% %>
+          <% lightness = (duration < 1.minute) ? 100 : 100 - (70.0 * duration / length_of_busiest_day) %>
+          <a class="day"
+            href="?date=<%= date %>"
+            data-turbo-frame="_top"
+            data-date="<%= date %>"
+            data-duration="<%= distance_of_time_in_words(duration) %>"
+            title="you hacked for <%= distance_of_time_in_words(duration) %> on <%= date %>"
+            style="background-color: hsl(120, 100%, <%= lightness %>%);">
+          </a>
         <% end %>
       </div>
+      <p class="super">
+        Calculated in <%= link_to ActiveSupport::TimeZone[current_user.timezone].to_s, my_settings_path(anchor: "user_timezone") %>
+      </p>
     </div>
   <% end %>
 <% end %>

--- a/app/views/static_pages/_activity_graph.html.erb
+++ b/app/views/static_pages/_activity_graph.html.erb
@@ -1,20 +1,22 @@
 <%= turbo_frame_tag "activity_graph" do %>
-  <%= cache ["activity_graph", current_user.id], expires_in: 5.hours do %>
+  <%= cache ["activity_graph", current_user.id, current_user.timezone], expires_in: 5.hours do %>
     <div class="activity-graph-container">
       <div class="activity-graph">
-        <% (365.days.ago.to_date..Time.current.to_date).to_a.each do |date| %>
-          <% duration = daily_durations[date] || 0 %>
-          <% # Calculate lightness from 90% (least active) to 20% (most active) %>
-          <% # if there is no duration, set lightness to 100% %>
-          <% lightness = (duration < 1.minute) ? 100 : 100 - (70.0 * duration / length_of_busiest_day) %>
-          <a class="day"
-            href="?date=<%= date %>"
-            data-turbo-frame="_top"
-            data-date="<%= date %>"
-            data-duration="<%= distance_of_time_in_words(duration) %>"
-            title="you hacked for <%= distance_of_time_in_words(duration) %> on <%= date %>"
-            style="background-color: hsl(120, 100%, <%= lightness %>%);">
-          </a>
+        <% Time.use_zone(current_user.timezone) do %>
+          <% (365.days.ago.to_date..Time.current.to_date).to_a.each do |date| %>
+            <% duration = daily_durations[date] || 0 %>
+            <% # Calculate lightness from 90% (least active) to 20% (most active) %>
+            <% # if there is no duration, set lightness to 100% %>
+            <% lightness = (duration < 1.minute) ? 100 : 100 - (70.0 * duration / length_of_busiest_day) %>
+            <a class="day"
+              href="?date=<%= date %>"
+              data-turbo-frame="_top"
+              data-date="<%= date %>"
+              data-duration="<%= distance_of_time_in_words(duration) %>"
+              title="you hacked for <%= distance_of_time_in_words(duration) %> on <%= date %>"
+              style="background-color: hsl(120, 100%, <%= lightness %>%);">
+            </a>
+          <% end %>
         <% end %>
       </div>
     </div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -10,6 +10,22 @@
 </div>
 
 <div>
+  <h2 id="user_timezone">Timezone</h2>
+  <%= form_with model: @user,
+    url: @is_own_settings ? my_settings_path : settings_user_path(@user),
+    method: :patch do |f| %>
+      <div>
+        <%= f.label :timezone, "Your timezone" %>
+        <%= f.select :timezone, 
+            TZInfo::Timezone.all.map(&:identifier).sort,
+            include_blank: @user.timezone.blank? %>
+        <small>This affects how your activity graph and other time-based features are displayed.</small>
+      </div>
+      <%= f.submit "Save Settings" %>
+  <% end %>
+</div>
+
+<div>
   <h2>Slack status</h2>
   <% unless @can_enable_slack_status %>
     <%= link_to "Re-authorize with Slack to give permission to update your status", slack_auth_path %>


### PR DESCRIPTION
Timezone is now shown on activity graph:
<img width="1026" alt="Screenshot 2025-03-19 at 11 43 23" src="https://github.com/user-attachments/assets/3934b303-59d2-4346-9946-7bf4d1548f89" />

User can edit their timezone:
<img width="1466" alt="Screenshot 2025-03-19 at 11 50 41" src="https://github.com/user-attachments/assets/9f7d9750-e9df-4286-8d2c-538c6976be98" />

This is the same user after switching timezones:
<img width="998" alt="Screenshot 2025-03-19 at 11 45 01" src="https://github.com/user-attachments/assets/6b6d033a-3dac-4ee3-9401-288a29d43dee" />
