### PR TITLE
Allow disabling Hackatime v1 import via Flipper flag

### DIFF
--- a/app/controllers/leaderboards_controller.rb
+++ b/app/controllers/leaderboards_controller.rb
@@ -73,6 +73,8 @@ class LeaderboardsController < ApplicationController
   end
 
   def calculate_untracked_entries(ids)
+    return 0 unless Flipper.enabled?(:hackatime_v1_import)
+
     range = @period_type == :last_7_days ? ((Date.current - 6.days).beginning_of_day...Date.current.end_of_day) : Date.current.all_day
     ids_set = ids.to_set
 

--- a/app/controllers/my/project_repo_mappings_controller.rb
+++ b/app/controllers/my/project_repo_mappings_controller.rb
@@ -112,7 +112,7 @@ class My::ProjectRepoMappingsController < InertiaController
     scoped_mappings = archived ? mappings.archived : mappings.active
     mappings_by_name = scoped_mappings.index_by(&:project_name)
     archived_names = current_user.project_repo_mappings.archived.pluck(:project_name).index_with(true)
-    labels_by_project_key = current_user.project_labels.pluck(:project_key, :label).to_h
+    labels_by_project_key = Flipper.enabled?(:hackatime_v1_import) ? current_user.project_labels.pluck(:project_key, :label).to_h : {}
 
     cached = Rails.cache.fetch(project_durations_cache_key, expires_in: 1.minute) do
       hb = current_user.heartbeats.filter_by_time_range(selected_interval, params[:from], params[:to])

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -29,7 +29,7 @@ class SessionsController < ApplicationController
     if @user&.persisted?
       session[:user_id] = @user.id
 
-      if @user.data_migration_jobs.empty?
+      if Flipper.enabled?(:hackatime_v1_import) && @user.data_migration_jobs.empty?
         MigrateUserFromHackatimeJob.perform_later(@user.id)
       end
 
@@ -77,7 +77,7 @@ class SessionsController < ApplicationController
     if @user&.persisted?
       session[:user_id] = @user.id
 
-      if @user.data_migration_jobs.empty?
+      if Flipper.enabled?(:hackatime_v1_import) && @user.data_migration_jobs.empty?
         # if they don't have a data migration job, add one to the queue
         MigrateUserFromHackatimeJob.perform_later(@user.id)
       end

--- a/app/controllers/settings/base_controller.rb
+++ b/app/controllers/settings/base_controller.rb
@@ -167,6 +167,7 @@ class Settings::BaseController < InertiaController
         api_url: "https://#{request.host_with_port}/api/hackatime/v1"
       },
       migration: {
+        enabled: Flipper.enabled?(:hackatime_v1_import),
         jobs: @heartbeats_migration_jobs.map { |job|
           {
             id: job.id,

--- a/app/controllers/settings/data_controller.rb
+++ b/app/controllers/settings/data_controller.rb
@@ -4,6 +4,11 @@ class Settings::DataController < Settings::BaseController
   end
 
   def migrate_heartbeats
+    unless Flipper.enabled?(:hackatime_v1_import)
+      redirect_to my_settings_data_path, alert: "Hackatime v1 import is currently disabled"
+      return
+    end
+
     MigrateUserFromHackatimeJob.perform_later(@user.id)
     redirect_to my_settings_data_path, notice: "Heartbeats & api keys migration started"
   end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -63,7 +63,7 @@ class StaticPagesController < InertiaController
 
     cached = Rails.cache.fetch(key, expires_in: 1.minute) do
       hb = current_user.heartbeats.filter_by_time_range(params[:interval], params[:from], params[:to])
-      labels = current_user.project_labels
+      labels = Flipper.enabled?(:hackatime_v1_import) ? current_user.project_labels : []
       projects = hb.group(:project).duration_seconds.filter_map do |proj, dur|
         next if dur <= 0
         m = @project_repo_mappings.find { |p| p.project_name == proj }

--- a/app/javascript/pages/Users/Settings/Data.svelte
+++ b/app/javascript/pages/Users/Settings/Data.svelte
@@ -261,7 +261,8 @@
       </form>
       {#if !migration.enabled}
         <p class="mt-2 text-xs text-muted">
-          Hackatime v1 import is currently disabled.
+          Hackatime v1 import is currently disabled due to an integration issue.
+          We're working on reinstating imports!
         </p>
       {/if}
 

--- a/app/javascript/pages/Users/Settings/Data.svelte
+++ b/app/javascript/pages/Users/Settings/Data.svelte
@@ -255,8 +255,15 @@
       </p>
       <form method="post" action={paths.migrate_heartbeats_path} class="mt-4">
         <input type="hidden" name="authenticity_token" value={csrfToken} />
-        <Button type="submit" class="rounded-md">Start migration</Button>
+        <Button type="submit" class="rounded-md" disabled={!migration.enabled}
+          >Start migration</Button
+        >
       </form>
+      {#if !migration.enabled}
+        <p class="mt-2 text-xs text-muted">
+          Hackatime v1 import is currently disabled.
+        </p>
+      {/if}
 
       {#if migration.jobs.length > 0}
         <div class="mt-4 space-y-2">

--- a/app/javascript/pages/Users/Settings/types.ts
+++ b/app/javascript/pages/Users/Settings/types.ts
@@ -114,6 +114,7 @@ export type ConfigFileProps = {
 };
 
 export type MigrationProps = {
+  enabled: boolean;
   jobs: { id: string; status: string }[];
 };
 

--- a/app/jobs/migrate_user_from_hackatime_job.rb
+++ b/app/jobs/migrate_user_from_hackatime_job.rb
@@ -10,6 +10,8 @@ class MigrateUserFromHackatimeJob < ApplicationJob
   )
 
   def perform(user_id)
+    return unless Flipper.enabled?(:hackatime_v1_import)
+
     @user = User.find(user_id)
     # Import from Hackatime
     return unless @user.slack_uid.present?

--- a/app/models/hackatime_record.rb
+++ b/app/models/hackatime_record.rb
@@ -1,4 +1,9 @@
 class HackatimeRecord < ApplicationRecord
   self.abstract_class = true
-  connects_to database: { reading: :wakatime, writing: :wakatime }
+
+  begin
+    connects_to database: { reading: :wakatime, writing: :wakatime }
+  rescue => e
+    Rails.logger.warn "HackatimeRecord: Could not connect to wakatime database: #{e.message}"
+  end
 end

--- a/app/models/hackatime_record.rb
+++ b/app/models/hackatime_record.rb
@@ -3,7 +3,7 @@ class HackatimeRecord < ApplicationRecord
 
   begin
     connects_to database: { reading: :wakatime, writing: :wakatime }
-  rescue => e
+  rescue StandardError => e
     Rails.logger.warn "HackatimeRecord: Could not connect to wakatime database: #{e.message}"
   end
 end


### PR DESCRIPTION
The old DB (on A server) seems to be wobbly and is taking down the leaderboards/projects pages.