### PR TITLE
Fix missing slack usernames

### DIFF
--- a/app/jobs/slack_username_update_job.rb
+++ b/app/jobs/slack_username_update_job.rb
@@ -13,18 +13,7 @@ class SlackUsernameUpdateJob < ApplicationJob
     # in batches of 100, update the slack info for each user
     User.where.not(slack_uid: nil).find_each(batch_size: 100) do |user|
       begin
-        user_response = HTTP.auth("Bearer #{user.slack_access_token}")
-          .get("https://slack.com/api/users.info?user=#{user.slack_uid}")
-
-        user_data = JSON.parse(user_response.body.to_s)
-
-        next unless user_data["ok"]
-
-        user.username = user_data.dig("user", "profile", "username")
-        user.username ||= user_data.dig("user", "profile", "display_name_normalized")
-        user.slack_username = user_data.dig("user", "profile", "username")
-        user.slack_username ||= user_data.dig("user", "profile", "display_name_normalized")
-        user.slack_avatar_url = user_data.dig("user", "profile", "image_192") || user_data.dig("user", "profile", "image_72")
+        user.update_from_slack
         user.save!
       rescue => e
         Rails.logger.error "Failed to update Slack username and avatar for user #{user.id}: #{e.message}"


### PR DESCRIPTION
Before: some users would get the "email sign up" message despite having a slack_uid & a link to their slack profile!

<img width="278" alt="Screenshot 2025-03-24 at 15 47 21" src="https://github.com/user-attachments/assets/20003b1d-fb62-484e-b966-ecde18a12b6e" />

After: We correctly pull slack username for any user who slack authed

<img width="279" alt="Screenshot 2025-03-24 at 15 51 35" src="https://github.com/user-attachments/assets/eb05ace4-9669-45cd-be38-49ce5cd5e55a" />
