### PR TITLE
Changed interpreter shell for downloaded script from sh to bash

### DIFF
--- a/docs/editors/terminal.md
+++ b/docs/editors/terminal.md
@@ -17,7 +17,7 @@ Visit the [setup page](https://hackatime.hackclub.com/my/wakatime_setup) to auto
 Run this command in your terminal to install the Hack Club terminal-wakatime plugin:
 
 ```bash
-curl -fsSL https://hack.club/terminal-wakatime.sh | sh
+curl -fsSL https://hack.club/terminal-wakatime.sh | bash
 ```
 
 This installs `terminal-wakatime` and automatically configures it for bash, zsh, or fish shells. The plugin will use your Hackatime configuration from the setup script.


### PR DESCRIPTION
In the current hackatime setup page for terminal, we are asked to run:
```bash
curl -fsSL https://hack.club/terminal-wakatime.sh | sh
```
But this apparently leads to an interpreter error.
```bash
sh: 238: Syntax error: "(" unexpected (expecting ";;")
```

I simply changed the command so it pipes script to bash instead of sh, which effectively solved the issue for me.

```bash
curl -fsSL https://hack.club/terminal-wakatime.sh | bash
```

Thank you! I am not any good at sh or bash, but I hope that can help.