### PR TITLE
Fix: Add logout confirmation and danger styling to logout button (#381)

### DIFF
--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -68,7 +68,9 @@
             <% end %>
           </div>
           <div>
-            <%= link_to signout_path, class: "block px-2 py-1 rounded-lg transition hover:bg-[#23272a]", data: { turbo_method: :delete, action: "click->nav#clickLink" } do %>
+            <%= link_to signout_path,
+                class: "block px-2 py-1 rounded-lg transition border border-red-600 text-red-600 font-bold hover:bg-red-100",
+                data: { turbo_method: :delete, turbo_confirm: "Are you sure you want to log out?", action: "click->nav#clickLink" } do %>
               Logout
             <% end %>
           </div>


### PR DESCRIPTION
### Add logout confirmation and danger styling to logout button

Fixes #381 

#### Changes
- Added a confirmation dialog when the "Logout" button is clicked, to prevent accidental logouts.
- Updated the "Logout" button styling to make it stand out as a dangerous action (red color).

#### Before
- Clicking "Logout" immediately signed the user out.
- The logout button looked similar to other navigation buttons.

#### After
- A browser confirmation dialog asks "Are you sure you want to log out?" before logging out.
- The logout button now uses a red theme to indicate a destructive action.

#### Screenshot
<img width="2267" alt="image" src="https://github.com/user-attachments/assets/fdc6858c-2708-4ae4-a0fe-79fe441f883b" />


---

Let me know if you have any questions or want changes!