### PR TITLE
Add projects list endpoint & add project remapping form

### DIFF
--- a/app/controllers/my/project_repo_mappings_controller.rb
+++ b/app/controllers/my/project_repo_mappings_controller.rb
@@ -1,0 +1,39 @@
+class My::ProjectRepoMappingsController < ApplicationController
+  before_action :require_github_oauth
+  before_action :set_project_repo_mapping, only: [ :edit, :update ]
+
+  def edit
+  end
+
+  def update
+    if @project_repo_mapping.new_record?
+      @project_repo_mapping.project_name = params[:project_name]
+    end
+
+    if @project_repo_mapping.update(project_repo_mapping_params)
+      redirect_to root_path, notice: "Repository mapping updated successfully."
+    else
+      flash.now[:alert] = @project_repo_mapping.errors.full_messages.join(", ")
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def require_github_oauth
+    unless current_user.github_uid.present?
+      flash[:alert] = "Please connect your GitHub account to map repositories."
+      redirect_to root_path
+    end
+  end
+
+  def set_project_repo_mapping
+    @project_repo_mapping = current_user.project_repo_mappings.find_or_initialize_by(
+      project_name: params[:project_name]
+    )
+  end
+
+  def project_repo_mapping_params
+    params.require(:project_repo_mapping).permit(:repo_url)
+  end
+end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -78,6 +78,9 @@ class StaticPagesController < ApplicationController
     end
   end
 
+  def my_projects
+  end
+
   def project_durations
     return unless current_user
 
@@ -93,7 +96,7 @@ class StaticPagesController < ApplicationController
           repo_url: @project_repo_mappings.find { |p| p.project_name == project }&.repo_url,
           duration: duration
         }
-      end.filter { |p| p[:duration].positive? }.sort_by { |p| p[:duration] }.reverse.first(4)
+      end.filter { |p| p[:duration].positive? }.sort_by { |p| p[:duration] }.reverse
     end
 
     render partial: "project_durations", locals: { project_durations: project_durations }

--- a/app/models/project_repo_mapping.rb
+++ b/app/models/project_repo_mapping.rb
@@ -9,4 +9,14 @@ class ProjectRepoMapping < ApplicationRecord
     with: %r{\A(https?://[^/]+/[^/]+/[^/]+)\z},
     message: "must be a valid repository URL"
   }
+
+  validate :repo_url_exists
+
+  private
+
+  def repo_url_exists
+    unless GitRemote.check_remote_exists(repo_url)
+      errors.add(:repo_url, "is not cloneable")
+    end
+  end
 end

--- a/app/views/my/project_repo_mappings/edit.html.erb
+++ b/app/views/my/project_repo_mappings/edit.html.erb
@@ -1,0 +1,20 @@
+<div class="container">
+  <h1>Edit Repository Mapping</h1>
+
+  <%= form_with(model: @project_repo_mapping, url: my_project_repo_mapping_path(@project_repo_mapping.project_name), method: :patch, local: true) do |f| %>
+    <div class="field">
+      <%= f.label :project_name %>
+      <%= f.text_field :project_name, value: @project_repo_mapping.project_name, disabled: true %>
+    </div>
+
+    <div class="field">
+      <%= f.label :repo_url %>
+      <%= f.url_field :repo_url, placeholder: "https://github.com/username/repo" %>
+    </div>
+
+    <div class="actions">
+      <%= f.submit "Update Mapping" %>
+      <%= link_to "Cancel", root_path, class: "button" %>
+    </div>
+  <% end %>
+</div> 

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -35,6 +35,11 @@
     </li>
     <% if current_user %>
       <li>
+        <%= link_to my_projects_static_pages_path, class: "nav-item #{current_page?(my_projects_static_pages_path) ? 'active' : ''}" do %>
+          My Projects
+        <% end %>
+      </li>
+      <li>
         <%= link_to my_settings_path, class: "nav-item #{current_page?(my_settings_path) ? 'active' : ''}" do %>
           Settings
         <% end %>

--- a/app/views/static_pages/_project_durations.html.erb
+++ b/app/views/static_pages/_project_durations.html.erb
@@ -1,0 +1,32 @@
+<%= turbo_frame_tag "project_durations" do %>
+  <%= cache ["project_durations", current_user.id], expires_in: 5.minute do %>
+    <%
+      max_project_duration = project_durations.map { |p| p[:duration] }.max || 1
+    %>
+    <div class="project-durations-grid">
+      <% project_durations.each do |project| %>
+        <div class="project-duration-card">
+          <div class="project-header">
+            <strong title="<%= project[:project] %>">
+              <%= (project[:project].presence || "Unknown").truncate(12) %>
+            </strong>
+            <% if project[:repo_url].present? %>
+              <%= link_to "🔗", project[:repo_url], target: "_blank" %>
+            <% end %>
+            <% if current_user.github_uid.present? %>
+              <%= link_to "✏️", edit_my_project_repo_mapping_path(project_name: project[:project]), class: "edit-repo-link", data: { turbo_frame: '_top'} %>
+            <% end %>
+            <span class="project-time"><%= short_time_detailed project[:duration] %></span>
+          </div>
+          <div class="project-progress-bar">
+            <div 
+              class="progress" 
+              style="width: <%= [project[:duration].to_f / max_project_duration.to_f * 100, 100].min %>%; 
+                    background-color: var(--primary-color);"
+            ></div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/static_pages/my_projects.html.erb
+++ b/app/views/static_pages/my_projects.html.erb
@@ -1,0 +1,12 @@
+<h1>My Projects</h1>
+
+<% if current_user.github_uid.blank? %>
+  <div class="notice">
+    You can't tie your projects to GitHub until you connect your GitHub account.
+    <%= link_to "Sign in with GitHub", github_auth_path, class: "btn btn-primary" %>
+  </div>
+<% end %>
+
+<%= turbo_frame_tag "project_durations", src: project_durations_static_pages_path do %>
+  <span>Loading...</span>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,7 @@ Rails.application.routes.draw do
       get :currently_hacking
       get :filterable_dashboard_content
       get :filterable_dashboard
+      get :my_projects
       get "🃏", to: "static_pages#🃏", as: :wildcard
     end
   end
@@ -61,6 +62,10 @@ Rails.application.routes.draw do
   get "my/settings", to: "users#edit", as: :my_settings
   patch "my/settings", to: "users#update"
   post "my/settings/migrate_heartbeats", to: "users#migrate_heartbeats", as: :my_settings_migrate_heartbeats
+
+  namespace :my do
+    resources :project_repo_mappings, param: :project_name, only: [ :edit, :update ]
+  end
 
   get "my/wakatime_setup", to: "users#wakatime_setup"
   get "my/wakatime_setup/step-2", to: "users#wakatime_setup_step_2"

--- a/lib/git_remote.rb
+++ b/lib/git_remote.rb
@@ -1,0 +1,6 @@
+class GitRemote
+  def self.check_remote_exists(repo_url)
+    `git ls-remote #{repo_url}`
+    $?.success?
+  end
+end

--- a/lib/git_remote.rb
+++ b/lib/git_remote.rb
@@ -1,6 +1,8 @@
+require "open3"
+
 class GitRemote
   def self.check_remote_exists(repo_url)
-    `git ls-remote #{repo_url}`
-    $?.success?
+    safe_repo_url = URI.parse(repo_url).to_s.gsub(" ", "").gsub("'", "")
+    Open3.capture2e("git", "ls-remote", safe_repo_url).last.success?
   end
 end


### PR DESCRIPTION
New! A page for your projects list:
<img width="234" alt="Screenshot 2025-04-25 at 13 17 44" src="https://github.com/user-attachments/assets/47e2fa79-d4c1-41dd-b4d1-78034e4097c8" />

No github auth, no service:
<img width="789" alt="Screenshot 2025-04-25 at 13 15 37" src="https://github.com/user-attachments/assets/11bdeee8-8fa9-4950-900f-657a68e112fb" />

If you are authed we automatically find repos, but if you can also edit the repo link yourself:
<img width="626" alt="Screenshot 2025-04-25 at 13 19 31" src="https://github.com/user-attachments/assets/9dc89fca-68b6-4455-9b03-3bbfee280e0f" />
<img width="822" alt="Screenshot 2025-04-25 at 13 19 45" src="https://github.com/user-attachments/assets/8cdf1882-15df-4c3e-ab84-753dc555ff86" />

We clone try to clone your repo too just to make sure your link works:
<img width="777" alt="Screenshot 2025-04-25 at 13 08 40" src="https://github.com/user-attachments/assets/5fac292c-b4b9-4a33-83ab-c0e729cddd49" />


