### PR TITLE
Suspend sailors log poll for users with active migrations

### DIFF
--- a/app/jobs/sailors_log_poll_for_changes_job.rb
+++ b/app/jobs/sailors_log_poll_for_changes_job.rb
@@ -30,6 +30,9 @@ class SailorsLogPollForChangesJob < ApplicationJob
   private
 
   def update_sailors_log(sailors_log)
+    # Skip if there's an active migration job for this user
+    return [] if sailors_log.user.in_progress_migration_jobs?
+
     project_updates = []
     project_durations = Heartbeat.where(user_id: sailors_log.user.id)
                                  .group(:project).duration_seconds

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -67,6 +67,13 @@ class User < ApplicationRecord
     ).order(created_at: :desc).limit(10).all
   end
 
+  def in_progress_migration_jobs?
+    GoodJob::Job.where(job_class: "MigrateUserFromHackatimeJob")
+                .where("serialized_params->>'arguments' = ?", [ id ].to_json)
+                .where(finished_at: nil)
+                .exists?
+  end
+
   def set_neighborhood_channel
     return unless slack_uid.present?
 


### PR DESCRIPTION
Gone are the days of [wat?](https://hackclub.slack.com/archives/C08MDGUPJ6A/p1747075054294209)

![Screenshot 2025-05-12 203619](https://github.com/user-attachments/assets/bceca622-039f-466f-9cb6-428afa4466b9)

(fixes the bug where sailors log spazzes out because it runs at the same time a migration job happens)