### PR TITLE
Fix: Dropdown menu and text not visible in light mode (#377)

### DIFF
--- a/app/assets/stylesheets/filterable_dashboard.css
+++ b/app/assets/stylesheets/filterable_dashboard.css
@@ -1,3 +1,11 @@
+:root {
+  --text-color: #222;
+}
+
+.dark-mode {
+  --text-color: #f5f5f5;
+}
+
 .filter .options-container {
   position: absolute;
   top: 100%;


### PR DESCRIPTION
**Fix: Dropdown menu visible in light mode**  

Fixes #377 

This PR resolves an issue where users could not see or interact with the dropdown menu in light mode, affecting core functionality. The problem was caused by the `--text-color` CSS variable not being defined or set correctly, resulting in invisible text and non-functional dropdowns.

**Changes:**
- Defined `--text-color` for both light mode (`#222`) and dark mode (`#f5f5f5`)
- Ensured dropdown and option elements use `color: var(--text-color);`
- Dropdown menus are now visible and usable in both themes

**Note:**  
This is both a visual and functional fix—users can now see and interact with dropdowns in light mode.