### PR TITLE
Hide the scroll bar

### DIFF
--- a/app/assets/stylesheets/filterable_dashboard.css
+++ b/app/assets/stylesheets/filterable_dashboard.css
@@ -44,11 +44,22 @@
 }
 
 .filter .options-list {
-  max-height: 200px;
+  /* not 200 cause the search thingie is 35.5 px high */
+  max-height: 164.5px; 
   overflow-y: auto;
   padding: 0;
   margin: 0;
+  /* Hide the scroll bar for stupid browers that dont follow regular standereds (looking at u microsoft IE) */
+  -ms-overflow-style: none;
+  scrollbar-width: none;
 }
+
+/* Hide the scroll bar cause it looks terrible (sorry to eho ever made it) */
+.filter .options-list::-webkit-scrollbar {
+  display: none;
+}
+
+
 
 .filter .option {
   display: flex;
@@ -442,7 +453,7 @@
   border-radius: 4px;
   margin-top: 4px;
   max-height: 200px;
-  overflow-y: auto;
+  overflow-y: hidden  ;
   z-index: 1000;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }


### PR DESCRIPTION
Hides the scroll bar from the options list in the projects and langs, removes the outer scroll bar to make it look pretty.

<img width="277" height="296" alt="image" src="https://github.com/user-attachments/assets/97c5b2cc-e9b2-4d33-ad3e-f7d000e6e7b6" />

^^^ Very ugly
<img width="266" height="278" alt="image" src="https://github.com/user-attachments/assets/c9c76d6e-da8d-49b7-82e6-e8cc72aca9c5" />

Less ugly with scroll