### PR TITLE
Fix global cache of currently hacking

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -50,9 +50,9 @@
 
     <div class="currently-hacking-container">
       <%= turbo_frame_tag "currently_hacking", src: currently_hacking_static_pages_path do %>
-        <%# <div class="loading">
+        <div class="loading">
           Loading currently hacking...
-        </div> %>
+        </div>
       <% end %>
     </div>
   </body>

--- a/app/views/static_pages/_currently_hacking.erb
+++ b/app/views/static_pages/_currently_hacking.erb
@@ -1,37 +1,35 @@
 <%= turbo_frame_tag "currently_hacking" do %>
-  <%= cache ["currently_hacking"], expires_in: 1.minute do %>
-    <% if users.any? %>
-      <div class="currently-hacking" onclick="this.classList.toggle('visible')">
-        <div class="currently-hacking-header">
-          <span>
-            <div class="live-indicator"></div>
-            <%= pluralize(users.count, "person") %> currently hacking
-          </span>
-        </div>
-        <div class="currently-hacking-list">
-          <hr>
-          <ul>
-            <% users.each do |user| %>
-              <%= render "shared/user_mention", user: user, show: [:slack] %>
-              <% if active_projects[user.id].present? %>
-                <span class="super">
-                  working on <%= link_to active_projects[user.id].project_name, active_projects[user.id].repo_url, target: "_blank" %>
-                </span>
-              <% end %>
-              <% if user == current_user && user.github_username.blank? %>
-                <span class="super">
-                  <%= link_to "Link active projects", my_settings_path(anchor: "user_github_account"), target: "_blank" %>
-                </span>
-              <% end %>
+  <% if users.any? %>
+    <div class="currently-hacking" onclick="this.classList.toggle('visible')">
+      <div class="currently-hacking-header">
+        <span>
+          <div class="live-indicator"></div>
+          <%= pluralize(users.count, "person") %> currently hacking
+        </span>
+      </div>
+      <div class="currently-hacking-list">
+        <hr>
+        <ul>
+          <% users.each do |user| %>
+            <%= render "shared/user_mention", user: user, show: [:slack] %>
+            <% if active_projects[user.id].present? %>
+              <span class="super">
+                working on <%= link_to active_projects[user.id].project_name, active_projects[user.id].repo_url, target: "_blank" %>
+              </span>
             <% end %>
-          </ul>
-        </div>
+            <% if user == current_user && user.github_username.blank? %>
+              <span class="super">
+                <%= link_to "Link active projects", my_settings_path(anchor: "user_github_account"), target: "_blank" %>
+              </span>
+            <% end %>
+          <% end %>
+        </ul>
       </div>
-    <% else %>
-      <div class="currently-hacking">
-        <p>No one is currently hacking</p>
-      </div>
-    <% end %>
+    </div>
+  <% else %>
+    <div class="currently-hacking">
+      <span class="super">No one is currently hacking</span>
+    </div>
   <% end %>
 <% end %>
 


### PR DESCRIPTION
Before:
See how i'm signed out but there is still the "🥸" admin button showing up? That's because this partial loaded from a cache that was global. That means not only I could see those buttons while signed out, other users could to!
<img width="750" alt="Screenshot 2025-03-23 at 11 31 15" src="https://github.com/user-attachments/assets/fdf2e98a-4617-4a2d-811b-7e7d29cff434" />

Now: no more cache! Not much to look at– just the "active user" is the same as the one we say they are.
<img width="1058" alt="Screenshot 2025-03-23 at 11 44 59" src="https://github.com/user-attachments/assets/992ef5b7-a9cc-4f9e-af30-ddf747061ae4" />
