### PR TITLE
Replace WakaTime editor links with Hackatime docs

### DIFF
--- a/app/views/users/wakatime_setup_step_3.html.erb
+++ b/app/views/users/wakatime_setup_step_3.html.erb
@@ -29,7 +29,7 @@
       <h3 class="text-2xl font-bold text-orange mb-4">🔧 Other Editors</h3>
       <div class="bg-yellow/50 bg-opacity-10 border border-yellow rounded-lg p-4">
         <p class="mb-4">
-          <em>Hackatime is WakaTime-compatible, so you can use it with any editor that WakaTime supports. For other editors, please refer to the <a href="https://wakatime.com/plugins" class="text-cyan hover:text-blue underline">WakaTime docs</a>.</em>
+          <em>Hackatime is WakaTime-compatible, so you can use it with any editor that WakaTime supports. For other editors, please refer to our <a href="https://hackatime.hackclub.com/docs#supported-editors" class="text-cyan hover:text-blue underline">editor extension docs</a>.</em>
         </p>
         <p class="text-yellow font-bold">
           ⚠️ Note: skip any steps that update your ~/.wakatime.cfg file or change the api_url inside it.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -11,11 +11,11 @@ Before you start, make sure you have:
 
 ## Step 1: Do the Automated Setup
 
-**First, use the [setup page](https://hackatime.hackclub.com/my/wakatime_setup)!** It automatically sets up your API key and endpoint so everything works perfectly.
+**First, use our automated [setup tutorial](https://hackatime.hackclub.com/my/wakatime_setup)!** It automatically sets up your API key and endpoint so everything works perfectly.
 
 ## Step 2: Add WakaTime Plugin
 
-After doing the automated setup, install the WakaTime plugin for your editor. Visit our [editor documentation](https://hackatime.hackclub.com/docs#supported-editors) for instructions for your editor.
+After doing the automated setup, install the WakaTime plugin for your editor. Visit our [editor documentation](https://hackatime.hackclub.com/docs#supported-editors) for instructions on how to install a WakaTime plugin for your specific editor.
 
 ## Already Have the Plugin Installed?
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -15,40 +15,7 @@ Before you start, make sure you have:
 
 ## Step 2: Add WakaTime Plugin
 
-After doing the automated setup, install the WakaTime plugin for your editor:
-
-### VS Code
-
-1. Open VS Code
-2. Click the Extensions button (or press Ctrl+Shift+X)
-3. Type "WakaTime" in the search box
-4. Click Install
-
-### PyCharm / IntelliJ
-
-1. Go to File → Settings (on Mac: IntelliJ IDEA → Preferences)
-2. Click Plugins
-3. Type "WakaTime" in the search box
-4. Install and restart your app
-
-### Vim
-
-Copy and paste this into your terminal:
-
-```bash
-git clone https://github.com/wakatime/vim-wakatime.git ~/.vim/bundle/vim-wakatime
-```
-
-### Sublime Text
-
-1. Press Ctrl+Shift+P (or Cmd+Shift+P on Mac)
-2. Type "Install Package"
-3. Type "WakaTime"
-4. Install it
-
-### Other Editors
-
-Visit [wakatime.com/plugins](https://wakatime.com/plugins) to find plugins for 40+ other editors.
+After doing the automated setup, install the WakaTime plugin for your editor. Visit our [editor documentation](https://hackatime.hackclub.com/docs#supported-editors) for instructions for your editor.
 
 ## Already Have the Plugin Installed?
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -27,19 +27,7 @@ The setup page handles all configuration automatically - no manual editing requi
 
 ## Step 3: Install WakaTime Plugin
 
-Hackatime works with **any WakaTime plugin**. Install for your editor:
-
-### Popular Editors
-
-- **VS Code**: Search "WakaTime" in Extensions marketplace
-- **IntelliJ/PyCharm**: Settings → Plugins → Install "WakaTime"
-- **Vim/Neovim**: Install `vim-wakatime` plugin
-- **Sublime Text**: Install via Package Control
-- **Atom**: Install `wakatime` package
-
-### All Other Editors
-
-Visit [wakatime.com/plugins](https://wakatime.com/plugins) for 40+ supported editors.
+Hackatime works with **any WakaTime plugin**. Visit our [editor documentation](https://hackatime.hackclub.com/docs#supported-editors) for instructions for your editor.
 
 ## Step 4: Configure Plugin to Use Hackatime
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -27,7 +27,7 @@ The setup page handles all configuration automatically - no manual editing requi
 
 ## Step 3: Install WakaTime Plugin
 
-Hackatime works with **any WakaTime plugin**. Visit our [editor documentation](https://hackatime.hackclub.com/docs#supported-editors) for instructions for your editor.
+Hackatime works with **any WakaTime plugin**. Visit our [editor documentation](https://hackatime.hackclub.com/docs#supported-editors) for instructions on how to install a WakaTime plugin for your specific editor.
 
 ## Step 4: Configure Plugin to Use Hackatime
 


### PR DESCRIPTION
Hackatime has its own [editor docs](https://hackatime.hackclub.com/docs#supported-editors) which are Hackatime-specific (like using the automated script instead of manual WakaTime setup), so it makes sense to use Hackatime's own docs.

- [x] Actually test this (this was done on my underpowered laptop and has yet to be tested on a more powerful machine)