### PR TITLE
Fix missing ":user_agent" causing heartbeat request to fail

### DIFF
--- a/app/controllers/api/hackatime/v1/hackatime_controller.rb
+++ b/app/controllers/api/hackatime/v1/hackatime_controller.rb
@@ -95,7 +95,7 @@ class Api::Hackatime::V1::HackatimeController < ApplicationController
         ip_address: request.remote_ip,
         editor: parsed_ua[:editor],
         operating_system: parsed_ua[:os],
-        machine: request.headers["X-Machine-Name"] || "Unknown",
+        machine: request.headers["X-Machine-Name"] || "Unknown"
       })
       new_heartbeat = Heartbeat.find_or_create_by(attrs)
       if @raw_heartbeat_upload.present? && new_heartbeat.persisted?

--- a/app/controllers/api/hackatime/v1/hackatime_controller.rb
+++ b/app/controllers/api/hackatime/v1/hackatime_controller.rb
@@ -76,7 +76,13 @@ class Api::Hackatime::V1::HackatimeController < ApplicationController
     heartbeat_array.each do |heartbeat|
       source_type = :direct_entry
 
-      parsed_ua = WakatimeService.parse_user_agent(heartbeat[:user_agent])
+      if heartbeat[:user_agent].present?
+        parsed_ua = WakatimeService.parse_user_agent(heartbeat[:user_agent])
+      elsif request.headers["User-Agent"].present?
+        parsed_ua = WakatimeService.parse_user_agent(request.headers["User-Agent"])
+      else
+        parsed_ua = { editor: "Unknown", os: "Unknown" }
+      end
 
       # special case: if the entity is "test.txt", this is a test heartbeat
       if heartbeat[:entity] == "test.txt"

--- a/app/controllers/api/hackatime/v1/hackatime_controller.rb
+++ b/app/controllers/api/hackatime/v1/hackatime_controller.rb
@@ -78,11 +78,8 @@ class Api::Hackatime::V1::HackatimeController < ApplicationController
 
       user_agent = heartbeat[:user_agent] || request.headers["User-Agent"]
 
-      if user_agent.present?
-        parsed_ua = WakatimeService.parse_user_agent(user_agent)
-      else
-        parsed_ua = { editor: "Unknown", os: "Unknown" }
-      end
+      # dont pass nil to the user agent parser
+      parsed_ua = WakatimeService.parse_user_agent(user_agent || "")
 
       # special case: if the entity is "test.txt", this is a test heartbeat
       if heartbeat[:entity] == "test.txt"

--- a/app/controllers/api/hackatime/v1/hackatime_controller.rb
+++ b/app/controllers/api/hackatime/v1/hackatime_controller.rb
@@ -89,7 +89,7 @@ class Api::Hackatime::V1::HackatimeController < ApplicationController
         ip_address: request.remote_ip,
         editor: parsed_ua[:editor],
         operating_system: parsed_ua[:os],
-        machine: request.headers["X-Machine-Name"]
+        machine: request.headers["X-Machine-Name"] || "Unknown",
       })
       new_heartbeat = Heartbeat.find_or_create_by(attrs)
       if @raw_heartbeat_upload.present? && new_heartbeat.persisted?

--- a/app/controllers/api/hackatime/v1/hackatime_controller.rb
+++ b/app/controllers/api/hackatime/v1/hackatime_controller.rb
@@ -76,10 +76,10 @@ class Api::Hackatime::V1::HackatimeController < ApplicationController
     heartbeat_array.each do |heartbeat|
       source_type = :direct_entry
 
-      if heartbeat[:user_agent].present?
-        parsed_ua = WakatimeService.parse_user_agent(heartbeat[:user_agent])
-      elsif request.headers["User-Agent"].present?
-        parsed_ua = WakatimeService.parse_user_agent(request.headers["User-Agent"])
+      user_agent = heartbeat[:user_agent] || request.headers["User-Agent"]
+
+      if user_agent.present?
+        parsed_ua = WakatimeService.parse_user_agent(user_agent)
       else
         parsed_ua = { editor: "Unknown", os: "Unknown" }
       end
@@ -95,7 +95,7 @@ class Api::Hackatime::V1::HackatimeController < ApplicationController
         ip_address: request.remote_ip,
         editor: parsed_ua[:editor],
         operating_system: parsed_ua[:os],
-        machine: request.headers["X-Machine-Name"] || "Unknown"
+        machine: request.headers["X-Machine-Name"]
       })
       new_heartbeat = Heartbeat.find_or_create_by(attrs)
       if @raw_heartbeat_upload.present? && new_heartbeat.persisted?

--- a/app/controllers/api/hackatime/v1/hackatime_controller.rb
+++ b/app/controllers/api/hackatime/v1/hackatime_controller.rb
@@ -78,7 +78,7 @@ class Api::Hackatime::V1::HackatimeController < ApplicationController
 
       user_agent = heartbeat[:user_agent] || request.headers["User-Agent"]
 
-      # dont pass nil to the user agent parser
+      # don't pass nil to the user agent parser
       parsed_ua = WakatimeService.parse_user_agent(user_agent || "")
 
       # special case: if the entity is "test.txt", this is a test heartbeat


### PR DESCRIPTION
~If the machine name does not exist it will get set to "Unknown" (not sure if this would be the desired behavior)~