### PR TITLE
Renaming the channel hackatime-dev to hackatime-v2

### DIFF
--- a/app/views/docs/index.html.erb
+++ b/app/views/docs/index.html.erb
@@ -93,7 +93,7 @@
   </p>
   <p>
     <strong>Have questions?</strong> Ask in the <a href="https://hackclub.slack.com" target="_blank">Hack Club Slack</a> 
-    (#hackatime-dev channel) or <a href="https://github.com/hackclub/hackatime/issues" target="_blank">ask on GitHub</a>.
+    (#hackatime-v2 channel) or <a href="https://github.com/hackclub/hackatime/issues" target="_blank">ask on GitHub</a>.
   </p>
 
   <h3>🔧 Supported Editors</h3>

--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -92,4 +92,4 @@ Having trouble with your API key? Check:
 2. You're using the right website URL
 3. Your request looks like the examples above
 
-Still stuck? Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)!
+Still stuck? Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)!

--- a/docs/editors/android-studio.md
+++ b/docs/editors/android-studio.md
@@ -30,7 +30,7 @@ That's it! The plugin will use your settings from Step 2.
 
 **Plugin not working?** Close Android Studio and open it again.
 
-**Still having trouble?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) - look for the #hackatime-dev channel.
+**Still having trouble?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) - look for the #hackatime-v2 channel.
 
 ## What Happens Next
 

--- a/docs/editors/appcode.md
+++ b/docs/editors/appcode.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting AppCode after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/aptana.md
+++ b/docs/editors/aptana.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting Aptana after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/arduino-ide.md
+++ b/docs/editors/arduino-ide.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting Arduino IDE after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/azure-data-studio.md
+++ b/docs/editors/azure-data-studio.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting Azure Data Studio after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/blender.md
+++ b/docs/editors/blender.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting Blender after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/brackets.md
+++ b/docs/editors/brackets.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting Brackets after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/brave.md
+++ b/docs/editors/brave.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting Brave after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/c++-builder.md
+++ b/docs/editors/c++-builder.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting C++ Builder after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/canva.md
+++ b/docs/editors/canva.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting Canva after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/chrome.md
+++ b/docs/editors/chrome.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting Chrome after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/clion.md
+++ b/docs/editors/clion.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting CLion after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/cloud9.md
+++ b/docs/editors/cloud9.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting Cloud9 after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/coda.md
+++ b/docs/editors/coda.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting Coda after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/codetasty.md
+++ b/docs/editors/codetasty.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting CodeTasty after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/cursor.md
+++ b/docs/editors/cursor.md
@@ -28,7 +28,7 @@ That's it! The plugin will use your settings from Step 2.
 
 **Plugin not working?** Close Cursor and open it again.
 
-**Still having trouble?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) - look for the #hackatime-dev channel.
+**Still having trouble?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) - look for the #hackatime-v2 channel.
 
 ## What Happens Next
 

--- a/docs/editors/datagrip.md
+++ b/docs/editors/datagrip.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting DataGrip after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/dataspell.md
+++ b/docs/editors/dataspell.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting DataSpell after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/dbeaver.md
+++ b/docs/editors/dbeaver.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting DBeaver after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/delphi.md
+++ b/docs/editors/delphi.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting Delphi after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/discord.md
+++ b/docs/editors/discord.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting Discord after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/eclipse.md
+++ b/docs/editors/eclipse.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting Eclipse after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/edge.md
+++ b/docs/editors/edge.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting Edge after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/emacs.md
+++ b/docs/editors/emacs.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting Emacs after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/eric.md
+++ b/docs/editors/eric.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting Eric after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/excel.md
+++ b/docs/editors/excel.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting Excel after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/figma.md
+++ b/docs/editors/figma.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting Figma after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/firefox.md
+++ b/docs/editors/firefox.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting Firefox after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/gedit.md
+++ b/docs/editors/gedit.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting Gedit after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/godot.md
+++ b/docs/editors/godot.md
@@ -48,7 +48,7 @@ This Hack Club-approved plugin provides:
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not enabled?** Check **Project → Project Settings → Plugins** and enable "Godot Super Wakatime"
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/goland.md
+++ b/docs/editors/goland.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting GoLand after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/hbuilder-x.md
+++ b/docs/editors/hbuilder-x.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting HBuilder X after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/ida-pro.md
+++ b/docs/editors/ida-pro.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting IDA Pro after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/intellij-idea.md
+++ b/docs/editors/intellij-idea.md
@@ -30,7 +30,7 @@ That's it! The plugin will use your settings from Step 2.
 
 **Plugin not working?** Close IntelliJ IDEA and open it again.
 
-**Still having trouble?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) - look for the #hackatime-dev channel.
+**Still having trouble?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) - look for the #hackatime-v2 channel.
 
 ## What Happens Next
 

--- a/docs/editors/jupyter.md
+++ b/docs/editors/jupyter.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting Jupyter after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/kakoune.md
+++ b/docs/editors/kakoune.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting Kakoune after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/kate.md
+++ b/docs/editors/kate.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting Kate after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/komodo.md
+++ b/docs/editors/komodo.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting Komodo after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/micro.md
+++ b/docs/editors/micro.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting Micro after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/mps.md
+++ b/docs/editors/mps.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting MPS after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/neovim.md
+++ b/docs/editors/neovim.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting Neovim after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/netbeans.md
+++ b/docs/editors/netbeans.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting NetBeans after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/notepad++.md
+++ b/docs/editors/notepad++.md
@@ -28,7 +28,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting Notepad++ after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/nova.md
+++ b/docs/editors/nova.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting Nova after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/obsidian.md
+++ b/docs/editors/obsidian.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting Obsidian after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/oxygen.md
+++ b/docs/editors/oxygen.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting Oxygen after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/phpstorm.md
+++ b/docs/editors/phpstorm.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting PhpStorm after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/postman.md
+++ b/docs/editors/postman.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting Postman after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/powerpoint.md
+++ b/docs/editors/powerpoint.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting PowerPoint after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/processing.md
+++ b/docs/editors/processing.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting Processing after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/pulsar.md
+++ b/docs/editors/pulsar.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting Pulsar after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/pycharm.md
+++ b/docs/editors/pycharm.md
@@ -30,7 +30,7 @@ That's it! The plugin will use your settings from Step 2.
 
 **Plugin not working?** Close PyCharm and open it again.
 
-**Still having trouble?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) - look for the #hackatime-dev channel.
+**Still having trouble?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) - look for the #hackatime-v2 channel.
 
 ## What Happens Next
 

--- a/docs/editors/reclassex.md
+++ b/docs/editors/reclassex.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting ReClassEx after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/rider.md
+++ b/docs/editors/rider.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting Rider after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/roblox-studio.md
+++ b/docs/editors/roblox-studio.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting Roblox Studio after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/rubymine.md
+++ b/docs/editors/rubymine.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting RubyMine after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/rustrover.md
+++ b/docs/editors/rustrover.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting RustRover after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/safari.md
+++ b/docs/editors/safari.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting Safari after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/siyuan.md
+++ b/docs/editors/siyuan.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting SiYuan after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/sketch.md
+++ b/docs/editors/sketch.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting Sketch after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/slickedit.md
+++ b/docs/editors/slickedit.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting SlickEdit after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/sql-server-management-studio.md
+++ b/docs/editors/sql-server-management-studio.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting SQL Server Management Studio after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/sublime-text.md
+++ b/docs/editors/sublime-text.md
@@ -31,7 +31,7 @@ That's it! The plugin will use your settings from Step 2.
 
 **Don't have Package Control?** Go to [packagecontrol.io](https://packagecontrol.io/installation) to install it first.
 
-**Still having trouble?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) - look for the #hackatime-dev channel.
+**Still having trouble?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) - look for the #hackatime-v2 channel.
 
 ## What Happens Next
 

--- a/docs/editors/terminal.md
+++ b/docs/editors/terminal.md
@@ -26,7 +26,7 @@ This installs `terminal-wakatime` and automatically configures it for bash, zsh,
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting Terminal after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/texstudio.md
+++ b/docs/editors/texstudio.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting TeXstudio after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/textmate.md
+++ b/docs/editors/textmate.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting TextMate after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/trae.md
+++ b/docs/editors/trae.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting Trae after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/unity.md
+++ b/docs/editors/unity.md
@@ -34,7 +34,7 @@ After installing, the plugin will use your settings from Step 2.
 
 **Package Manager not working?** Make sure you're connected to the internet.
 
-**Still having trouble?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) - look for the #hackatime-dev channel.
+**Still having trouble?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) - look for the #hackatime-v2 channel.
 
 ## What Happens Next
 

--- a/docs/editors/vim.md
+++ b/docs/editors/vim.md
@@ -43,7 +43,7 @@ That's it! The plugin will use your settings from Step 2.
 
 **Don't know how to edit .vimrc?** Type `:e ~/.vimrc` in Vim to open it.
 
-**Still having trouble?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) - look for the #hackatime-dev channel.
+**Still having trouble?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) - look for the #hackatime-v2 channel.
 
 ## What Happens Next
 

--- a/docs/editors/visual-studio.md
+++ b/docs/editors/visual-studio.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting Visual Studio after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/vs-code.md
+++ b/docs/editors/vs-code.md
@@ -28,7 +28,7 @@ That's it! The plugin will use your settings from Step 2.
 
 **Plugin not working?** Close VS Code and open it again.
 
-**Still having trouble?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) - look for the #hackatime-dev channel.
+**Still having trouble?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) - look for the #hackatime-v2 channel.
 
 ## What Happens Next
 

--- a/docs/editors/webstorm.md
+++ b/docs/editors/webstorm.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting WebStorm after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/windsurf.md
+++ b/docs/editors/windsurf.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting Windsurf after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/wing.md
+++ b/docs/editors/wing.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting Wing after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/word.md
+++ b/docs/editors/word.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting Word after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/xcode.md
+++ b/docs/editors/xcode.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting Xcode after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/editors/zed.md
+++ b/docs/editors/zed.md
@@ -22,7 +22,7 @@ The WakaTime plugin will automatically use your Hackatime configuration after ru
 
 - **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
 - **Plugin not working?** Try restarting Zed after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 
 ## Next Steps
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -74,4 +74,4 @@ include_only_with_project_file = true
 
 ## Need Help?
 
-Having trouble with setup? Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)!
+Having trouble with setup? Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)!

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -62,4 +62,4 @@ After setup, start coding! Your time will show up on your [Hackatime dashboard](
 
 - **Not seeing your time?** Make sure the API URL is set correctly
 - **Plugin not working?** Try closing and opening your editor again
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -85,7 +85,7 @@ Check that it's working:
 **Need help?**
 
 - Visit the [Hackatime Setup Page](https://hackatime.hackclub.com/my/wakatime_setup) for guided troubleshooting
-- Join [Hack Club Slack](https://hackclub.slack.com) (#hackatime-dev channel)
+- Join [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
 - [Create an issue](https://github.com/hackclub/hackatime/issues) on GitHub
 
 **Migrating from WakaTime?**


### PR DESCRIPTION
What the title says :)
The correct channel for Hackatime support is #hackatime-v2