### PR TITLE
Add active user counts to the footer

### DIFF
--- a/app/assets/stylesheets/active_users_graph.css
+++ b/app/assets/stylesheets/active_users_graph.css
@@ -1,0 +1,13 @@
+.active-users-graph {
+  display: flex;
+  flex-direction: row;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.active-users-graph__hour {
+  background-color: var(--uchu-dark-gray);
+  opacity: 0.1;
+  flex-grow: 1;
+  min-width: 10px;
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,6 +43,7 @@
             <%= link_to "Stop impersonating", stop_impersonating_path, class: "impersonate-link" %>
           <% end %>
         </div>
+        <%= render "static_pages/active_users_graph", hours: active_users_graph_data %>
       </footer>
     </main>
 

--- a/app/views/static_pages/_active_users_graph.html.erb
+++ b/app/views/static_pages/_active_users_graph.html.erb
@@ -1,0 +1,9 @@
+<div class="active-users-graph">
+  <!-- "nihil boni sine labore" -->
+  <% hours.each_with_index do |h, i| %>
+    <div class="active-users-graph__hour"
+      title="<%= pluralize(i + 1, 'hour') %> ago, <%= pluralize(h[:users], 'people') %> logged time. '<%= FlavorText.latin_phrases.sample %>.'"
+      style="height: <%= h[:height] %>px;">
+    </div>
+  <% end %>
+</div>

--- a/lib/flavor_text.rb
+++ b/lib/flavor_text.rb
@@ -217,4 +217,19 @@ class FlavorText
 
     r
   end
+
+  def self.latin_phrases
+    [
+      "carpe diem", # "seize the day"
+      "nemo sine vitio est", # "no one is without fault"
+      "docendo discimus", # "by teaching, we learn"
+      "per aspera ad astra", # "through adversity to the stars"
+      "ex nihilo nihil", # "from nothing, nothing"
+      "aut viam inveniam aut faciam", # "i will either find a way or make one"
+      "semper ad mellora", # "always towards better things"
+      "soli fortes, una fortiores", # "strong alone, stronger together"
+      "nulla tenaci invia est via", # "for the tenacious, no road is impassable"
+      "nihil boni sine labore" # "nothing achieved without hard work"
+    ]
+  end
 end


### PR DESCRIPTION
Adds a small easter egg to the page that I personally want to use to check on health of the site's userbase
<img width="1208" alt="Screenshot 2025-03-21 at 20 39 20" src="https://github.com/user-attachments/assets/bd97762a-7402-45cb-9a45-4229b40f0937" />
