### PR TITLE
fix: allow_public_stats_lookup was ignored

### DIFF
--- a/app/controllers/api/v1/stats_controller.rb
+++ b/app/controllers/api/v1/stats_controller.rb
@@ -34,6 +34,10 @@ class Api::V1::StatsController < ApplicationController
 
     return render json: { error: "User not found" }, status: :not_found unless @user.present?
 
+    if !@user.allow_public_stats_lookup && (!current_user || current_user != @user)
+      return render json: { error: "user has disabled public stats" }, status: :forbidden
+    end
+
     start_date = params[:start_date].to_datetime if params[:start_date].present?
     start_date ||= 10.years.ago
     end_date = params[:end_date].to_datetime if params[:end_date].present?


### PR DESCRIPTION
Add back the "Allow public stats lookup" check from privacy settings has it was removed by 2831a5670e129b6e206ceab77aaeefdfc7930d15

Security report: `SEC-1755126121314`