### PR TITLE
Add ability to unlink emails

### DIFF
--- a/app/models/email_address.rb
+++ b/app/models/email_address.rb
@@ -15,6 +15,11 @@ class EmailAddress < ApplicationRecord
 
   before_validation :downcase_email
 
+  def can_unlink?
+    # only allow unlinking if signin email
+    self.source_signing_in?
+  end
+
   private
 
   def downcase_email

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -153,6 +153,15 @@ class User < ApplicationRecord
     last_audit.created_at <= 365.days.ago
   end
 
+  def can_delete_emails?
+    # don't let user delete emails if email count is <= 1
+    email_addresses.size > 1
+  end
+
+  def can_delete_email_address?(email)
+    email.can_unlink? && can_delete_emails?
+  end
+
   if Rails.env.development?
     def self.slow_find_by_email(email)
       # This is an n+1 query, but provided for developer convenience

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -245,11 +245,21 @@
           <% if @user.email_addresses.any? %>
             <div class="space-y-2">
               <% @user.email_addresses.each do |email| %>
-                <div class="flex items-center gap-2 p-2 bg-gray-800 border border-gray-600 rounded">
-                  <span class="text-gray-300 text-sm"><%= email.email %></span>
-                  <span class="text-xs px-2 py-1 bg-gray-700 text-gray-200 rounded">
-                    <%= email.source&.humanize || "Unknown" %>
-                  </span>
+                <div class="flex gap-2 items-center">
+                  <div class="flex items-center gap-2 p-2 bg-gray-800 border border-gray-600 rounded grow">
+                    <span class="text-gray-300 text-sm"><%= email.email %></span>
+                    <span class="text-xs px-2 py-1 bg-gray-700 text-gray-200 rounded">
+                      <%= email.source&.humanize || "Unknown" %>
+                    </span>
+                  </div>
+                  <% if @user.can_delete_email_address?(email) %>
+                    <%= form_with url: unlink_email_auth_path,
+                      method: :delete,
+                      class: "space-y-4" do |f| %>
+                      <%= f.hidden_field :email, value: email.email %>
+                      <%= f.submit "Unlink!", class: "w-full px-4 py-2 bg-primary text-white font-medium rounded transition-colors duration-200 cursor-pointer" %>
+                    <% end %>
+                  <% end %>
                 </div>
               <% end %>
             </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -89,6 +89,7 @@ Rails.application.routes.draw do
   delete "/auth/github/unlink", to: "sessions#github_unlink", as: :github_unlink
   post "/auth/email", to: "sessions#email", as: :email_auth
   post "/auth/email/add", to: "sessions#add_email", as: :add_email_auth
+  delete "/auth/email/unlink", to: "sessions#unlink_email", as: :unlink_email_auth
   get "/auth/token/:token", to: "sessions#token", as: :auth_token
   get "/auth/close_window", to: "sessions#close_window", as: :close_window
   delete "signout", to: "sessions#destroy", as: "signout"


### PR DESCRIPTION
Added the ability to unlink emails from accounts!

<img width="1341" height="712" alt="image" src="https://github.com/user-attachments/assets/816114ac-d084-4a6c-bf65-63fa8fae7df6" />

The requirements to unlink are:

- Email has source `signing_in` (shows up marked as "Signing in")
- There are >1 linked emails

Also deletes the email verification request associated with the email.

Currently it unlinks straight away without confirmation. I was going to add a confirmation modal but I'd need to pass data to the modal somehow and I barely know how rails works, so that's all you get from me :P