### PR TITLE
Fix modal close button alignment when icon is present

### DIFF
--- a/app/javascript/components/Modal.svelte
+++ b/app/javascript/components/Modal.svelte
@@ -44,7 +44,7 @@
       <div class="absolute inset-x-0 top-0 h-1 bg-primary"></div>
 
       <div class="p-6 sm:p-8">
-        <div class="mb-5 flex items-center justify-between gap-4">
+        <div class="mb-5 flex items-start justify-between gap-4">
           <div class="min-w-0">
             {#if hasIcon}
               <div


### PR DESCRIPTION
The X (close) button in the modal was vertically misaligned when an icon was present. The flex container used `items-center`, which centered the close button relative to the entire left block (icon + title + description). Changed to `items-start` so the X stays pinned to the top-right corner.