### PR TITLE
Fix bypass of user allow_public_stats_lookup setting

### DIFF
--- a/app/controllers/api/v1/stats_controller.rb
+++ b/app/controllers/api/v1/stats_controller.rb
@@ -33,6 +33,10 @@ class Api::V1::StatsController < ApplicationController
 
     return render json: { error: "User not found" }, status: :not_found unless @user.present?
 
+    if !@user.allow_public_stats_lookup && (!current_user || current_user != @user)
+      return render json: { error: "user has disabled public stats" }, status: :forbidden
+    end
+
     start_date = params[:start_date].to_datetime if params[:start_date].present?
     start_date ||= 10.years.ago
     end_date = params[:end_date].to_datetime if params[:end_date].present?
@@ -75,10 +79,6 @@ class Api::V1::StatsController < ApplicationController
                      .coding_only
                      .with_valid_timestamps
                      .where(time: start_date..end_date)
-
-        if !@user.allow_public_stats_lookup && (!current_user || current_user != @user)
-          return render json: { error: "user has disabled public stats" }, status: :forbidden
-        end
 
         if params[:filter_by_project].present?
           filter_by_project = params[:filter_by_project].split(",")


### PR DESCRIPTION
Implement a check to ensure that users cannot access public stats if the setting is disabled, enhancing user privacy and security.