### PR TITLE
Revert "Fix missing ":user_agent" causing heartbeat request to fail"

### DIFF
--- a/app/controllers/api/hackatime/v1/hackatime_controller.rb
+++ b/app/controllers/api/hackatime/v1/hackatime_controller.rb
@@ -76,10 +76,7 @@ class Api::Hackatime::V1::HackatimeController < ApplicationController
     heartbeat_array.each do |heartbeat|
       source_type = :direct_entry
 
-      user_agent = heartbeat[:user_agent] || request.headers["User-Agent"]
-
-      # don't pass nil to the user agent parser
-      parsed_ua = WakatimeService.parse_user_agent(user_agent || "")
+      parsed_ua = WakatimeService.parse_user_agent(heartbeat[:user_agent])
 
       # special case: if the entity is "test.txt", this is a test heartbeat
       if heartbeat[:entity] == "test.txt"


### PR DESCRIPTION
Reverts hackclub/hackatime#234

Error was more complex than i thought and i'm not comfortable enough with ruby to be able to fix it. Reverting as it does not have the desired result.

The error on my local dev instance:
![image](https://github.com/user-attachments/assets/d382c5f2-f6b6-4a2d-a28e-7bfdf9ee312d)
