### PR TITLE
Roblox Studio Plugin Docs update // Not working Wakatime Plugin -> Working HackaTime Plugin

### DIFF
--- a/docs/editors/roblox-studio.md
+++ b/docs/editors/roblox-studio.md
@@ -1,29 +1,77 @@
-# Roblox Studio Setup Guide
+# Set Up Hackatime with Roblox Studio
 
 ![Roblox Studio](/images/editor-icons/roblox-studio-128.png)
 
-Follow these steps to start tracking your game development in Roblox Studio with Hackatime.
+This guide will walk you through setting up **Hackatime** to automatically track your game development time in **Roblox Studio**.
 
-## Step 1: Log into Hackatime
+---
 
-Make sure you have a [Hackatime account](https://hackatime.hackclub.com) and are logged in.
+## Step 1: Log In to Your Hackatime Account
 
-## Step 2: Run the Setup Script
+First, make sure you have a **Hackatime account** and are logged in. If you don't have an account, you can create one at [hackatime.hackclub.com](https://hackatime.hackclub.com).
 
-Visit the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) to automatically configure your API key and endpoint. This ensures everything works perfectly with Hackatime.
+---
 
-## Step 3: Install Roblox Studio Plugin
+## Step 2: Install the Hackatime Roblox Studio Plugin
 
-Follow the detailed plugin installation instructions on the [WakaTime Roblox Studio page](https://wakatime.com/roblox-studio).
+Next, you'll need to install the Hackatime plugin directly within Roblox Studio:
 
-The WakaTime plugin will automatically use your Hackatime configuration after running the setup script.
+1.  Open **Roblox Studio**.
+2.  Navigate to the **Toolbox**.
+3.  In the Toolbox search bar, select **"Plugins"** from the dropdown filter.
+4.  Search for **"HackaTime Roblox"**.
+5.  Install the plugin published by **"ThisWhity"**.
+
+    ![Toolbox filter showing Plugins selected](https://github.com/user-attachments/assets/65931fad-fa16-4df6-9a07-eadf1e2aaf07)
+    *Filter the Toolbox by "Plugins"*
+
+    ![Toolbox search results showing HackaTime Roblox plugin](https://github.com/user-attachments/assets/13233bf7-b876-4c29-b690-9ebbcb796488)
+    *Install the "HackaTime Roblox" plugin by ThisWhity*
+
+---
+
+## Step 3: Configure the Plugin with Your API Key
+
+Now, you'll connect the plugin to your Hackatime account using your unique API key:
+
+1.  Get your API key by visiting [hackatime.hackclub.com/my/wakatime_setup](https://hackatime.hackclub.com/my/wakatime_setup). It will look something like this: `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`.
+
+    ![Screenshot showing API Key on Hackatime website](https://github.com/user-attachments/assets/635cab06-36cb-4351-819b-62403b6c6885)
+    *Your API key from the Hackatime website*
+
+2.  In Roblox Studio, open the **Hackatime plugin**. You'll usually find it under the "Plugins" tab in the Ribbon bar.
+
+    ![Screenshot showing the Hackatime plugin tab with API key input](https://github.com/user-attachments/assets/c241dbe2-6f9a-44bf-adb9-f0b4780227db)
+    *Open the Plugin*
+
+4.  Paste your API key into the API key box. And hit "Save API Key"
+
+---
 
 ## Troubleshooting
 
-- **Not seeing your time?** Make sure you completed the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) first
-- **Plugin not working?** Try restarting Roblox Studio after installation
-- **Still stuck?** Ask for help in [Hack Club Slack](https://hackclub.slack.com) (#hackatime-v2 channel)
+### ERR\_NETWORK: Plugin Cannot Connect to Hackatime
 
-## Next Steps
+If you see an **ERR\_NETWORK** message, it means the plugin can't connect to Hackatime. This is likely due to you not allowing HTTP request from the plugin:
 
-Once configured, your activity time will automatically appear on your [Hackatime dashboard](https://hackatime.hackclub.com). Happy game developing!
+1.  Open the "Manage Plugins".
+2.  Hit the edit icon.
+3.  Ensure that **"hackatime.hackclub.com"** is enabled.
+
+    ![Screenshot showing Game Settings with Security tab open and Allow HTTP Requests highlighted](https://github.com/user-attachments/assets/c3533d87-2b06-4ba8-a1c5-7416332578e9)
+    *Open Plugin Managment*
+
+    ![Screenshot showing Allow HTTP Requests enabled](https://github.com/user-attachments/assets/86bea3e2-dbbe-496f-acd4-f5963c208767)
+    *Allow HTTP requests*
+
+### Still Stuck?
+
+If you're still experiencing issues, don't hesitate to ask for help in the **#hackatime-v2 channel** on the [Hack Club Slack](https://hackclub.slack.com).
+
+---
+
+## What's Next?
+
+Once the plugin is successfully configured, your Roblox Studio activity time will automatically start appearing on your [Hackatime dashboard](https://hackatime.hackclub.com).
+
+Happy game developing!


### PR DESCRIPTION
### Better Roblox Studio Plugin

WakaTime Plugin is hardcoded to WakaTime thus **doesnt work**, this plugin was in development way before it existed, and is what i made during HighSeas. It was made primarily for HackaTime yet all categories are WakaTime supported, i had to email wakatime to add support for some on their side!

The activity categories tracked by this plugin include:

```
AI.ActivityCategories = {
	CODING = "coding", --> Wakatime does too
	DEBUGGING = "debugging", --> Wakatime does too
	MODELING = "planning",
	BUILDING = "building",
	UI_DESIGN = "designing",
	CONFIGURING = "browsing",
	ANIMATING = "supporting",
	PLAY_TESTING = "manual-testing" --> Wakatime does too
}
```

Even though WakaTime's plugin does them, the plugin as i said is hardcoded to Wakatime's api.

This also resovles #345 

**Source is available on the [Roblox Creator Store](https://create.roblox.com/store/asset/108710222059981).**