### PR TITLE
Avoid preload/import map tags for rails_modals in Firefox

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -185,7 +185,7 @@
     <%= stylesheet_link_tag :app %>
     <%= stylesheet_link_tag 'tailwind', 'data-turbo-track': 'reload' %>
     <%= vite_client_tag %>
-    <%= vite_typescript_tag "rails_modals" %>
+    <%= vite_typescript_tag "rails_modals", skip_preload_tags: true, preload_links_header: false %>
     <% if Sentry.get_trace_propagation_meta %>
       <%= sanitize Sentry.get_trace_propagation_meta, tags: %w[meta], attributes: %w[name content] %>
     <% end %>


### PR DESCRIPTION
Summary
- disable the preload/importmap generation for the `rails_modals` entry when rendering `app/views/layouts/application.html.erb` to avoid Firefox errors about late imports
- keep the existing stylesheet and Vite client tags untouched so other browsers continue loading normally