### PR TITLE
fix: flag broken projects

### DIFF
--- a/app/views/static_pages/_project_durations.html.erb
+++ b/app/views/static_pages/_project_durations.html.erb
@@ -21,9 +21,11 @@
       <% end %>
       <div class="bg-dark border border-primary rounded-xl p-6 shadow-lg transition-all duration-300 flex flex-col gap-4 hover:border-primary/40 hover:-translate-y-1 hover:shadow-xl backdrop-blur-sm">
         <div class="flex justify-between items-start gap-3">
+          <% project_name = project[:project].presence || 'Unknown' %>
+          <% is_broken = project_name.blank? || project_name.downcase == 'unknown' || project_name.match?(/<<.*>>/) %>
           <div class="flex flex-col gap-2 flex-1 min-w-0">
             <h3 class="text-lg font-semibold text-white truncate" title="<%= h(project[:project]) %>">
-              <%= h(project[:project].presence || 'Unknown') %>
+              <%= h(project_name) %>
             </h3>
             <% if project[:repository]&.stars.present? %>
               <div class="flex items-center gap-1 text-sm text-yellow-400">
@@ -106,6 +108,14 @@
               <path fill="currentColor" d="M12 20c4.4 0 8-3.6 8-8s-3.6-8-8-8s-8 3.6-8 8s3.6 8 8 8m0-18c5.5 0 10 4.5 10 10s-4.5 10-10 10S2 17.5 2 12S6.5 2 12 2m.5 10.8l-4.8 2.8l-.7-1.4l4-2.3V7h1.5z" />
             </svg>
             <span class="text-white/50">Last commit <%= time_ago_in_words(project[:repository].last_commit_at) %> ago</span>
+          </div>
+        <% end %>
+
+        <% if is_broken %>
+          <div class="gap-2 p-3 bg-yellow-500/10 border border-yellow-500/30 rounded-lg">
+            <p class="text-sm text-yellow-200/80 leading-relaxed">
+              Your editor may not be set up properly—we're receiving invalid project names. This time is shown here but won't be counted accurately and may not be submitted to Hack Club programs.
+            </p>
           </div>
         <% end %>
       </div>


### PR DESCRIPTION
Add a mechanism to identify broken projects based on their names and display a warning message to inform users about potential issues with their project setup.