### PR TITLE
feat: add streaks to user stats endpoint

### DIFF
--- a/app/controllers/api/v1/stats_controller.rb
+++ b/app/controllers/api/v1/stats_controller.rb
@@ -126,7 +126,8 @@ class Api::V1::StatsController < ApplicationController
 
     render json: {
       data: summary,
-      trust_factor: trust_info
+      trust_factor: trust_info,
+      streak: @user.streak_days
     }
   end
 

--- a/spec/requests/api/v1/stats_spec.rb
+++ b/spec/requests/api/v1/stats_spec.rb
@@ -249,7 +249,8 @@ RSpec.describe 'Api::V1::Stats', type: :request do
                 trust_level: { type: :string, example: 'blue' },
                 trust_value: { type: :integer, example: 3 }
               }
-            }
+            },
+            streak: { type: :integer, example: 7, description: 'Number of consecutive days the user has coded' }
           }
         run_test!
       end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -3140,6 +3140,10 @@ paths:
                       trust_value:
                         type: integer
                         example: 3
+                  streak:
+                    type: integer
+                    example: 7
+                    description: Number of consecutive days the user has coded
         '403':
           description: forbidden
           content:


### PR DESCRIPTION
Includes the user's streak days in the user stats response.

![meffo](https://github.com/user-attachments/assets/0e83f083-4b78-4e7c-8582-42aa7e2a18af)
