### PR TITLE
remove .md extension from relative links in docs

### DIFF
--- a/app/controllers/docs_controller.rb
+++ b/app/controllers/docs_controller.rb
@@ -116,8 +116,22 @@ class DocsController < ApplicationController
     title_line&.sub(/^# /, "")&.strip
   end
 
+  # removes .md extension from links
+  class DocsRenderer < Redcarpet::Render::HTML
+    def link(link, title, content)
+      if link && !link.match?(/\A[a-z]+:/)
+        link = link.sub(/\.md(?=[#?]|$)/, "")
+      end
+
+      attributes = "href=\"#{link}\""
+      attributes += " title=\"#{title}\"" if title
+
+      "<a #{attributes}>#{content}</a>"
+    end
+  end
+
   def render_markdown(content)
-    renderer = Redcarpet::Render::HTML.new(
+    renderer = DocsRenderer.new(
       filter_html: true,
       no_links: false,
       no_images: false,


### PR DESCRIPTION
Fixes the issue of getting a 406 error in docs when going to [/docs/api/overview](https://hackatime.hackclub.com/docs/api/overview) and then clicking on "complete API list" at the bottom which leads to [/docs/api/endpoints.md](https://hackatime.hackclub.com/docs/api/endpoints.md) (which gives a 406 error) instead of leading to [/docs/api/endpoints](https://hackatime.hackclub.com/docs/api/endpoints)