### PR TITLE
Prioritize Slack display name over username

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -247,9 +247,9 @@ class User < ApplicationRecord
 
     self.slack_avatar_url = profile["image_192"] || profile["image_72"]
 
-    self.slack_username = user_data["name"].presence
-    self.slack_username ||= profile["display_name_normalized"].presence
+    self.slack_username = profile["display_name_normalized"].presence
     self.slack_username ||= profile["real_name_normalized"].presence
+    self.slack_username ||= user_data["name"].presence
   end
 
   def update_slack_status
@@ -381,9 +381,9 @@ class User < ApplicationRecord
     end
 
     user.slack_uid = data.dig("authed_user", "id")
-    user.slack_username = slack_user["name"].presence
-    user.slack_username ||= profile["display_name_normalized"].presence
+    user.slack_username = profile["display_name_normalized"].presence
     user.slack_username ||= profile["real_name_normalized"].presence
+    user.slack_username ||= slack_user["name"].presence
     user.slack_avatar_url = profile["image_192"] || profile["image_72"]
 
     user.parse_and_set_timezone(slack_user["tz"])


### PR DESCRIPTION
I've seen about 3 diferent people saying something like "why is my hackatime username my email now" as Hackatime was now using their slack username (the `name` field in the api), which defaults to the name part on their email.

This change makes the priority be:

> `display_name_normalized` -> `real_name_normalized` -> `name`

Instead of the previous:

> `name` -> `real_name_normalized` -> `display_name_normalized`