### PR TITLE
Speed up duration_seconds by removing...

### DIFF
--- a/app/models/concerns/heartbeatable.rb
+++ b/app/models/concerns/heartbeatable.rb
@@ -212,7 +212,6 @@ module Heartbeatable
             ELSE LEAST(EXTRACT(EPOCH FROM (to_timestamp(time) - to_timestamp(LAG(time) OVER (PARTITION BY #{group_expr} ORDER BY time)))), #{heartbeat_timeout_duration.to_i})
           END as diff")
           .where.not(time: nil)
-          .order(time: :asc)
           .unscope(:group)
 
         connection.select_all(
@@ -230,7 +229,6 @@ module Heartbeatable
             ELSE LEAST(EXTRACT(EPOCH FROM (to_timestamp(time) - to_timestamp(LAG(time) OVER (ORDER BY time)))), #{heartbeat_timeout_duration.to_i})
           END as diff")
           .where.not(time: nil)
-          .order(time: :asc)
 
         connection.select_value("SELECT COALESCE(SUM(diff), 0)::integer FROM (#{capped_diffs.to_sql}) AS diffs").to_i
       end


### PR DESCRIPTION
...unnecessary order_by in heartbeatable

Still figuring out why I included this originally, but the results speak for themselves:

```rb
harbor(dev)> User.find(1).heartbeats.duration_seconds
  User Load (28.8ms)  SELECT "users".* FROM "users" WHERE "users"."id" = 1 LIMIT 1 /*application='Harbor'*/
   (388.7ms)  SELECT COALESCE(SUM(diff), 0)::integer FROM (SELECT CASE
            WHEN LAG(time) OVER (ORDER BY time) IS NULL THEN 0
            ELSE LEAST(EXTRACT(EPOCH FROM (to_timestamp(time) - to_timestamp(LAG(time) OVER (ORDER BY time)))), 120)
          END as diff FROM "heartbeats" WHERE "heartbeats"."deleted_at" IS NULL AND "heartbeats"."user_id" = 1 AND (time >= 0 AND time <= 253402300799) AND "heartbeats"."time" IS NOT NULL ORDER BY "heartbeats"."time" ASC) AS diffs /*application='Harbor'*/
=> 2724486
harbor(dev)> reload!
Reloading...
=> true
harbor(dev)> User.find(1).heartbeats.duration_seconds
  User Load (28.1ms)  SELECT "users".* FROM "users" WHERE "users"."id" = 1 LIMIT 1 /*application='Harbor'*/
   (222.0ms)  SELECT COALESCE(SUM(diff), 0)::integer FROM (SELECT CASE
            WHEN LAG(time) OVER (ORDER BY time) IS NULL THEN 0
            ELSE LEAST(EXTRACT(EPOCH FROM (to_timestamp(time) - to_timestamp(LAG(time) OVER (ORDER BY time)))), 120)
          END as diff FROM "heartbeats" WHERE "heartbeats"."deleted_at" IS NULL AND "heartbeats"."user_id" = 1 AND (time >= 0 AND time <= 253402300799) AND "heartbeats"."time" IS NOT NULL) AS diffs /*application='Harbor'*/
=> 2724486
```