### PR TITLE
Add HTML and CSS to display_language_name to fix missing colors on github readme stats display

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -175,6 +175,8 @@ module ApplicationHelper
     case language.downcase
     when "typescript" then "TypeScript"
     when "javascript" then "JavaScript"
+    when "html" then "HTML"
+    when "css" then "CSS"
     when "json" then "JSON"
     when "sql" then "SQL"
     when "yaml" then "YAML"


### PR DESCRIPTION
Fixes the readme stats display showing html and css as "Html" and "Css" instead of being uppercase, which also causes the readme stats display to use the gray color instead of the correct orange & purple as before.

| Before | After |
|--------|--------|
| <img width="500" alt="Screenshot 2025-12-05 232911" src="https://github.com/user-attachments/assets/ba185a31-4971-4eda-8a19-3edef009daee" /> | <img width="500" alt="Screenshot 2025-12-05 232721" src="https://github.com/user-attachments/assets/1e68042f-9b0f-42db-919b-330b92cf8746" /> | 

