### PR TITLE
fix: resize skeleton loaders on home page to reduce shift

### DIFF
--- a/app/views/leaderboards/_mini_leaderboard_loading.html.erb
+++ b/app/views/leaderboards/_mini_leaderboard_loading.html.erb
@@ -1,15 +1,24 @@
 <div class="bg-elevated rounded-xl border border-primary p-4 shadow-lg">
-  <p class="text-xs italic text-muted mb-4 opacity-70">This leaderboard shows time logged in the last 24 hours (UTC time).</p>
+  <p class="text-xs italic text-muted mb-4">This leaderboard shows time logged in the last 24 hours (UTC time).</p>
   <div class="space-y-2">
-    <% (current_user ? 5 : 3).times do %>
+    <% (current_user ? 6 : 3).times do %>
       <div class="flex items-center p-3 rounded-lg bg-dark animate-pulse">
-        <div class="w-8 h-6 bg-darkless rounded"></div>
-        <div class="w-8 h-8 bg-darkless rounded-full mx-3"></div>
-        <div class="flex-1">
-          <div class="h-4 w-24 bg-darkless rounded"></div>
+        <div class="w-8 text-center">
+          <div class="h-5 w-5 bg-darkless rounded mx-auto"></div>
         </div>
-        <div class="h-4 w-16 bg-darkless rounded"></div>
+        <div class="flex-1 mx-3 min-w-0">
+          <div class="flex items-center gap-2">
+            <div class="w-8 h-8 bg-darkless rounded-full shrink-0"></div>
+            <div class="h-4 w-24 bg-darkless rounded"></div>
+          </div>
+        </div>
+        <div class="shrink-0">
+          <div class="h-4 w-16 bg-darkless rounded"></div>
+        </div>
       </div>
     <% end %>
+  </div>
+  <div class="mt-4 text-right">
+    <div class="h-4 w-32 bg-darkless rounded inline-block animate-pulse"></div>
   </div>
 </div>

--- a/app/views/static_pages/_filterable_dashboard_loading.html.erb
+++ b/app/views/static_pages/_filterable_dashboard_loading.html.erb
@@ -1,10 +1,10 @@
 <%= turbo_frame_tag "filterable_dashboard" do %>
   <div class="max-w-6xl mx-auto my-0 animate-pulse">
     <div class="flex gap-4 mt-2 mb-6 flex-wrap">
-      <% 5.times do %>
-        <div class="flex-1 min-w-37.5 relative">
-          <div class="h-4 w-16 bg-darkless rounded mb-2"></div>
-          <div class="h-10 w-full bg-darkless rounded"></div>
+      <% 6.times do %>
+        <div class="filter flex-1 min-w-37.5 relative">
+          <div class="h-3 w-16 bg-darkless rounded mb-1.5"></div>
+          <div class="h-10 w-full bg-darkless rounded-lg"></div>
         </div>
       <% end %>
     </div>
@@ -18,50 +18,53 @@
             <div class="h-3 w-20 bg-darkless rounded"></div>
           </div>
           <div class="text-lg font-semibold text-white">
-            <div class="h-8 w-24 bg-darkless rounded mt-2"></div>
+            <div class="h-6 w-24 bg-darkless rounded mt-1"></div>
           </div>
         </div>
       <% end %>
     </div>
 
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4 w-full">
-      <%# Project Durations skeleton %>
       <div class="bg-dark border border-primary rounded-xl p-6 flex flex-col animate-pulse">
-        <div class="h-6 w-40 bg-darkless rounded mb-4"></div>
-        <div class="mt-2 space-y-3">
-          <% 5.times do |i| %>
-            <div class="flex items-center mb-3 gap-3">
-              <div class="h-4 w-24 bg-darkless rounded"></div>
-              <div class="flex-1 h-7 bg-darkless rounded-lg overflow-hidden">
-                <div class="h-6 bg-darkless rounded" style="width: <%= 100 - (i * 15) %>%"></div>
+        <div class="h-7 w-40 bg-darkless rounded mb-4"></div>
+        <div class="mt-2">
+          <% 10.times do |i| %>
+            <div class="flex items-center mb-3">
+              <div class="w-37.5 text-right pr-4">
+                <div class="h-4 w-24 bg-darkless rounded ml-auto"></div>
               </div>
+              <div class="flex-1 h-7 bg-darkless rounded-lg overflow-hidden"></div>
             </div>
           <% end %>
         </div>
       </div>
 
-      <%# Language pie chart skeleton %>
       <div class="bg-dark border border-primary rounded-xl p-6 flex flex-col animate-pulse">
-        <div class="h-6 w-32 bg-darkless rounded mb-4"></div>
-        <div class="flex-1 relative min-h-48 flex items-center justify-center py-8">
+        <div class="h-7 w-24 bg-darkless rounded mb-4"></div>
+        <div class="flex-1 relative min-h-48 flex items-center justify-center">
           <div class="w-32 h-32 bg-darkless rounded-full"></div>
         </div>
       </div>
 
-      <%# Editor pie chart skeleton %>
       <div class="bg-dark border border-primary rounded-xl p-6 flex flex-col animate-pulse">
-        <div class="h-6 w-24 bg-darkless rounded mb-4"></div>
-        <div class="flex-1 relative min-h-48 flex items-center justify-center py-8">
+        <div class="h-7 w-20 bg-darkless rounded mb-4"></div>
+        <div class="flex-1 relative min-h-48 flex items-center justify-center">
           <div class="w-32 h-32 bg-darkless rounded-full"></div>
         </div>
       </div>
 
-      <%# Project Timeline skeleton %>
       <div class="bg-dark border border-primary rounded-xl p-6 flex flex-col animate-pulse">
-        <div class="h-6 w-36 bg-darkless rounded mb-4"></div>
-        <div class="flex-1 relative min-h-48 flex items-end justify-between gap-1 py-8 h-48">
+        <div class="h-7 w-40 bg-darkless rounded mb-4"></div>
+        <div class="flex-1 relative min-h-48 flex items-center justify-center">
+          <div class="w-32 h-32 bg-darkless rounded-full"></div>
+        </div>
+      </div>
+
+      <div class="bg-dark border border-primary rounded-xl p-6 flex flex-col animate-pulse">
+        <div class="h-7 w-36 bg-darkless rounded mb-4"></div>
+        <div class="flex-1 relative min-h-48 flex items-end justify-between gap-1">
           <% 12.times do %>
-            <div class="bg-darkless rounded" style="width: 8%; height: <%= rand(20..100) %>%"></div>
+            <div class="flex-1 bg-darkless rounded" style="height: <%= rand(20..100) %>%"></div>
           <% end %>
         </div>
       </div>


### PR DESCRIPTION
Adjust skeleton loaders on the home page to reduce layout shifts and improve visual consistency.