### PR TITLE
Add admin routes for looking up by email address / slack

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,36 @@
+class Api::V1::UsersController < ApplicationController
+  before_action :ensure_authenticated!
+
+  def lookup_email
+    email = params[:email]
+
+    user = EmailAddress.find_by_email(email)&.user
+
+    if user.present?
+      render json: { user_id: user.id, email: email }
+    else
+      render json: { error: "User not found", email: email }, status: :not_found
+    end
+  end
+
+  def lookup_slack_uid
+    slack_uid = params[:slack_uid]
+
+    user = User.find_by(slack_uid: slack_uid)
+
+    if user.present?
+      render json: { user_id: user.id, slack_uid: slack_uid }
+    else
+      render json: { error: "User not found", slack_uid: slack_uid }, status: :not_found
+    end
+  end
+
+  private
+
+  def ensure_authenticated!
+    return if Rails.env.development?
+
+    token = request.headers["Authorization"]&.split(" ")&.last
+    render json: { error: "Unauthorized" }, status: :unauthorized unless token == ENV["STATS_API_KEY"]
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -86,6 +86,9 @@ Rails.application.routes.draw do
       get "users/:username/stats", to: "stats#user_stats"
       get "users/:username/heartbeats/spans", to: "stats#user_spans"
 
+      get "users/lookup_email/:email", to: "users#lookup_email", constraints: { email: /[^\/]+/ }
+      get "users/lookup_slack_uid/:slack_uid", to: "users#lookup_slack_uid"
+
       # External service Slack OAuth integration
       post "external/slack/oauth", to: "external_slack#create_user"
 


### PR DESCRIPTION
New routes for YSWS programs to use:

<img width="654" alt="Screenshot 2025-05-06 at 14 31 00" src="https://github.com/user-attachments/assets/24d4869e-9bb2-4e28-abf6-d2a59d3f1446" />

This endpoint needs the stats api key provided to programs

This is specifically to handle the confusion of hackatime supporting multiple email addresses while most programs supporting just one