### PR TITLE
Order currently hacking list by active project, then usernames

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -130,6 +130,15 @@ class StaticPagesController < ApplicationController
         active_projects[user.id] = user.project_repo_mappings.find { |p| p.project_name == user.active_project }
       end
 
+      users = users.sort_by do |user|
+        [
+          active_projects[user.id].present? ? 0 : 1,
+          user.username.present? ? 0 : 1,
+          user.slack_username.present? ? 0 : 1,
+          user.github_username.present? ? 0 : 1
+        ]
+      end
+
       { users: users, active_projects: active_projects }
     end
 


### PR DESCRIPTION
Before the order was kinda random:
<img width="287" alt="Screenshot 2025-03-23 at 11 50 49" src="https://github.com/user-attachments/assets/c4fe3282-62c4-49d0-a72f-4e1c52216986" />

After: show active projects first, then people with usernames, then email users last
<img width="304" alt="Screenshot 2025-03-23 at 11 51 06" src="https://github.com/user-attachments/assets/2fd37d59-b489-4d2d-80b1-9b5aaa6c76c7" />
