### PR TITLE
remove references to kicad-wakatime

### DIFF
--- a/app/views/users/wakatime_setup_step_2.html.erb
+++ b/app/views/users/wakatime_setup_step_2.html.erb
@@ -9,9 +9,6 @@
     <%= link_to "vs-code (visual studio code)", my_wakatime_setup_step_3_path(anchor: "vs-code") %>
   </li>
   <li>
-    <%= link_to "kicad", my_wakatime_setup_step_3_path(anchor: "kicad") %>
-  </li>
-  <li>
     <%= link_to "vim", my_wakatime_setup_step_3_path(anchor: "vim") %>
   </li>
   <li>

--- a/app/views/users/wakatime_setup_step_3.html.erb
+++ b/app/views/users/wakatime_setup_step_3.html.erb
@@ -12,14 +12,6 @@
   </p>
 </section>
   
-<section id="kicad">
-  <h2>Kicad</h2>
-  <p>
-    <em>Hackatime is WakaTime-compatible, so you can use it with any editor that WakaTime supports. For Kicad, 
-      we recommend this <a href="https://github.com/hackclub/kicad-wakatime?tab=readme-ov-file#installation">Kicad plugin built by hack clubbers</a>.</em>
-  </p>
-</section>
-
 <section id="vs-code">
   <h2>VS Code (Visual Studio Code)</h2>
   <p>


### PR DESCRIPTION
in the wake of [Summer of Making](https://summer.hackclub.com/), tons of people are finding [kicad-wakatime](https://github.com/hackclub/kicad-wakatime) again from links left in the copy. this plugin is not suitable for time tracking in the current era due to bugs that were left behind when it was frozen earlier this year; this pull request should remove all surviving references to it.