### PR TITLE
Add mini-leaderboard styling to primary leaderboard

### DIFF
--- a/app/controllers/leaderboards_controller.rb
+++ b/app/controllers/leaderboards_controller.rb
@@ -39,6 +39,16 @@ class LeaderboardsController < ApplicationController
             .pluck(:user_id)
             .count { |user_id| !tracked_user_ids.include?(user_id) }
       end
+
+      # Get active projects for the leaderboard entries
+      if @entries&.any?
+        user_ids = @entries.pluck(:user_id)
+        users = User.where(id: user_ids).includes(:project_repo_mappings)
+        @active_projects = {}
+        users.each do |user|
+          @active_projects[user.id] = user.project_repo_mappings.find { |p| p.project_name == user.active_project }
+        end
+      end
     end
   end
 end

--- a/app/views/leaderboards/index.html.erb
+++ b/app/views/leaderboards/index.html.erb
@@ -25,24 +25,33 @@
 
   <div class="content">
     <% if @entries&.any? %>
-      <table>
-        <thead>
-          <tr>
-            <th>Rank</th>
-            <th>User</th>
-            <th>Time</th>
-          </tr>
-        </thead>
-        <tbody>
-          <% @entries.each_with_index do |entry, index| %>
-            <tr>
-              <td><%= (index + 1).ordinalize %></td>
-              <td><%= render "shared/user_mention", user: entry.user, show: [:neighborhood, :slack] %></td>
-              <td><%= short_time_detailed entry.total_seconds %></td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
+      <div class="leaderboard-entries">
+        <% @entries.each_with_index do |entry, index| %>
+          <div class="leaderboard-entry <%= 'current-user' if entry.user_id == current_user&.id %>">
+            <span class="rank">
+              <% case index %>
+              <% when 0 then %>
+                <%= "🥇" %>
+              <% when 1 then %>
+                <%= "🥈" %>
+              <% when 2 then %>
+                <%= "🥉" %>
+              <% else %>
+                <%= (index + 1).ordinalize %>
+              <% end %>
+            </span>
+            <span class="user">
+              <%= render "shared/user_mention", user: entry.user, show: [:neighborhood, :slack] %>
+              <% if @active_projects&.dig(entry.user_id).present? %>
+                <span class="super">
+                  working on <%= link_to @active_projects[entry.user_id].project_name, @active_projects[entry.user_id].repo_url, target: "_blank" %>
+                </span>
+              <% end %>
+            </span>
+            <span class="time"><%= short_time_detailed entry.total_seconds %></span>
+          </div>
+        <% end %>
+      </div>
       <% unless @user_on_leaderboard %>
         <p>
           Don't see yourself on the leaderboard? You're probably one of the


### PR DESCRIPTION
Before:

<img width="1204" alt="Screenshot 2025-03-21 at 22 15 28" src="https://github.com/user-attachments/assets/fe170f90-cca9-4894-b259-bc45704d9fc7" />

After:

<img width="1207" alt="Screenshot 2025-03-21 at 22 15 40" src="https://github.com/user-attachments/assets/0a341e3b-5fe3-465d-9ed6-d52add88336b" />
