### PR TITLE
Initial email verification request implementation

### DIFF
--- a/app/jobs/cleanup_expired_email_verification_requests_job.rb
+++ b/app/jobs/cleanup_expired_email_verification_requests_job.rb
@@ -1,0 +1,9 @@
+class CleanupExpiredEmailVerificationRequestsJob < ApplicationJob
+  queue_as :interval_10s
+
+  def perform
+    # Soft delete all expired and non-deleted verification requests in a single query
+    EmailVerificationRequest.expired.where(deleted_at: nil)
+                            .update_all(deleted_at: Time.current)
+  end
+end

--- a/app/mailers/email_verification_mailer.rb
+++ b/app/mailers/email_verification_mailer.rb
@@ -1,0 +1,17 @@
+class EmailVerificationMailer < ApplicationMailer
+  # Subject can be set in your I18n file at config/locales/en.yml
+  # with the following lookup:
+  #
+  #   en.email_verification_mailer.verify_email.subject
+  #
+  def verify_email(verification_request)
+    @verification_request = verification_request
+    @user = verification_request.user
+    @verification_url = auth_token_url(verification_request.token)
+
+    mail(
+      to: verification_request.email,
+      subject: "Verify your email address for Hackatime"
+    )
+  end
+end

--- a/app/models/email_verification_request.rb
+++ b/app/models/email_verification_request.rb
@@ -1,0 +1,49 @@
+class EmailVerificationRequest < ApplicationRecord
+  belongs_to :user
+
+  validates :email, presence: true,
+                   uniqueness: { conditions: -> { where(deleted_at: nil) } },
+                   format: { with: URI::MailTo::EMAIL_REGEXP }
+  validates :token, presence: true, uniqueness: { conditions: -> { where(deleted_at: nil) } }
+  validates :expires_at, presence: true
+
+  before_validation :generate_token, on: :create
+  before_validation :set_expiration, on: :create
+  before_validation :downcase_email
+
+  scope :valid, -> { where("expires_at > ? AND deleted_at IS NULL", Time.current) }
+  scope :expired, -> { where("expires_at <= ?", Time.current) }
+
+  def expired?
+    expires_at <= Time.current
+  end
+
+  def soft_delete!
+    update!(deleted_at: Time.current)
+  end
+
+  def verify!
+    email_address = user.email_addresses.create!(
+      email: email,
+      source: :signing_in
+    )
+
+    soft_delete!
+
+    email_address
+  end
+
+  private
+
+  def generate_token
+    self.token ||= SecureRandom.urlsafe_base64(32)
+  end
+
+  def set_expiration
+    self.expires_at ||= 30.minutes.from_now
+  end
+
+  def downcase_email
+    self.email = email.downcase if email.present?
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,8 +7,9 @@ class User < ApplicationRecord
   validates :timezone, inclusion: { in: TZInfo::Timezone.all.map(&:identifier) }, allow_nil: false
 
   has_many :heartbeats
-  has_many :email_addresses
-  has_many :sign_in_tokens
+  has_many :email_addresses, dependent: :destroy
+  has_many :email_verification_requests, dependent: :destroy
+  has_many :sign_in_tokens, dependent: :destroy
   has_many :project_repo_mappings
 
   has_many :hackatime_heartbeats,

--- a/app/views/email_verification_mailer/verify_email.html.erb
+++ b/app/views/email_verification_mailer/verify_email.html.erb
@@ -1,0 +1,17 @@
+<h1>Verify your email address for Hackatime</h1>
+<p>
+  Hi <%= @user.display_name %>,
+</p>
+<p>
+  You've requested to add <%= @verification_request.email %> to your Hackatime account.
+  Click the link below to verify this email address:
+</p>
+<p>
+  <%= link_to 'Verify email address', @verification_url %>
+</p>
+<p>
+  This link will expire in 30 minutes and can only be used once.
+</p>
+<p>
+  If you didn't request this email, you can safely ignore it.
+</p>

--- a/app/views/email_verification_mailer/verify_email.text.erb
+++ b/app/views/email_verification_mailer/verify_email.text.erb
@@ -1,0 +1,12 @@
+Verify your email address for Hackatime
+
+Hi <%= @user.display_name %>,
+
+You've requested to add <%= @verification_request.email %> to your Hackatime account.
+Click the link below to verify this email address:
+
+<%= @verification_url %>
+
+This link will expire in 30 minutes and can only be used once.
+
+If you didn't request this email, you can safely ignore it.

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -52,6 +52,11 @@
         Letter Opener
       <% end %>
     <% end %>
+    <% dev_tool(nil, "li") do %>
+      <%= link_to '/rails/mailers', class: "nav-item #{current_page?('/rails/mailers') ? 'active' : ''}" do %>
+        Mailers
+      <% end %>
+    <% end %>
     <% admin_tool(nil, "li") do %>
       <%= link_to avo_path, class: "nav-item #{current_page?(avo_path) ? 'active' : ''}" do %>
         Avo

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -104,6 +104,15 @@
     <% else %>
       <p>No email addresses found.</p>
     <% end %>
+
+    <div class="add-email-form">
+      <%= form_tag add_email_auth_path, data: { turbo: false } do %>
+        <div class="field">
+          <%= email_field_tag :email, nil, placeholder: "Add another email address", required: true %>
+        </div>
+        <%= submit_tag "Add Email" %>
+      <% end %>
+    </div>
   </section>
 
   <section>

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -45,6 +45,10 @@ Rails.application.configure do
       cron: "0 10 * * *",
       class: "ScanGithubReposJob"
     },
+    cleanup_expired_email_verification_requests: {
+      cron: "* * * * *",
+      class: "CleanupExpiredEmailVerificationRequestsJob"
+    },
     cache_active_user_graph_data_job: {
       cron: "*/10 * * * *",
       class: "Cache::ActiveUsersGraphDataJob",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,6 +49,7 @@ Rails.application.routes.draw do
   get "/auth/github", to: "sessions#github_new", as: :github_auth
   get "/auth/github/callback", to: "sessions#github_create"
   post "/auth/email", to: "sessions#email", as: :email_auth
+  post "/auth/email/add", to: "sessions#add_email", as: :add_email_auth
   get "/auth/token/:token", to: "sessions#token", as: :auth_token
   get "/auth/close_window", to: "sessions#close_window", as: :close_window
   delete "signout", to: "sessions#destroy", as: "signout"

--- a/db/migrate/20250505151057_create_email_verification_requests.rb
+++ b/db/migrate/20250505151057_create_email_verification_requests.rb
@@ -1,0 +1,13 @@
+class CreateEmailVerificationRequests < ActiveRecord::Migration[8.0]
+  def change
+    create_table :email_verification_requests do |t|
+      t.string :email
+      t.references :user, null: false, foreign_key: true
+      t.string :token
+      t.datetime :expires_at
+
+      t.timestamps
+    end
+    add_index :email_verification_requests, :email, unique: true
+  end
+end

--- a/db/migrate/20250505152654_add_deleted_at_to_email_verification_requests.rb
+++ b/db/migrate/20250505152654_add_deleted_at_to_email_verification_requests.rb
@@ -1,0 +1,5 @@
+class AddDeletedAtToEmailVerificationRequests < ActiveRecord::Migration[8.0]
+  def change
+    add_column :email_verification_requests, :deleted_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_05_045020) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_05_152654) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -77,6 +77,18 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_05_045020) do
     t.integer "source"
     t.index ["email"], name: "index_email_addresses_on_email", unique: true
     t.index ["user_id"], name: "index_email_addresses_on_user_id"
+  end
+
+  create_table "email_verification_requests", force: :cascade do |t|
+    t.string "email"
+    t.bigint "user_id", null: false
+    t.string "token"
+    t.datetime "expires_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
+    t.index ["email"], name: "index_email_verification_requests_on_email", unique: true
+    t.index ["user_id"], name: "index_email_verification_requests_on_user_id"
   end
 
   create_table "good_job_batches", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -312,6 +324,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_05_045020) do
 
   add_foreign_key "api_keys", "users"
   add_foreign_key "email_addresses", "users"
+  add_foreign_key "email_verification_requests", "users"
   add_foreign_key "heartbeats", "users"
   add_foreign_key "leaderboard_entries", "leaderboards"
   add_foreign_key "leaderboard_entries", "users"


### PR DESCRIPTION
Now users can put in alternative email addresses for signing in:

<img width="1186" alt="Screenshot 2025-05-05 at 11 44 18" src="https://github.com/user-attachments/assets/a7a00690-6b89-4b65-8bc2-b433732837aa" />

They get a verification email that expires in 30 min:

<img width="912" alt="Screenshot 2025-05-05 at 11 44 24" src="https://github.com/user-attachments/assets/a7e1f9df-7f32-4c95-aa23-b893b7414da6" />
