### PR TITLE
Normalize datetime params in ProjectStatsQuery to Time.zone to prevent range errors

### DIFF
--- a/app/services/project_stats_query.rb
+++ b/app/services/project_stats_query.rb
@@ -122,7 +122,9 @@ class ProjectStatsQuery
   def parse_datetime(value)
     return nil if value.blank?
 
-    value.to_datetime
+    return value.in_time_zone if value.respond_to?(:in_time_zone)
+
+    Time.zone.parse(value.to_s)
   rescue ArgumentError, TypeError
     nil
   end


### PR DESCRIPTION
### Motivation
- Fix a 500 `ArgumentError: bad value for range` in the `/api/v1/authenticated/projects` flow caused by mixed `DateTime`/`Time` range endpoints when parsing datetime params (likely surfaced after OAuth2 projects route unification). 

### Description
- Update `ProjectStatsQuery#parse_datetime` to return `value.in_time_zone` for objects that respond to `in_time_zone` and to parse string values with `Time.zone.parse(value.to_s)` instead of `to_datetime`, ensuring parsed bounds are `Time`-compatible.

### Testing
- Attempted local checks: `docker compose ps` failed due to missing `docker` and `bundle exec rails test test/lib/project_stats_query_test.rb` failed due to missing `rails` executable, so automated test runs could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69938d1cea4c832b9457d1871c233da2)