### PR TITLE
feat: derive dummy users for testing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,6 +96,9 @@ gem "norairrecord", "~> 0.5.1"
 # Country codes
 gem "countries"
 
+# Random data generation
+gem "faker"
+
 # Markdown parsing
 gem "redcarpet"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,6 +172,8 @@ GEM
     erubi (1.13.1)
     et-orbi (1.4.0)
       tzinfo
+    faker (3.6.0)
+      i18n (>= 1.8.11, < 2)
     faraday (2.14.0)
       faraday-net_http (>= 2.0, < 3.5)
       json
@@ -634,6 +636,7 @@ DEPENDENCIES
   doorkeeper (~> 5.8)
   dotenv-rails
   erb_lint
+  faker
   flamegraph
   flipper
   flipper-active_record

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -581,7 +581,7 @@ class User < ApplicationRecord
   end
 
   def display_name
-    name = slack_username || github_username
+    name = slack_username || github_username || username
     return name if name.present?
 
     # "zach@hackclub.com" -> "zach (email sign-up)"

--- a/lib/tasks/seed_dummy_users.rake
+++ b/lib/tasks/seed_dummy_users.rake
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+namespace :seed do
+  TO_COPY = %i[entity type category project project_root_count branch language dependencies
+                lines line_additions line_deletions lineno cursorpos is_write editor
+                operating_system machine user_agent].freeze
+
+  task dummy_users: :environment do
+    src = User.find(ENV.fetch("FROM", 2).to_i).heartbeats.limit(500).to_a
+    # most times the second user is the dev, as first place is taken up by seed file
+    # if you wanna manually pick a different user, use this:
+    # bin/rails seed:dummy_users FROM=69420
+    abort "nothing to clone" if src.empty?
+
+    puts "using the power of magic, we create 100 dummy users from #{src.count} source heartbeats..."
+
+    100.times do |i|
+      u = User.create!(username: "#{Faker::Creature::Animal.name.delete(' ')}#{rand(1000..9999)}",
+                       github_uid: "dummy_#{SecureRandom.hex(8)}")
+
+      hbs = src.sample(rand(50..200)).map do |h|
+        t = rand(24.hours.ago..Time.current)
+        TO_COPY.to_h { |a| [ a, h.send(a) ] }.merge(user_id: u.id, time: t, source_type: h.source_type || 0,
+                                                   created_at: t, updated_at: t)
+      end
+
+      Heartbeat.insert_all(hbs) if hbs.any?
+      puts "#{i + 1}/100: #{u.username} (#{hbs.count} hbs)"
+    end
+  end
+
+  task remove_dummy_users: :environment do
+    ids = User.where("github_uid LIKE ?", "dummy_%").ids
+    return puts "no dummies found (except for you)" if ids.empty?
+
+    Heartbeat.unscoped.where(user_id: ids).delete_all
+    LeaderboardEntry.where(user_id: ids).delete_all
+    User.where(id: ids).delete_all
+    puts "exploded #{ids.count} dummies"
+  end
+end


### PR DESCRIPTION
wanted fake friends to mess with leaderboards? now you can! it is just one `bin/rails seed:dummy_users` away!