### PR TITLE
feat: support multiple projects in projects param w/ exact dateime

### DIFF
--- a/app/controllers/api/v1/stats_controller.rb
+++ b/app/controllers/api/v1/stats_controller.rb
@@ -94,18 +94,19 @@ class Api::V1::StatsController < ApplicationController
   def user_spans
     return render json: { error: "User not found" }, status: :not_found unless @user
 
-    start_date = Date.parse(params[:start_date]) if params[:start_date].present?
+    start_date = params[:start_date].to_datetime if params[:start_date].present?
     start_date ||= 10.years.ago
-    end_date = Date.parse(params[:end_date]) if params[:end_date].present?
-    end_date ||= Date.today
+    end_date = params[:end_date].to_datetime if params[:end_date].present?
+    end_date ||= Date.today.end_of_day
 
-    timespan = (start_date.beginning_of_day.to_f..end_date.end_of_day.to_f)
+    timespan = (start_date.to_f..end_date.to_f)
 
-    heartbeats = @user.heartbeats
-                      .where(time: timespan)
+    heartbeats = @user.heartbeats.where(time: timespan)
 
     if params[:project].present?
       heartbeats = heartbeats.where(project: params[:project])
+    elsif params[:filter_by_project].present?
+      heartbeats = heartbeats.where(project: params[:filter_by_project].split(","))
     end
 
     render json: { spans: heartbeats.to_span }


### PR DESCRIPTION
previously, you couldn't search for multiple projects or specify an exact time range– any time you provided would be rounded to the start of the day. but now you can do both. for example:

`/api/v1/users/U07L45W79E1/heartbeats/spans?start_date=2025-06-15T18:30:00Z&end_date=2025-06-23T06:41:32Z&filter_by_project=inf-express-api,som-votes`

instead of something like:

`/api/v1/users/U07L45W79E1/heartbeats/spans?start_date=2025-06-28&end_date=2025-06-28&project=inf-express-api`

follow [this thread](https://hackclub.slack.com/archives/C08KUN6TF61/p1752507467006229) for context.