### PR TITLE
Attempt to speed up currently hacking by loading in count upfront

### DIFF
--- a/app/assets/stylesheets/currently_hacking.css
+++ b/app/assets/stylesheets/currently_hacking.css
@@ -17,17 +17,11 @@
 .currently-hacking {
   padding: 8px;
   background: white;
+  cursor: pointer;
+  user-select: none;
 }
 
 .currently-hacking-header {
-  cursor: pointer;
-  user-select: none;
-  color: var(--black);
-}
-
-.currently-hacking-header {
-  cursor: pointer;
-  user-select: none;
   color: var(--black);
 }
 
@@ -46,6 +40,10 @@
   animation: pulse 2s infinite;
 }
 
+.loading-text {
+  opacity: 0.7;
+}
+
 @keyframes pulse {
   0% {
     opacity: 0.5;
@@ -58,10 +56,13 @@
   }
 }
 
+#currently_hacking {
+  display: none;
+}
 .currently-hacking-list {
   max-height: 60vh;
   overflow-y: auto;
-  padding-right: 8px;
+  padding: 8px;
   background: white;
   display: none;
 }
@@ -81,8 +82,8 @@
   margin-bottom: 0;
 }
 
-/* Show list when parent has visible class */
-.currently-hacking.visible > .currently-hacking-list {
+.currently-hacking-container.visible .currently-hacking-list,
+.currently-hacking-container.visible #currently_hacking {
   display: block;
 }
 

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,13 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import "@hotwired/turbo-rails"
 import "controllers"
+
+document.addEventListener("DOMContentLoaded", function() {
+  const container = document.querySelector('.currently-hacking-container');
+  const header = container?.querySelector('.currently-hacking-header');
+  if (container && header) {
+    header.addEventListener('click', function() {
+      container.classList.toggle('visible');
+    });
+  }
+});

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="mobile-web-app-capable" content="yes">
+
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
@@ -48,11 +49,16 @@
       </footer>
     </main>
 
-    <div class="currently-hacking-container">
-      <%= turbo_frame_tag "currently_hacking", src: currently_hacking_static_pages_path do %>
-        <div class="loading">
-          Loading currently hacking...
+    <div class="currently-hacking-container" data-controller="currently-hacking" data-currently-hacking-target="container">
+      <div class="currently-hacking">
+        <div class="currently-hacking-header">
+          <span>
+            <div class="live-indicator"></div>
+            <%= pluralize(Cache::CurrentlyHackingJob.perform_now[:users].count, "person") %> currently hacking
+          </span>
         </div>
+      </div>
+      <%= turbo_frame_tag "currently_hacking", src: currently_hacking_static_pages_path, 'no-spinner' => true do %>
       <% end %>
     </div>
   </body>

--- a/app/views/static_pages/_currently_hacking.erb
+++ b/app/views/static_pages/_currently_hacking.erb
@@ -1,31 +1,22 @@
 <%= turbo_frame_tag "currently_hacking" do %>
   <% if users&.any? %>
-    <div class="currently-hacking" onclick="this.classList.toggle('visible')">
-      <div class="currently-hacking-header">
-        <span>
-          <div class="live-indicator"></div>
-          <%= pluralize(users.count, "person") %> currently hacking
-        </span>
-      </div>
-      <div class="currently-hacking-list">
-        <hr>
-        <ul>
-          <% users.each do |user| %>
-            <%= render "shared/user_mention", user: user, show: [:slack] %>
-            <% if active_projects[user.id].present? %>
-              <span class="super">
-                working on <%= link_to active_projects[user.id].project_name, active_projects[user.id].repo_url, target: "_blank" %>
-                <%= link_to "🌌", visualize_git_url(active_projects[user.id].repo_url), target: "_blank" %>
-              </span>
-            <% end %>
-            <% if user == current_user && user.github_username.blank? %>
-              <span class="super">
-                <%= link_to "Link active projects", my_settings_path(anchor: "user_github_account"), target: "_blank" %>
-              </span>
-            <% end %>
+    <div class="currently-hacking-list">
+      <ul>
+        <% users.each do |user| %>
+          <%= render "shared/user_mention", user: user, show: [:slack] %>
+          <% if active_projects[user.id].present? %>
+            <span class="super">
+              working on <%= link_to active_projects[user.id].project_name, active_projects[user.id].repo_url, target: "_blank" %>
+              <%= link_to "🌌", visualize_git_url(active_projects[user.id].repo_url), target: "_blank" %>
+            </span>
           <% end %>
-        </ul>
-      </div>
+          <% if user == current_user && user.github_username.blank? %>
+            <span class="super">
+              <%= link_to "Link active projects", my_settings_path(anchor: "user_github_account"), target: "_blank" %>
+            </span>
+          <% end %>
+        <% end %>
+      </ul>
     </div>
   <% else %>
     <div class="currently-hacking">


### PR DESCRIPTION
This can load quick because it's just a count of records that we cache regularly:

<img width="341" alt="Screenshot 2025-05-07 at 13 28 10" src="https://github.com/user-attachments/assets/03334b9a-4edb-4504-afcf-3250ffe2e671" />

This is async loaded because there are a bunch of n+1s here that are hard to wrap into a single quick call (some rely on external API calls that aren't currently cached well)

<img width="323" alt="Screenshot 2025-05-07 at 13 28 15" src="https://github.com/user-attachments/assets/72af413a-3293-4153-8306-8683fc2e8039" />

