### PR TITLE
Change "High Seas" to "Hack Club events" in docs

### DIFF
--- a/docs/editors/godot.md
+++ b/docs/editors/godot.md
@@ -56,4 +56,4 @@ Once configured, your game development time will automatically appear on your [H
 
 ---
 
-*Plugin created by [Bartosz (BudzioT)](https://github.com/BudzioT), a Hack Clubber, and officially approved for High Seas!*
+*Plugin created by [Bartosz (BudzioT)](https://github.com/BudzioT), a Hack Clubber, and officially approved for Hack Club events!*


### PR DESCRIPTION
There are other Hack Club events which allow (or specifically mention, like Shiba) this WakaTime extension.

> *Plugin created by [Bartosz (BudzioT)](https://github.com/BudzioT), a Hack Clubber, and officially approved for <del>High Seas</del><ins>Hack Club events</ins>!*