### PR TITLE
Removed scrapyard from dev env

### DIFF
--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -35,7 +35,7 @@
       <% end %>
     </li>
     <li>
-      <% unless !Rails.env.development? %>
+      <% if Rails.env.production? %>
         <%= link_to scrapyard_leaderboards_path, class: "nav-item #{current_page?(scrapyard_leaderboards_path) ? 'active' : ''}" do %>
           Scrapyard
         <% end %>

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -35,8 +35,10 @@
       <% end %>
     </li>
     <li>
-      <%= link_to scrapyard_leaderboards_path, class: "nav-item #{current_page?(scrapyard_leaderboards_path) ? 'active' : ''}" do %>
-        Scrapyard
+      <% unless !Rails.env.development? %>
+        <%= link_to scrapyard_leaderboards_path, class: "nav-item #{current_page?(scrapyard_leaderboards_path) ? 'active' : ''}" do %>
+          Scrapyard
+        <% end %>
       <% end %>
     </li>
     <li>


### PR DESCRIPTION
Hey!

Clicking on the Scrapyard tab in the navbar proves to be an issue in dev env since there's no airtable link. This should hide it completely for the dev env. I used !Rails.env.development instead of Rails.env.production since there might be a Staging env sometime soon. 