### PR TITLE
Replace slack app_redirect links to be workspace specific instead

### DIFF
--- a/app/javascript/controllers/currently_hacking_controller.js
+++ b/app/javascript/controllers/currently_hacking_controller.js
@@ -169,7 +169,7 @@ export default class extends Controller {
     const url = u.avatar_url || ''
     
     const name = u.slack_uid ? 
-      `<a href="https://slack.com/app_redirect?channel=${u.slack_uid}" target="_blank" class="text-blue-500 hover:underline">@${dis}</a>` :
+      `<a href="https://hackclub.slack.com/team/${u.slack_uid}" target="_blank" class="text-blue-500 hover:underline">@${dis}</a>` :
       `<span class="text-white">${dis}</span>`
     
     return `

--- a/app/views/shared/_slack_channel_mention.erb
+++ b/app/views/shared/_slack_channel_mention.erb
@@ -1,1 +1,1 @@
-<%= link_to SlackChannel.find_by_id(channel_id), "https://slack.com/app_redirect?channel=#{channel_id}", target: "_blank" %>
+<%= link_to SlackChannel.find_by_id(channel_id), "https://hackclub.slack.com/archives/#{channel_id}", target: "_blank" %>

--- a/app/views/shared/_user_mention.html.erb
+++ b/app/views/shared/_user_mention.html.erb
@@ -5,7 +5,7 @@
                 alt: "#{h(user.username)}'s avatar" if user.avatar_url %>
   <span class="inline-flex items-center gap-1">
     <% if local_assigns.fetch(:show, []).include?(:slack) && user.slack_uid.present? %>
-      <%= link_to "@#{h(user.display_name)}", "https://slack.com/app_redirect?channel=#{user.slack_uid}", target: "_blank", class: "text-blue-500 hover:underline" %>
+      <%= link_to "@#{h(user.display_name)}", "https://hackclub.slack.com/team/#{user.slack_uid}", target: "_blank", class: "text-blue-500 hover:underline" %>
     <% else %>
       <%= h(user.display_name) %>
     <% end %>
@@ -24,7 +24,7 @@
     </span>
   <% end %>
   <% if local_assigns.fetch(:show, []).include?(:neighborhood) && user.slack_neighborhood_channel.present? %>
-    <%= link_to "🏘️", "https://slack.com/app_redirect?channel={user.slack_neighborhood_channel}", target: "_blank" %>
+    <%= link_to "🏘️", "https://hackclub.slack.com/archives/#{user.slack_neighborhood_channel}", target: "_blank" %>
   <% end %>
   <% unless current_user == user %>
     <% admin_tool('', 'span') do %>


### PR DESCRIPTION
Otherwise, user/channel links (on pages e.g. leaderboard) could redirect you to the wrong workspace before and give you a error on the slack page if you're in multiple workspaces. 

This replaces the app_redirect links to use hackclub.slack.com instead.

| Before | After |
|--------|--------|
| <img width="350" alt="image" src="https://github.com/user-attachments/assets/650e9b2d-2d1a-4a69-a7fa-83d17ab014dd" /> | <img width="350" alt="image" src="https://github.com/user-attachments/assets/48653267-9fd7-495a-a065-3c94bbea45b0" /> | 