### PR TITLE
Add iOS widget section to docs

### DIFF
--- a/app/views/docs/index.html.erb
+++ b/app/views/docs/index.html.erb
@@ -177,29 +177,31 @@
     </details>
 
 <div class="inline-block bg-darkless rounded-lg px-5 py-4 mb-8">
-      <div class="flex flex-col md:flex-row items-start md:items-center gap-5">
+  <div class="flex flex-col md:flex-row items-start md:items-center gap-5">
 
-        <div class="text-white">
-          <h4 class="text-xl font-semibold text-primary mb-1">📱 On iOS?</h4>
-          <p class="font-medium mb-2">Try the Hackatime widget.</p>
+    <div class="text-white">
+      <h4 class="text-xl font-semibold text-primary mb-1">📱 On iOS?</h4>
+      <p class="font-medium mb-1">Try the Hackatime widget.</p>
+      <p class="text-secondary text-sm mb-3">Shows your daily coding time</p>
 
-          <p class="mb-1">
-            <a href="https://testflight.apple.com/join/Fda4449P" target="_blank" class="text-primary hover:text-red underline">
-              Join the beta on TestFlight
-            </a>
-          </p>
+      <p class="mb-1">
+        <a href="https://testflight.apple.com/join/Fda4449P" target="_blank" class="text-primary hover:text-red underline">
+          Join the beta on TestFlight
+        </a>
+      </p>
 
-          <p>
-            <a href="https://github.com/jacobprezant/wakaScript/tree/main/iOS" target="_blank" class="text-primary hover:text-red underline">
-              View the code on GitHub
-          </p>
-        </div>
-
-        <img src="https://hc-cdn.hel1.your-objectstorage.com/s/v3/47e6a7f8a0fc0d04a6cb0bda1df78f707f8a637a_img_0069.jpg"
-             alt="Hackatime iOS Widget"
-             class="w-32 rounded shadow-md">
-      </div>
+      <p>
+        <a href="https://github.com/jacobprezant/wakaScript/tree/main/iOS" target="_blank" class="text-primary hover:text-red underline">
+          View the code on GitHub
+        </a>
+      </p>
     </div>
+
+    <img src="https://hc-cdn.hel1.your-objectstorage.com/s/v3/47e6a7f8a0fc0d04a6cb0bda1df78f707f8a637a_img_0069.jpg"
+         alt="Hackatime iOS Widget"
+         class="w-32 rounded shadow-md">
+  </div>
+</div>
 
     <div class="border-t border-darkless my-8"></div>
 

--- a/app/views/docs/index.html.erb
+++ b/app/views/docs/index.html.erb
@@ -176,6 +176,31 @@
       </div>
     </details>
 
+<div class="inline-block bg-darkless rounded-lg px-5 py-4 mb-8">
+      <div class="flex flex-col md:flex-row items-start md:items-center gap-5">
+
+        <div class="text-white">
+          <h4 class="text-xl font-semibold text-primary mb-1">📱 On iOS?</h4>
+          <p class="font-medium mb-2">Try the Hackatime widget.</p>
+
+          <p class="mb-1">
+            <a href="https://testflight.apple.com/join/Fda4449P" target="_blank" class="text-primary hover:text-red underline">
+              Join the beta on TestFlight
+            </a>
+          </p>
+
+          <p>
+            <a href="https://github.com/jacobprezant/wakaScript/tree/main/iOS" target="_blank" class="text-primary hover:text-red underline">
+              View the code on GitHub
+          </p>
+        </div>
+
+        <img src="https://hc-cdn.hel1.your-objectstorage.com/s/v3/47e6a7f8a0fc0d04a6cb0bda1df78f707f8a637a_img_0069.jpg"
+             alt="Hackatime iOS Widget"
+             class="w-32 rounded shadow-md">
+      </div>
+    </div>
+
     <div class="border-t border-darkless my-8"></div>
 
     <div class="text-center">


### PR DESCRIPTION
This PR adds a section to the bottom of the docs page for a Hackatime iOS daily time widget, with a screenshot.