### PR TITLE
Fixing 'probably one of the 0 users'

### DIFF
--- a/app/views/leaderboards/index.html.erb
+++ b/app/views/leaderboards/index.html.erb
@@ -61,7 +61,7 @@
           </div>
         <% end %>
       </div>
-      <% unless @user_on_leaderboard %>
+      <% unless @user_on_leaderboard && @untracked_entries != 0 %>
         <p>
           Don't see yourself on the leaderboard? You're probably one of the
           <%= pluralize(@untracked_entries, "user") %>


### PR DESCRIPTION
Hey!

![image](https://github.com/user-attachments/assets/14d961fe-346d-4773-889d-e88d0263cff7)


This should fix the last line, and should not show up if there are 0 untracked users. 

Thanks! :))