### PR TITLE
Use correct WakaTime for Figma instructions

### DIFF
--- a/docs/editors/figma.md
+++ b/docs/editors/figma.md
@@ -10,7 +10,7 @@ Make sure you have a [Hackatime account](https://hackatime.hackclub.com) and are
 
 ## Step 2: Install the Extension
 
-Visit the [GitHub page](https://go.skyfall.dev/waka) and install the extension on Chrome or Firefox.
+Visit the [GitHub page](https://github.com/SkyfallWasTaken/figma-wakatime) and install the extension on Chrome or Firefox.
 
 ## Step 3: Configure API credentials
 
@@ -22,7 +22,7 @@ Visit the [GitHub page](https://go.skyfall.dev/waka) and install the extension o
 ## Troubleshooting
 
 - **Plugin not working?** Try refreshing your Figma after installation. You should see a "WakaTime for Figma is running!" toast when you open a Figma design.
-- **Using FigJam or Figma Slides?** The plugin currently doesn't support FigJam or Figma Slides - it only works for the main editor. If you would like support for this, open an issue on the extension's [GitHub page.](https://go.skyfall.dev/waka)
+- **Using FigJam or Figma Slides?** The plugin currently doesn't support FigJam or Figma Slides - it only works for the main editor. If you would like support for this, open an issue on the extension's [GitHub page.](https://github.com/SkyfallWasTaken/figma-wakatime)
 - **Is time being misattributed to different projects?** The extension uses your Figma filename as the Hackatime project name. So make sure it's not called "Untitled" or something similar!
 - **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) ([#figma-wakatime channel](https://hackclub.slack.com/archives/C092UUSQC01)), or open an issue to report bugs.
 

--- a/docs/editors/figma.md
+++ b/docs/editors/figma.md
@@ -8,22 +8,22 @@ Follow these steps to start tracking your design work in Figma with Hackatime.
 
 Make sure you have a [Hackatime account](https://hackatime.hackclub.com) and are logged in.
 
-## Step 2: Run the Setup Script
+## Step 2: Install the Extension
 
-Visit the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) to automatically configure your API key and endpoint. This ensures everything works perfectly with Hackatime.
+Visit the [GitHub page](https://go.skyfall.dev/waka) and install the extension on Chrome or Firefox.
 
-## Step 3: Install Figma Plugin
+## Step 3: Configure API credentials
 
-Follow the detailed plugin installation instructions on the [WakaTime Figma page](https://wakatime.com/figma).
-
-The WakaTime plugin will automatically use your Hackatime configuration after running the setup script.
+1. Click the "puzzle piece" icon on your toolbar
+2. Click on "WakaTime for Figma"
+3. For the API key, use your Hackatime API key (which is located [here](https://hackatime.hackclub.com/my/wakatime_setup))
+4. For the API URL, use `https://hackatime.hackclub.com/api/hackatime/v1`
 
 ## Troubleshooting
 
-- **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
-- **Plugin not working?** Try restarting Figma after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
-
-## Next Steps
+- **Plugin not working?** Try refreshing your Figma after installation. You should see a "WakaTime for Figma is running!" toast when you open a Figma design.
+- **Using FigJam or Figma Slides?** The plugin currently doesn't support FigJam or Figma Slides - it only works for the main editor. If you would like support for this, open an issue on the extension's [GitHub page.](https://go.skyfall.dev/waka)
+- **Is time being misattributed to different projects?** The extension uses your Figma filename as the Hackatime project name. So make sure it's not called "Untitled" or something similar!
+- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) ([#figma-wakatime channel](https://hackclub.slack.com/archives/C092UUSQC01)), or open an issue to report bugs.
 
 Once configured, your activity time will automatically appear on your [Hackatime dashboard](https://hackatime.hackclub.com). Happy designing!


### PR DESCRIPTION
This docs page recommends using the WakaTime desktop app, which doesn't work for things like SOM. This PR updates the instructions to use my plugin instead, which attributes time to projects instead of `Unknown` or `<<LAST_PROJECT>>`