### PR TITLE
Add automatic backup of previous configuration

### DIFF
--- a/public/hackatime/setup.ps1
+++ b/public/hackatime/setup.ps1
@@ -1,7 +1,12 @@
 try {
     # Create config file with API settings
     $configPath = "$env:USERPROFILE\.wakatime.cfg"
-    
+    # If config exists, backup
+    if (Test-Path $configPath) {
+        Write-Host "[INFO] Config file already exists, moving into ~/.wakatime.cfg.bak"
+        Move-Item -Path $configPath -Destination "$configPath.bak"
+    }
+
     @"
 [settings]
 api_url = $env:HACKATIME_API_URL

--- a/public/hackatime/setup.sh
+++ b/public/hackatime/setup.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -e
 
+# If config exists, backup
+if [ -f ~/.wakatime.cfg ]; then
+    echo "[INFO] Config file already exists, moving into ~/.wakatime.cfg.bak"
+    mv ~/.wakatime.cfg ~/.wakatime.cfg.bak
+fi
+
 # Create or update config file
 cat > ~/.wakatime.cfg << EOL
 [settings]


### PR DESCRIPTION
If a configuration exists we should not just overwrite it. Instead making a backup is a better option. 

Something that may have to be done is prompting, but this was a "quickfix" so didn't really have time for that. 
However if prompting is desired I could implement it later :+1: 