### PR TITLE
Add time range selector on projects list

### DIFF
--- a/app/assets/stylesheets/filterable_dashboard.css
+++ b/app/assets/stylesheets/filterable_dashboard.css
@@ -540,3 +540,189 @@ h1 {
   pointer-events: none;
   transition: filter 0.2s ease;
 }
+
+.interval-selector {
+  margin-bottom: 1rem;
+}
+
+.interval-options {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-end;
+}
+
+.preset-selector,
+.custom-range {
+  flex: 1;
+}
+
+.preset-selector label,
+.custom-range label {
+  display: block;
+  font-size: 0.9rem;
+  margin-bottom: 0.25rem;
+  color: #666;
+}
+
+.preset-selector select {
+  width: 100%;
+  padding: 0.4rem 0.5rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  background-color: white;
+  font-size: 0.9rem;
+}
+
+.date-inputs {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.date-inputs input[type="date"] {
+  padding: 0.4rem 0.5rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 0.9rem;
+  background-color: white;
+}
+
+.date-inputs span {
+  color: #666;
+  font-size: 0.9rem;
+}
+
+.interval-dropdown {
+  position: relative;
+  display: inline-block;
+}
+.interval-dropdown-trigger {
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+  border: 1px solid #bbb;
+  border-radius: 4px;
+  background: #fff;
+  cursor: pointer;
+  min-width: 180px;
+  text-align: left;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.interval-dropdown-menu {
+  position: absolute;
+  top: 110%;
+  left: 0;
+  min-width: 220px;
+  background: #fff;
+  border: 1px solid #bbb;
+  border-radius: 6px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+  z-index: 1000;
+  padding: 0.5rem 0.75rem;
+}
+.interval-options-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.interval-options-list li {
+  padding: 0.4rem 0.2rem;
+  cursor: pointer;
+  border-radius: 3px;
+  font-size: 1rem;
+}
+.interval-options-list li:hover {
+  background: #f0f0f0;
+}
+.interval-custom-range {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+.interval-custom-range label {
+  font-size: 0.95rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.interval-custom-range input[type="date"] {
+  margin-left: 0.5rem;
+  padding: 0.2rem 0.4rem;
+  font-size: 1rem;
+}
+.interval-custom-range button {
+  margin-top: 0.5rem;
+  padding: 0.4rem 0.8rem;
+  font-size: 1rem;
+  border-radius: 4px;
+  border: none;
+  background: #f5b041;
+  color: #222;
+  cursor: pointer;
+}
+.interval-custom-range button:hover {
+  background: #f39c12;
+}
+.dropdown-arrow {
+  margin-left: 0.5rem;
+  font-size: 0.9em;
+}
+
+@media (prefers-color-scheme: dark) {
+  .interval-dropdown-trigger {
+    background: #23272f;
+    color: #f5f5f5;
+    border: 1px solid #444;
+  }
+  .interval-dropdown-menu {
+    background: #23272f;
+    color: #f5f5f5;
+    border: 1px solid #444;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.4);
+  }
+  .interval-options-list li {
+    color: #f5f5f5;
+  }
+  .interval-options-list li:hover {
+    background: #2c313a;
+  }
+  .interval-custom-range label {
+    color: #f5f5f5;
+  }
+  .interval-custom-range input[type="date"] {
+    background: #181b20;
+    color: #f5f5f5;
+    border: 1px solid #444;
+  }
+  .interval-custom-range button {
+    background: #f5b041;
+    color: #23272f;
+  }
+  .interval-custom-range button:hover {
+    background: #f39c12;
+  }
+  .dropdown-arrow {
+    color: #f5f5f5;
+  }
+}
+
+.compact-options-list {
+  max-height: 220px;
+  overflow-y: auto;
+  font-size: 0.97rem;
+  padding-bottom: 0.2rem;
+}
+.compact-options-list li {
+  padding: 0.25rem 0.2rem;
+  font-size: 0.97rem;
+}
+.interval-dropdown-menu {
+  min-width: 210px;
+  padding: 0.3rem 0.5rem 0.5rem 0.5rem;
+}
+.interval-custom-range {
+  margin-top: 0.3rem;
+  padding-bottom: 0.1rem;
+}

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -82,14 +82,13 @@ class StaticPagesController < ApplicationController
     return unless current_user
 
     @project_repo_mappings = current_user.project_repo_mappings
+    cache_key = "user_#{current_user.id}_project_durations_#{params[:interval]}"
+    cache_key += "_#{params[:from]}_#{params[:to]}" if params[:interval] == "custom"
 
-    project_durations = Rails.cache.fetch("user_#{current_user.id}_project_durations_#{params[:interval]}", expires_in: 1.minute) do
-      heartbeats = current_user.heartbeats
-      heartbeats = heartbeats.public_send(params[:interval]) if params[:interval].present?
-
+    project_durations = Rails.cache.fetch(cache_key, expires_in: 1.minute) do
+      heartbeats = current_user.heartbeats.filter_by_time_range(params[:interval], params[:from], params[:to])
       project_times = heartbeats.group(:project).duration_seconds
       project_labels = current_user.project_labels
-
       project_times.map do |project, duration|
         {
           project: project_labels.find { |p| p.project_key == project }&.label || project || "Unknown",
@@ -98,7 +97,6 @@ class StaticPagesController < ApplicationController
         }
       end.filter { |p| p[:duration].positive? }.sort_by { |p| p[:duration] }.reverse
     end
-
     render partial: "project_durations", locals: { project_durations: project_durations }
   end
 
@@ -258,6 +256,9 @@ class StaticPagesController < ApplicationController
             result["singular_#{filter}"] = filter_arr.length == 1
           end
         end
+
+        # Only use the concern for time filtering
+        filtered_heartbeats = filtered_heartbeats.filter_by_time_range(params[:interval], params[:from], params[:to])
 
         result[:filtered_heartbeats] = filtered_heartbeats
 

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -83,8 +83,11 @@ class StaticPagesController < ApplicationController
 
     @project_repo_mappings = current_user.project_repo_mappings
 
-    project_durations = Rails.cache.fetch("user_#{current_user.id}_project_durations", expires_in: 1.minute) do
-      project_times = current_user.heartbeats.group(:project).duration_seconds
+    project_durations = Rails.cache.fetch("user_#{current_user.id}_project_durations_#{params[:interval]}", expires_in: 1.minute) do
+      heartbeats = current_user.heartbeats
+      heartbeats = heartbeats.public_send(params[:interval]) if params[:interval].present?
+
+      project_times = heartbeats.group(:project).duration_seconds
       project_labels = current_user.project_labels
 
       project_times.map do |project, duration|

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -95,4 +95,14 @@ module ApplicationHelper
     ]
     clocks[half_hours % clocks.length]
   end
+
+  def human_interval_name(key, from: nil, to: nil)
+    if key.present? && Heartbeat.respond_to?(:humanize_range) && Heartbeat::RANGES.key?(key.to_sym)
+      Heartbeat.humanize_range(Heartbeat::RANGES[key.to_sym][:calculate].call)
+    elsif from.present? && to.present?
+      "#{from} to #{to}"
+    else
+      "All Time"
+    end
+  end
 end

--- a/app/models/concerns/time_range_filterable.rb
+++ b/app/models/concerns/time_range_filterable.rb
@@ -1,0 +1,76 @@
+module TimeRangeFilterable
+  extend ActiveSupport::Concern
+
+  RANGES = {
+    today: {
+      human_name: "Today",
+      calculate: -> { Time.current.beginning_of_day..Time.current.end_of_day }
+    },
+    yesterday: {
+      human_name: "Yesterday",
+      calculate: -> { (Time.current - 1.day).beginning_of_day..(Time.current - 1.day).end_of_day }
+    },
+    this_week: {
+      human_name: "This Week",
+      calculate: -> { Time.current.beginning_of_week..Time.current.end_of_week }
+    },
+    last_7_days: {
+      human_name: "Last 7 Days",
+      calculate: -> { (Time.current - 7.days).beginning_of_day..Time.current.end_of_day }
+    },
+    this_month: {
+      human_name: "This Month",
+      calculate: -> { Time.current.beginning_of_month..Time.current.end_of_month }
+    },
+    last_30_days: {
+      human_name: "Last 30 Days",
+      calculate: -> { (Time.current - 30.days).beginning_of_day..Time.current.end_of_day }
+    },
+    this_year: {
+      human_name: "This Year",
+      calculate: -> { Time.current.beginning_of_year..Time.current.end_of_year }
+    },
+    last_12_months: {
+      human_name: "Last 12 Months",
+      calculate: -> { (Time.current - 12.months).beginning_of_day..Time.current.end_of_day }
+    },
+    high_seas: {
+      human_name: "High Seas Hackathon",
+      calculate: -> {
+        timezone = "America/New_York"
+        Time.use_zone(timezone) do
+          from = Time.parse("2024-10-30").beginning_of_day
+          to = Time.parse("2025-01-31").end_of_day
+          from.beginning_of_day..to.end_of_day
+        end
+      }
+    },
+    low_skies: {
+      human_name: "Low Skies Hackathon",
+      calculate: -> {
+        timezone = "America/New_York"
+        Time.use_zone(timezone) do
+          from = Time.parse("2024-10-3").beginning_of_day
+          to = Time.parse("2025-01-12").end_of_day
+          from.beginning_of_day..to.end_of_day
+        end
+      }
+    }
+  }.freeze
+
+  class_methods do
+    def time_range_filterable_field(field_name)
+      RANGES.each do |name, config|
+        scope name, -> { where(field_name => config[:calculate].call) }
+      end
+
+      define_singleton_method(:humanize_range) do |range|
+        RANGES.each do |name, config|
+          return config[:human_name] if range == config[:calculate].call
+        end
+
+        "#{range.begin.strftime('%B %d, %Y')} - #{range.end.strftime('%B %d, %Y')}"
+      end
+    end
+  end
+end

--- a/app/models/concerns/time_range_filterable.rb
+++ b/app/models/concerns/time_range_filterable.rb
@@ -35,7 +35,7 @@ module TimeRangeFilterable
       calculate: -> { (Time.current - 12.months).beginning_of_day..Time.current.end_of_day }
     },
     high_seas: {
-      human_name: "High Seas Hackathon",
+      human_name: "High Seas",
       calculate: -> {
         timezone = "America/New_York"
         Time.use_zone(timezone) do
@@ -46,12 +46,23 @@ module TimeRangeFilterable
       }
     },
     low_skies: {
-      human_name: "Low Skies Hackathon",
+      human_name: "Low Skies",
       calculate: -> {
         timezone = "America/New_York"
         Time.use_zone(timezone) do
           from = Time.parse("2024-10-3").beginning_of_day
           to = Time.parse("2025-01-12").end_of_day
+          from.beginning_of_day..to.end_of_day
+        end
+      }
+    },
+    scrapyard: {
+      human_name: "Scrapyard Global",
+      calculate: -> {
+        timezone = "America/New_York"
+        Time.use_zone(timezone) do
+          from = Time.parse("2025-03-14").beginning_of_day
+          to = Time.parse("2025-03-17").end_of_day
           from.beginning_of_day..to.end_of_day
         end
       }

--- a/app/models/concerns/time_range_filterable.rb
+++ b/app/models/concerns/time_range_filterable.rb
@@ -83,5 +83,18 @@ module TimeRangeFilterable
         "#{range.begin.strftime('%B %d, %Y')} - #{range.end.strftime('%B %d, %Y')}"
       end
     end
+
+    def filter_by_time_range(interval, from = nil, to = nil)
+      interval = interval&.to_sym
+      if interval == :custom
+        from_time = from.present? ? Time.zone.parse(from).beginning_of_day.to_i : 0
+        to_time = to.present? ? Time.zone.parse(to).end_of_day.to_i : 253402300799
+        where(time: from_time..to_time)
+      elsif RANGES.key?(interval)
+        public_send(interval)
+      else
+        all
+      end
+    end
   end
 end

--- a/app/models/heartbeat.rb
+++ b/app/models/heartbeat.rb
@@ -2,6 +2,9 @@ class Heartbeat < ApplicationRecord
   before_save :set_fields_hash!
 
   include Heartbeatable
+  include TimeRangeFilterable
+
+  time_range_filterable_field :time
 
   scope :today, -> { where(time: Time.current.beginning_of_day..Time.current.end_of_day) }
   scope :recent, -> { where("created_at > ?", 24.hours.ago) }

--- a/app/views/shared/_interval_selector.html.erb
+++ b/app/views/shared/_interval_selector.html.erb
@@ -153,8 +153,8 @@
   <style>
     /* Adding explicit styles for the Apply button */
     .interval-custom-range .primary-button {
-      margin-top: 0.5rem;
       padding: 0.4rem 0.8rem;
+      margin: 0;
       font-size: 1rem;
       border-radius: 4px;
       border: none;

--- a/app/views/shared/_interval_selector.html.erb
+++ b/app/views/shared/_interval_selector.html.erb
@@ -1,22 +1,204 @@
 <%= turbo_frame_tag "interval_selector" do %>
-  <div class="interval-selector">
-    <select name="interval" onchange="window.location.href = this.value ? '?interval=' + this.value : window.location.pathname">
-      <option value="">All Time</option>
-      <optgroup label="Relative">
-        <option value="today" <%= "selected" if params[:interval] == "today" %>>Today</option>
-        <option value="yesterday" <%= "selected" if params[:interval] == "yesterday" %>>Yesterday</option>
-        <option value="this_week" <%= "selected" if params[:interval] == "this_week" %>>This Week</option>
-        <option value="last_7_days" <%= "selected" if params[:interval] == "last_7_days" %>>Last 7 Days</option>
-        <option value="this_month" <%= "selected" if params[:interval] == "this_month" %>>This Month</option>
-        <option value="last_30_days" <%= "selected" if params[:interval] == "last_30_days" %>>Last 30 Days</option>
-        <option value="this_year" <%= "selected" if params[:interval] == "this_year" %>>This Year</option>
-        <option value="last_12_months" <%= "selected" if params[:interval] == "last_12_months" %>>Last 12 Months</option>
-      </optgroup>
-      <optgroup label="Events">
-        <option value="high_seas" <%= "selected" if params[:interval] == "high_seas" %>>High Seas Hackathon</option>
-        <option value="low_skies" <%= "selected" if params[:interval] == "low_skies" %>>Low Skies Hackathon</option>
-        <option value="scrapyard" <%= "selected" if params[:interval] == "scrapyard" %>>Scrapyard Hackathon</option>
-      </optgroup>
-    </select>
+  <%# TODO: dry this up %>
+  <% human_names = {
+    'today' => 'Today',
+    'yesterday' => 'Yesterday',
+    'this_week' => 'This Week',
+    'last_7_days' => 'Last 7 Days',
+    'this_month' => 'This Month',
+    'last_30_days' => 'Last 30 Days',
+    'this_year' => 'This Year',
+    'last_12_months' => 'Last 12 Months',
+    'high_seas' => 'High Seas Hackathon',
+    'low_skies' => 'Low Skies Hackathon',
+    'scrapyard' => 'Scrapyard Hackathon',
+    'custom' => 'Custom Range',
+    '' => 'All Time',
+    nil => 'All Time'
+  } %>
+  <% selected_label = if params[:interval].present? && human_names[params[:interval]]
+    human_names[params[:interval]]
+  elsif params[:from].present? && params[:to].present?
+    "#{params[:from]} to #{params[:to]}"
+  else
+    'All Time'
+  end %>
+  <div class="interval-dropdown">
+    <button type="button" class="interval-dropdown-trigger" onclick="toggleIntervalDropdown()">
+      <span id="interval-dropdown-label">
+        <%= human_interval_name(params[:interval], from: params[:from], to: params[:to]) %>
+      </span>
+      <span class="dropdown-arrow">▼</span>
+    </button>
+    <div class="interval-dropdown-menu" id="interval-dropdown-menu" style="display: none;">
+      <ul class="interval-options-list compact-options-list">
+        <li onclick="selectInterval('today', 'Today')">Today</li>
+        <li onclick="selectInterval('yesterday', 'Yesterday')">Yesterday</li>
+        <li onclick="selectInterval('this_week', 'This Week')">This Week</li>
+        <li onclick="selectInterval('last_7_days', 'Last 7 Days')">Last 7 Days</li>
+        <li onclick="selectInterval('this_month', 'This Month')">This Month</li>
+        <li onclick="selectInterval('last_30_days', 'Last 30 Days')">Last 30 Days</li>
+        <li onclick="selectInterval('this_year', 'This Year')">This Year</li>
+        <li onclick="selectInterval('last_12_months', 'Last 12 Months')">Last 12 Months</li>
+        <li onclick="selectInterval('high_seas', 'High Seas Hackathon')">High Seas Hackathon</li>
+        <li onclick="selectInterval('low_skies', 'Low Skies Hackathon')">Low Skies Hackathon</li>
+        <li onclick="selectInterval('scrapyard', 'Scrapyard Hackathon')">Scrapyard Hackathon</li>
+        <li onclick="selectInterval('', 'All Time')">All Time</li>
+      </ul>
+      <hr>
+      <div class="interval-custom-range">
+        <label>Start:
+          <input type="date" id="custom-start" value="<%= params[:from] %>">
+        </label>
+        <label>End:
+          <input type="date" id="custom-end" value="<%= params[:to] %>">
+        </label>
+        <button type="button" class="primary-button" onclick="applyCustomRange()">Apply</button>
+      </div>
+    </div>
   </div>
+
+  <script>
+    function updateProjectsFrame(url) {
+      let baseUrl = '<%= project_durations_static_pages_path %>';
+      
+      const params = new URLSearchParams(new URL(url).search);
+      
+      const frameUrl = baseUrl + '?' + params.toString();
+      
+      const frame = document.getElementById('project_durations');
+      if (frame) {
+        console.log('Updating frame with URL:', frameUrl);
+        frame.src = frameUrl;
+        try {
+          frame.reload();
+          console.log('Frame reload called successfully');
+        } catch (e) {
+          console.error('Error reloading frame:', e);
+        }
+        history.replaceState({}, '', url);
+      } else {
+        console.error('Frame with ID "project_durations" not found');
+        window.location.href = url;
+      }
+    }
+
+    function updateDropdownLabel(label) {
+      const labelElement = document.getElementById('interval-dropdown-label');
+      if (labelElement) {
+        labelElement.textContent = label;
+      }
+    }
+
+    function selectInterval(interval, label) {
+      updateDropdownLabel(label);
+      
+      document.getElementById('interval-dropdown-menu').style.display = 'none';
+      
+      const url = new URL(window.location.href);
+      if (interval) {
+        url.searchParams.set('interval', interval);
+        url.searchParams.delete('from');
+        url.searchParams.delete('to');
+      } else {
+        url.searchParams.delete('interval');
+        url.searchParams.delete('from');
+        url.searchParams.delete('to');
+      }
+      updateProjectsFrame(url.toString());
+    }
+    
+    function applyCustomRange() {
+      const start = document.getElementById('custom-start').value;
+      const end = document.getElementById('custom-end').value;
+      if (start || end) {
+        let label = 'Custom Range';
+        if (start && end) {
+          label = `${start} to ${end}`;
+        } else if (start) {
+          label = `From ${start}`;
+        } else if (end) {
+          label = `Until ${end}`;
+        }
+        updateDropdownLabel(label);
+        
+        document.getElementById('interval-dropdown-menu').style.display = 'none';
+        
+        const url = new URL(window.location.href);
+        if (start) url.searchParams.set('from', start);
+        else url.searchParams.delete('from');
+        if (end) url.searchParams.set('to', end);
+        else url.searchParams.delete('to');
+        url.searchParams.set('interval', 'custom');
+        updateProjectsFrame(url.toString());
+      }
+    }
+    
+    function toggleIntervalDropdown() {
+      const menu = document.getElementById('interval-dropdown-menu');
+      menu.style.display = menu.style.display === 'block' ? 'none' : 'block';
+      document.addEventListener('mousedown', closeDropdownOnClickOutside);
+    }
+    
+    function closeDropdownOnClickOutside(e) {
+      const menu = document.getElementById('interval-dropdown-menu');
+      const trigger = document.querySelector('.interval-dropdown-trigger');
+      if (!menu.contains(e.target) && !trigger.contains(e.target)) {
+        menu.style.display = 'none';
+        document.removeEventListener('mousedown', closeDropdownOnClickOutside);
+      }
+    }
+  </script>
+
+  <style>
+    /* Adding explicit styles for the Apply button */
+    .interval-custom-range .primary-button {
+      margin-top: 0.5rem;
+      padding: 0.4rem 0.8rem;
+      font-size: 1rem;
+      border-radius: 4px;
+      border: none;
+      background: var(--primary-color);
+      color: white;
+      cursor: pointer;
+    }
+    
+    .interval-custom-range .primary-button:hover {
+      filter: brightness(1.1);
+    }
+
+    /* Ensure dropdown is visible in light mode */
+    @media (prefers-color-scheme: light) {
+      .interval-dropdown-trigger {
+        background: white;
+        color: #333;
+        border: 1px solid #ccc;
+      }
+      
+      .interval-dropdown-menu {
+        background: white;
+        color: #333;
+        border: 1px solid #ccc;
+        box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+      }
+      
+      .interval-options-list li {
+        color: #333;
+      }
+      
+      .interval-options-list li:hover {
+        background: #f5f5f5;
+      }
+      
+      .interval-custom-range label {
+        color: #333;
+      }
+      
+      .interval-custom-range input[type="date"] {
+        background: white;
+        color: #333;
+        border: 1px solid #ccc;
+      }
+    }
+  </style>
 <% end %> 

--- a/app/views/shared/_interval_selector.html.erb
+++ b/app/views/shared/_interval_selector.html.erb
@@ -1,0 +1,21 @@
+<%= turbo_frame_tag "interval_selector" do %>
+  <div class="interval-selector">
+    <select name="interval" onchange="window.location.href = this.value ? '?interval=' + this.value : window.location.pathname">
+      <option value="">All Time</option>
+      <optgroup label="Relative">
+        <option value="today" <%= "selected" if params[:interval] == "today" %>>Today</option>
+        <option value="yesterday" <%= "selected" if params[:interval] == "yesterday" %>>Yesterday</option>
+        <option value="this_week" <%= "selected" if params[:interval] == "this_week" %>>This Week</option>
+        <option value="last_7_days" <%= "selected" if params[:interval] == "last_7_days" %>>Last 7 Days</option>
+        <option value="this_month" <%= "selected" if params[:interval] == "this_month" %>>This Month</option>
+        <option value="last_30_days" <%= "selected" if params[:interval] == "last_30_days" %>>Last 30 Days</option>
+        <option value="this_year" <%= "selected" if params[:interval] == "this_year" %>>This Year</option>
+        <option value="last_12_months" <%= "selected" if params[:interval] == "last_12_months" %>>Last 12 Months</option>
+      </optgroup>
+      <optgroup label="Events">
+        <option value="high_seas" <%= "selected" if params[:interval] == "high_seas" %>>High Seas Hackathon</option>
+        <option value="low_skies" <%= "selected" if params[:interval] == "low_skies" %>>Low Skies Hackathon</option>
+      </optgroup>
+    </select>
+  </div>
+<% end %> 

--- a/app/views/shared/_interval_selector.html.erb
+++ b/app/views/shared/_interval_selector.html.erb
@@ -1,28 +1,4 @@
 <%= turbo_frame_tag "interval_selector" do %>
-  <%# TODO: dry this up %>
-  <% human_names = {
-    'today' => 'Today',
-    'yesterday' => 'Yesterday',
-    'this_week' => 'This Week',
-    'last_7_days' => 'Last 7 Days',
-    'this_month' => 'This Month',
-    'last_30_days' => 'Last 30 Days',
-    'this_year' => 'This Year',
-    'last_12_months' => 'Last 12 Months',
-    'high_seas' => 'High Seas Hackathon',
-    'low_skies' => 'Low Skies Hackathon',
-    'scrapyard' => 'Scrapyard Hackathon',
-    'custom' => 'Custom Range',
-    '' => 'All Time',
-    nil => 'All Time'
-  } %>
-  <% selected_label = if params[:interval].present? && human_names[params[:interval]]
-    human_names[params[:interval]]
-  elsif params[:from].present? && params[:to].present?
-    "#{params[:from]} to #{params[:to]}"
-  else
-    'All Time'
-  end %>
   <div class="interval-dropdown">
     <button type="button" class="interval-dropdown-trigger" onclick="toggleIntervalDropdown()">
       <span id="interval-dropdown-label">
@@ -32,17 +8,9 @@
     </button>
     <div class="interval-dropdown-menu" id="interval-dropdown-menu" style="display: none;">
       <ul class="interval-options-list compact-options-list">
-        <li onclick="selectInterval('today', 'Today')">Today</li>
-        <li onclick="selectInterval('yesterday', 'Yesterday')">Yesterday</li>
-        <li onclick="selectInterval('this_week', 'This Week')">This Week</li>
-        <li onclick="selectInterval('last_7_days', 'Last 7 Days')">Last 7 Days</li>
-        <li onclick="selectInterval('this_month', 'This Month')">This Month</li>
-        <li onclick="selectInterval('last_30_days', 'Last 30 Days')">Last 30 Days</li>
-        <li onclick="selectInterval('this_year', 'This Year')">This Year</li>
-        <li onclick="selectInterval('last_12_months', 'Last 12 Months')">Last 12 Months</li>
-        <li onclick="selectInterval('high_seas', 'High Seas Hackathon')">High Seas Hackathon</li>
-        <li onclick="selectInterval('low_skies', 'Low Skies Hackathon')">Low Skies Hackathon</li>
-        <li onclick="selectInterval('scrapyard', 'Scrapyard Hackathon')">Scrapyard Hackathon</li>
+        <% TimeRangeFilterable::RANGES.each do |key, config| %>
+          <li onclick="selectInterval('<%= key %>', '<%= config[:human_name] %>')"><%= config[:human_name] %></li>
+        <% end %>
         <li onclick="selectInterval('', 'All Time')">All Time</li>
       </ul>
       <hr>
@@ -59,11 +27,26 @@
   </div>
 
   <script>
+    // Common function to update URL parameters and refresh the frame
+    function updateWithParams(params) {
+      const url = new URL(window.location.href);
+      
+      // Clear existing parameters
+      url.searchParams.delete('interval');
+      url.searchParams.delete('from');
+      url.searchParams.delete('to');
+      
+      // Add new parameters
+      Object.entries(params).forEach(([key, value]) => {
+        if (value) url.searchParams.set(key, value);
+      });
+      
+      updateProjectsFrame(url.toString());
+    }
+    
     function updateProjectsFrame(url) {
       let baseUrl = '<%= project_durations_static_pages_path %>';
-      
       const params = new URLSearchParams(new URL(url).search);
-      
       const frameUrl = baseUrl + '?' + params.toString();
       
       const frame = document.getElementById('project_durations');
@@ -92,25 +75,14 @@
 
     function selectInterval(interval, label) {
       updateDropdownLabel(label);
-      
       document.getElementById('interval-dropdown-menu').style.display = 'none';
-      
-      const url = new URL(window.location.href);
-      if (interval) {
-        url.searchParams.set('interval', interval);
-        url.searchParams.delete('from');
-        url.searchParams.delete('to');
-      } else {
-        url.searchParams.delete('interval');
-        url.searchParams.delete('from');
-        url.searchParams.delete('to');
-      }
-      updateProjectsFrame(url.toString());
+      updateWithParams({ interval });
     }
     
     function applyCustomRange() {
       const start = document.getElementById('custom-start').value;
       const end = document.getElementById('custom-end').value;
+      
       if (start || end) {
         let label = 'Custom Range';
         if (start && end) {
@@ -120,17 +92,10 @@
         } else if (end) {
           label = `Until ${end}`;
         }
+        
         updateDropdownLabel(label);
-        
         document.getElementById('interval-dropdown-menu').style.display = 'none';
-        
-        const url = new URL(window.location.href);
-        if (start) url.searchParams.set('from', start);
-        else url.searchParams.delete('from');
-        if (end) url.searchParams.set('to', end);
-        else url.searchParams.delete('to');
-        url.searchParams.set('interval', 'custom');
-        updateProjectsFrame(url.toString());
+        updateWithParams({ interval: 'custom', from: start, to: end });
       }
     }
     

--- a/app/views/shared/_interval_selector.html.erb
+++ b/app/views/shared/_interval_selector.html.erb
@@ -15,6 +15,7 @@
       <optgroup label="Events">
         <option value="high_seas" <%= "selected" if params[:interval] == "high_seas" %>>High Seas Hackathon</option>
         <option value="low_skies" <%= "selected" if params[:interval] == "low_skies" %>>Low Skies Hackathon</option>
+        <option value="scrapyard" <%= "selected" if params[:interval] == "scrapyard" %>>Scrapyard Hackathon</option>
       </optgroup>
     </select>
   </div>

--- a/app/views/static_pages/my_projects.html.erb
+++ b/app/views/static_pages/my_projects.html.erb
@@ -7,6 +7,8 @@
   </div>
 <% end %>
 
-<%= turbo_frame_tag "project_durations", src: project_durations_static_pages_path do %>
+<%= render "shared/interval_selector" %>
+
+<%= turbo_frame_tag "project_durations", src: project_durations_static_pages_path(interval: params[:interval]) do %>
   <span>Loading...</span>
 <% end %>

--- a/app/views/static_pages/my_projects.html.erb
+++ b/app/views/static_pages/my_projects.html.erb
@@ -9,6 +9,6 @@
 
 <%= render "shared/interval_selector" %>
 
-<%= turbo_frame_tag "project_durations", src: project_durations_static_pages_path(interval: params[:interval]) do %>
-  <span>Loading...</span>
+<%= turbo_frame_tag "project_durations", src: project_durations_static_pages_path(interval: params[:interval], from: params[:from], to: params[:to]), target: "_top" do %>
+  <div class="loading-indicator">Loading projects...</div>
 <% end %>


### PR DESCRIPTION
Adds a time range selector to the my/projects page:

<img width="1439" alt="Screenshot 2025-05-04 at 17 35 54" src="https://github.com/user-attachments/assets/341593e5-4398-417e-a9cd-13ee861a0067" />
<img width="390" alt="Screenshot 2025-05-04 at 17 36 00" src="https://github.com/user-attachments/assets/71278643-8c2a-4c10-885d-3acf1b26c8de" />

Also has a list of events we've run so you can select for what you did during a specific hackathon
<img width="293" alt="Screenshot 2025-05-04 at 17 36 18" src="https://github.com/user-attachments/assets/f7187d64-9517-42ce-a8e4-de762dbd6e90" />
