### PR TITLE
Change email unlink validation to allow "unknown" source emails to unlink

### DIFF
--- a/app/models/email_address.rb
+++ b/app/models/email_address.rb
@@ -16,8 +16,7 @@ class EmailAddress < ApplicationRecord
   before_validation :downcase_email
 
   def can_unlink?
-    # only allow unlinking if signin email
-    self.source_signing_in?
+    !(self.source_github? || self.source_slack? || self.source_preserved_for_deletion?)
   end
 
   private


### PR DESCRIPTION
Continuation of #698