### PR TITLE
Fix broken link to wakatime.com

### DIFF
--- a/app/views/users/wakatime_setup_step_3.html.erb
+++ b/app/views/users/wakatime_setup_step_3.html.erb
@@ -6,7 +6,7 @@
 <section>
   <h2>Other</h2>
   <p>
-    <em>Hackatime is WakaTime-compatible, so you can use it with any editor that WakaTime supports. For other editors, please refer to the <a href="https://wakatime.com/docs/editors">WakaTime docs</a>.</em>
+    <em>Hackatime is WakaTime-compatible, so you can use it with any editor that WakaTime supports. For other editors, please refer to the <a href="https://wakatime.com/plugins">WakaTime docs</a>.</em>
 
     <strong>⚠️ Note: skip any steps that update your ~/.wakatime.cfg file or change the api_url inside it.</strong>
   </p>


### PR DESCRIPTION
Hi y'all,

It looks like WakaTime's editor plugin list has moved. It now can be found at [/plugins](https://wakatime.com/plugins), but the "Step 3" editor setup page had a link to [/docs/editors](https://wakatime.com/docs/editors), which is now a 404. This PR updates the link.

I'm excited to get making, thanks for running this!

See you,
Micha