### PR TITLE
feat: allow usage of admin keys in user endpoints

### DIFF
--- a/app/controllers/api/hackatime/v1/hackatime_controller.rb
+++ b/app/controllers/api/hackatime/v1/hackatime_controller.rb
@@ -333,7 +333,7 @@ class Api::Hackatime::V1::HackatimeController < ApplicationController
 
     # Sanitize api_token to handle invalid UTF-8 sequences
     api_token = api_token.to_s.encode("UTF-8", invalid: :replace, undef: :replace, replace: "")
-    
+
     # When using an admin key, we allow any ID for endpoints that accept an :id parameter.
     admin_key = AdminApiKey.find_by(token: api_token)
     if admin_key.present?
@@ -342,7 +342,7 @@ class Api::Hackatime::V1::HackatimeController < ApplicationController
       @user = admin_key.user
       return
     end
-    
+
     valid_key = ApiKey.find_by(token: api_token)
     return render json: { error: "Unauthorized" }, status: :unauthorized unless valid_key.present?
 

--- a/app/controllers/api/hackatime/v1/hackatime_controller.rb
+++ b/app/controllers/api/hackatime/v1/hackatime_controller.rb
@@ -341,9 +341,9 @@ class Api::Hackatime::V1::HackatimeController < ApplicationController
       @current_admin_user = admin_key.user
       @user = admin_key.user
       return
-    end
+      end
 
-    valid_key = ApiKey.find_by(token: api_token)
+      valid_key = ApiKey.find_by(token: api_token)
     return render json: { error: "Unauthorized" }, status: :unauthorized unless valid_key.present?
 
     @user = valid_key.user
@@ -370,7 +370,7 @@ class Api::Hackatime::V1::HackatimeController < ApplicationController
     else
       # This is a regular API key - the only user they can fetch is themselves.
       if requested_id != "current"
-        return render json: { error: "Unauthorized" }, status: :unauthorized
+        render json: { error: "Unauthorized" }, status: :unauthorized
       end
 
       # @user is already set by set_user.

--- a/app/controllers/api/hackatime/v1/hackatime_controller.rb
+++ b/app/controllers/api/hackatime/v1/hackatime_controller.rb
@@ -370,7 +370,7 @@ class Api::Hackatime::V1::HackatimeController < ApplicationController
     else
       # This is a regular API key - the only user they can fetch is themselves.
       if requested_id != "current"
-        render json: { error: "Unauthorized" }, status: :unauthorized
+        return render json: { error: "Unauthorized" }, status: :unauthorized
       end
 
       # @user is already set by set_user.

--- a/app/controllers/api/hackatime/v1/hackatime_controller.rb
+++ b/app/controllers/api/hackatime/v1/hackatime_controller.rb
@@ -336,14 +336,14 @@ class Api::Hackatime::V1::HackatimeController < ApplicationController
 
     # When using an admin key, we allow any ID for endpoints that accept an :id parameter.
     admin_key = AdminApiKey.find_by(token: api_token)
-    if admin_key.present?
+    if admin_key.present? && admin_key.active?
       @admin_api_key = admin_key
       @current_admin_user = admin_key.user
       @user = admin_key.user
       return
-      end
+    end
 
-      valid_key = ApiKey.find_by(token: api_token)
+    valid_key = ApiKey.find_by(token: api_token)
     return render json: { error: "Unauthorized" }, status: :unauthorized unless valid_key.present?
 
     @user = valid_key.user

--- a/app/controllers/api/hackatime/v1/hackatime_controller.rb
+++ b/app/controllers/api/hackatime/v1/hackatime_controller.rb
@@ -337,7 +337,7 @@ class Api::Hackatime::V1::HackatimeController < ApplicationController
     admin_key = AdminApiKey.find_by(token: api_token)
     if admin_key.present?
       return render json: { error: "Unauthorized" }, status: :unauthorized unless admin_key.active?
-      
+
       @admin_api_key = admin_key
       @current_admin_user = admin_key.user
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -212,7 +212,6 @@ Rails.application.routes.draw do
         get "/", to: redirect("/", status: 302) # some clients seem to link this as the user's dashboard instead of /api/v1/hackatime
         get "/users/:id/statusbar/today", to: "hackatime#status_bar_today"
         post "/users/:id/heartbeats", to: "hackatime#push_heartbeats"
-        post "/users/:id/heartbeats.bulk", to: "hackatime#push_heartbeats"
         get "/users/:id/stats/last_7_days", to: "hackatime#stats_last_7_days"
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -212,7 +212,8 @@ Rails.application.routes.draw do
         get "/", to: redirect("/", status: 302) # some clients seem to link this as the user's dashboard instead of /api/v1/hackatime
         get "/users/:id/statusbar/today", to: "hackatime#status_bar_today"
         post "/users/:id/heartbeats", to: "hackatime#push_heartbeats"
-        get "/users/current/stats/last_7_days", to: "hackatime#stats_last_7_days"
+        post "/users/:id/heartbeats.bulk", to: "hackatime#push_heartbeats", format: false
+        get "/users/:id/stats/last_7_days", to: "hackatime#stats_last_7_days"
       end
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -212,7 +212,7 @@ Rails.application.routes.draw do
         get "/", to: redirect("/", status: 302) # some clients seem to link this as the user's dashboard instead of /api/v1/hackatime
         get "/users/:id/statusbar/today", to: "hackatime#status_bar_today"
         post "/users/:id/heartbeats", to: "hackatime#push_heartbeats"
-        post "/users/:id/heartbeats.bulk", to: "hackatime#push_heartbeats", format: false
+        post "/users/:id/heartbeats.bulk", to: "hackatime#push_heartbeats"
         get "/users/:id/stats/last_7_days", to: "hackatime#stats_last_7_days"
       end
     end


### PR DESCRIPTION
# What changed
Allows for the usage of admin API keys in most `/users/` endpoints. This will allow for a service with an admin key to invoke the API like e.g. `POST /users/U082DPCGPST/heartbeats.bulk` on behalf of the given user.

# Use-cases
Web-based services - like Lapse - need to create heartbeats on behalf of a user. Asking the user for an API key would be a bit cumbersome, given that we can already extract it from the Slack ID.

# Notes
As the `/execute` endpoint has been recently removed, this change is needed for Lapse's Hackatime sync feature to work without prompting the user for an API key.

https://github.com/hackclub/lapse/blob/90efd493adec5ac8cc0c7241d40ca2d39d64c224/apps/web/src/server/hackatime.ts#L258-L272
