### PR TITLE
Make homepage more candid (and update signin buttons)

### DIFF
--- a/app/javascript/layouts/AppLayout.svelte
+++ b/app/javascript/layouts/AppLayout.svelte
@@ -408,8 +408,8 @@
           <a
             href={layout.nav.login_path}
             class="block px-4 py-2 rounded-md transition text-on-primary font-semibold bg-primary hover:bg-secondary text-center"
-            >Get Started/a >
-          </a>
+            >Get Started</a
+          >
         </div>
       {/if}
 

--- a/app/javascript/layouts/AppLayout.svelte
+++ b/app/javascript/layouts/AppLayout.svelte
@@ -408,7 +408,7 @@
           <a
             href={layout.nav.login_path}
             class="block px-4 py-2 rounded-md transition text-on-primary font-semibold bg-primary hover:bg-secondary text-center"
-            >Login</a
+            >Get Started/a
           >
         </div>
       {/if}

--- a/app/javascript/layouts/AppLayout.svelte
+++ b/app/javascript/layouts/AppLayout.svelte
@@ -408,7 +408,7 @@
           <a
             href={layout.nav.login_path}
             class="block px-4 py-2 rounded-md transition text-on-primary font-semibold bg-primary hover:bg-secondary text-center"
-            >Get Started</a
+            >Login</a
           >
         </div>
       {/if}

--- a/app/javascript/layouts/AppLayout.svelte
+++ b/app/javascript/layouts/AppLayout.svelte
@@ -408,8 +408,8 @@
           <a
             href={layout.nav.login_path}
             class="block px-4 py-2 rounded-md transition text-on-primary font-semibold bg-primary hover:bg-secondary text-center"
-            >Get Started/a
-          >
+            >Get Started/a >
+          </a>
         </div>
       {/if}
 

--- a/app/javascript/pages/Home/SignedOut.svelte
+++ b/app/javascript/pages/Home/SignedOut.svelte
@@ -103,7 +103,7 @@
           href="/signin"
           class="px-4 py-2 bg-primary text-on-primary rounded-md font-semibold hover:opacity-90 transition-colors"
         >
-          Get Started
+          Sign In
         </Link>
       </nav>
     </div>

--- a/app/javascript/pages/Home/SignedOut.svelte
+++ b/app/javascript/pages/Home/SignedOut.svelte
@@ -103,7 +103,7 @@
           href="/signin"
           class="px-4 py-2 bg-primary text-on-primary rounded-md font-semibold hover:opacity-90 transition-colors"
         >
-          Start tracking
+          Login
         </Link>
       </nav>
     </div>
@@ -128,7 +128,7 @@
           href="/signin"
           class="px-7 py-3.5 bg-primary text-on-primary rounded-md font-semibold text-base hover:opacity-90 transition-colors"
         >
-          Start tracking
+          Login
         </Link>
         <Link
           href="/docs"

--- a/app/javascript/pages/Home/SignedOut.svelte
+++ b/app/javascript/pages/Home/SignedOut.svelte
@@ -103,7 +103,7 @@
           href="/signin"
           class="px-4 py-2 bg-primary text-on-primary rounded-md font-semibold hover:opacity-90 transition-colors"
         >
-          Login
+          Get Started
         </Link>
       </nav>
     </div>
@@ -128,7 +128,7 @@
           href="/signin"
           class="px-7 py-3.5 bg-primary text-on-primary rounded-md font-semibold text-base hover:opacity-90 transition-colors"
         >
-          Login
+          Get Started
         </Link>
         <Link
           href="/docs"

--- a/app/javascript/pages/Home/signedOut/CTASection.svelte
+++ b/app/javascript/pages/Home/signedOut/CTASection.svelte
@@ -15,7 +15,7 @@
     <h2
       class="text-3xl md:text-4xl font-semibold text-on-primary tracking-tight mb-4"
     >
-      Start tracking <i>all</i> your hacking.
+      Start tracking your hacking.
     </h2>
     <p class="text-on-primary/90 text-lg mb-10">
       Join {usersTracked} users who have tracked {hoursTracked}+ hours of coding

--- a/app/javascript/pages/Home/signedOut/CTASection.svelte
+++ b/app/javascript/pages/Home/signedOut/CTASection.svelte
@@ -15,7 +15,7 @@
     <h2
       class="text-3xl md:text-4xl font-semibold text-on-primary tracking-tight mb-4"
     >
-      Start tracking your hacking.
+      Start tracking your <s>code</s> work.
     </h2>
     <p class="text-on-primary/90 text-lg mb-10">
       Join {usersTracked} users who have tracked {hoursTracked}+ hours of coding

--- a/app/javascript/pages/Home/signedOut/CTASection.svelte
+++ b/app/javascript/pages/Home/signedOut/CTASection.svelte
@@ -15,10 +15,10 @@
     <h2
       class="text-3xl md:text-4xl font-semibold text-on-primary tracking-tight mb-4"
     >
-      Start tracking your <s>code</s> work.
+      Start tracking your technical work.
     </h2>
     <p class="text-on-primary/90 text-lg mb-10">
-      Join {usersTracked} users who have tracked {hoursTracked}+ hours of coding
+      Join {usersTracked} users who have tracked {hoursTracked}+ hours of work
       with Hackatime.
     </p>
     <Link

--- a/app/javascript/pages/Home/signedOut/CTASection.svelte
+++ b/app/javascript/pages/Home/signedOut/CTASection.svelte
@@ -15,7 +15,7 @@
     <h2
       class="text-3xl md:text-4xl font-semibold text-on-primary tracking-tight mb-4"
     >
-      Start tracking your technical work.
+      What are you waiting for?
     </h2>
     <p class="text-on-primary/90 text-lg mb-10">
       Join {usersTracked} users who have tracked {hoursTracked}+ hours of work

--- a/app/javascript/pages/Home/signedOut/CTASection.svelte
+++ b/app/javascript/pages/Home/signedOut/CTASection.svelte
@@ -15,7 +15,7 @@
     <h2
       class="text-3xl md:text-4xl font-semibold text-on-primary tracking-tight mb-4"
     >
-      Start tracking your code.
+      Start tracking <i>all</i> your hacking.
     </h2>
     <p class="text-on-primary/90 text-lg mb-10">
       Join {usersTracked} users who have tracked {hoursTracked}+ hours of coding

--- a/app/javascript/pages/Home/signedOut/FeaturesGrid.svelte
+++ b/app/javascript/pages/Home/signedOut/FeaturesGrid.svelte
@@ -15,7 +15,7 @@
     {
       title: "Track everything, not just code",
       description:
-        "Using <a href="https://lapse.hackclub.com" target="_blank">Lapse</a>, you can track time everywhere, even outside your IDE.",
+        "Using Lapse, you can record your screen to track time everywhere (not just coding!).",
       icon: `<path d="M5.625 1.5c-1.036 0-1.875.84-1.875 1.875v17.25c0 1.035.84 1.875 1.875 1.875h12.75c1.035 0 1.875-.84 1.875-1.875V12.75A3.75 3.75 0 0016.5 9h-1.875a1.875 1.875 0 01-1.875-1.875V5.25A3.75 3.75 0 009 1.5H5.625z" /><path d="M12.971 1.816A5.23 5.23 0 0114.25 5.25v1.875c0 .207.168.375.375.375H16.5a5.23 5.23 0 013.434 1.279 9.768 9.768 0 00-6.963-6.963z" /><path d="M9 12.75a.75.75 0 00-1.5 0v4.5a.75.75 0 001.5 0v-4.5zm2.25 2.25a.75.75 0 00-1.5 0v2.25a.75.75 0 001.5 0V15zm2.25-1.5a.75.75 0 00-1.5 0v3.75a.75.75 0 001.5 0v-3.75z" />`,
     },
     {

--- a/app/javascript/pages/Home/signedOut/FeaturesGrid.svelte
+++ b/app/javascript/pages/Home/signedOut/FeaturesGrid.svelte
@@ -26,9 +26,9 @@
         <path d="M7.151 21.75a2.999 2.999 0 0 0 2.599 1.5h7.5a3 3 0 0 0 3-3v-7.5c0-1.11-.603-2.08-1.5-2.599v7.099a4.5 4.5 0 0 1-4.5 4.5H7.151Z" />`,
     },
     {
-      title: "Leaderboards (coming soon)",
+      title: "Built-in Motivation",
       description:
-        "Create private leaderboards for your team or hackathon. Compete on consistency.",
+        "Leaderboards, goals, streaks, and email summaries create competetion and consistency.",
       icon: `<path d="M4.5 6.375a4.125 4.125 0 118.25 0 4.125 4.125 0 01-8.25 0zM14.25 8.625a3.375 3.375 0 116.75 0 3.375 3.375 0 01-6.75 0zM1.5 19.125a7.125 7.125 0 0114.25 0v.003l-.001.119a.75.75 0 01-.363.63 13.067 13.067 0 01-6.761 1.873c-2.472 0-4.786-.684-6.76-1.873a.75.75 0 01-.364-.63l-.001-.122zM17.25 19.128l-.001.144a2.25 2.25 0 01-.233.96 10.088 10.088 0 005.06-1.01.75.75 0 00.42-.643 4.875 4.875 0 00-6.957-4.611 8.586 8.586 0 011.71 5.157v.003z" />`,
     },
     {

--- a/app/javascript/pages/Home/signedOut/FeaturesGrid.svelte
+++ b/app/javascript/pages/Home/signedOut/FeaturesGrid.svelte
@@ -13,9 +13,9 @@
       icon: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-6"><path fill-rule="evenodd" d="M3 6a3 3 0 0 1 3-3h12a3 3 0 0 1 3 3v12a3 3 0 0 1-3 3H6a3 3 0 0 1-3-3V6Zm14.25 6a.75.75 0 0 1-.22.53l-2.25 2.25a.75.75 0 1 1-1.06-1.06L15.44 12l-1.72-1.72a.75.75 0 1 1 1.06-1.06l2.25 2.25c.141.14.22.331.22.53Zm-10.28-.53a.75.75 0 0 0 0 1.06l2.25 2.25a.75.75 0 1 0 1.06-1.06L8.56 12l1.72-1.72a.75.75 0 1 0-1.06-1.06l-2.25 2.25Z" clip-rule="evenodd" /></svg>`,
     },
     {
-      title: "File-level insights",
+      title: "Track everything, not just code",
       description:
-        "Drill into specific files. Find the ones consuming all your time.",
+        "Using <a href="https://lapse.hackclub.com" target="_blank">Lapse</a>, you can track time everywhere, even outside your IDE.",
       icon: `<path d="M5.625 1.5c-1.036 0-1.875.84-1.875 1.875v17.25c0 1.035.84 1.875 1.875 1.875h12.75c1.035 0 1.875-.84 1.875-1.875V12.75A3.75 3.75 0 0016.5 9h-1.875a1.875 1.875 0 01-1.875-1.875V5.25A3.75 3.75 0 009 1.5H5.625z" /><path d="M12.971 1.816A5.23 5.23 0 0114.25 5.25v1.875c0 .207.168.375.375.375H16.5a5.23 5.23 0 013.434 1.279 9.768 9.768 0 00-6.963-6.963z" /><path d="M9 12.75a.75.75 0 00-1.5 0v4.5a.75.75 0 001.5 0v-4.5zm2.25 2.25a.75.75 0 00-1.5 0v2.25a.75.75 0 001.5 0V15zm2.25-1.5a.75.75 0 00-1.5 0v3.75a.75.75 0 001.5 0v-3.75z" />`,
     },
     {

--- a/app/javascript/pages/Home/signedOut/FeaturesGrid.svelte
+++ b/app/javascript/pages/Home/signedOut/FeaturesGrid.svelte
@@ -28,7 +28,7 @@
     {
       title: "Built-in Motivation",
       description:
-        "Leaderboards, goals, streaks, and email summaries create competetion and consistency.",
+        "Leaderboards, goals, streaks, and email summaries create competition and consistency.",
       icon: `<path d="M4.5 6.375a4.125 4.125 0 118.25 0 4.125 4.125 0 01-8.25 0zM14.25 8.625a3.375 3.375 0 116.75 0 3.375 3.375 0 01-6.75 0zM1.5 19.125a7.125 7.125 0 0114.25 0v.003l-.001.119a.75.75 0 01-.363.63 13.067 13.067 0 01-6.761 1.873c-2.472 0-4.786-.684-6.76-1.873a.75.75 0 01-.364-.63l-.001-.122zM17.25 19.128l-.001.144a2.25 2.25 0 01-.233.96 10.088 10.088 0 005.06-1.01.75.75 0 00.42-.643 4.875 4.875 0 00-6.957-4.611 8.586 8.586 0 011.71 5.157v.003z" />`,
     },
     {

--- a/app/javascript/pages/Home/signedOut/HowItWorks.svelte
+++ b/app/javascript/pages/Home/signedOut/HowItWorks.svelte
@@ -3,7 +3,7 @@
     <h2
       class="text-3xl md:text-4xl font-semibold text-surface-content text-center tracking-tight mb-12"
     >
-      Start tracking in 30 seconds.
+      Start tracking in minutes.
     </h2>
     <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
       <div class="border-l-2 border-surface-200 pl-4">
@@ -19,11 +19,10 @@
       <div class="border-l-2 border-surface-200 pl-4">
         <span class="text-sm font-bold text-primary tracking-widest">02</span>
         <h3 class="text-lg font-semibold text-surface-content mt-2 mb-2">
-          Install Plugin
+          Run Installer
         </h3>
         <p class="text-secondary text-base leading-relaxed">
-          Install the WakaTime plugin for your editor (VS Code, JetBrains, Vim,
-          etc.) from its extension marketplace.
+          Run the unified setup command which configures plugins for most editors.
         </p>
       </div>
       <div class="border-l-2 border-surface-200 pl-4">
@@ -32,10 +31,7 @@
           Configure
         </h3>
         <p class="text-secondary text-base leading-relaxed">
-          Enter your API key and set the <code
-            class="text-primary bg-surface-100 px-1.5 py-0.5 rounded text-sm"
-            >api_url</code
-          > to Hackatime. Done.
+          Done! Your work is now trackeed across project repositories. 
         </p>
       </div>
     </div>

--- a/app/javascript/pages/Home/signedOut/HowItWorks.svelte
+++ b/app/javascript/pages/Home/signedOut/HowItWorks.svelte
@@ -3,7 +3,7 @@
     <h2
       class="text-3xl md:text-4xl font-semibold text-surface-content text-center tracking-tight mb-12"
     >
-      Start tracking in minutes.
+      Start tracking in just minutes.
     </h2>
     <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
       <div class="border-l-2 border-surface-200 pl-4">

--- a/app/javascript/pages/Home/signedOut/HowItWorks.svelte
+++ b/app/javascript/pages/Home/signedOut/HowItWorks.svelte
@@ -22,7 +22,8 @@
           Run Installer
         </h3>
         <p class="text-secondary text-base leading-relaxed">
-          Run the unified setup command which configures plugins for most editors.
+          Run the unified setup command which configures plugins for most
+          editors.
         </p>
       </div>
       <div class="border-l-2 border-surface-200 pl-4">
@@ -31,7 +32,7 @@
           Configure
         </h3>
         <p class="text-secondary text-base leading-relaxed">
-          Done! Your work is now trackeed across project repositories. 
+          Done! Your work is now trackeed across project repositories.
         </p>
       </div>
     </div>

--- a/app/javascript/pages/Home/signedOut/HowItWorks.svelte
+++ b/app/javascript/pages/Home/signedOut/HowItWorks.svelte
@@ -32,7 +32,7 @@
           Configure
         </h3>
         <p class="text-secondary text-base leading-relaxed">
-          Done! Your work is now trackeed across project repositories.
+          Done! Your work is now tracked across project repositories.
         </p>
       </div>
     </div>

--- a/app/javascript/pages/WakatimeAlternative.svelte
+++ b/app/javascript/pages/WakatimeAlternative.svelte
@@ -135,6 +135,7 @@
     "Open source - audit the code, contribute, or self-host",
     "Privacy-first - only metadata tracked, never your code",
     "Community leaderboards - see how you stack up against peers",
+    "Track time for non-coding or web editors",
   ];
 </script>
 

--- a/app/javascript/pages/WakatimeAlternative.svelte
+++ b/app/javascript/pages/WakatimeAlternative.svelte
@@ -174,7 +174,7 @@
           href="/signin"
           class="px-4 py-2 bg-primary text-on-primary rounded-md font-semibold hover:opacity-90 transition-colors"
         >
-          Start tracking
+          Login
         </Link>
       </nav>
     </div>
@@ -388,7 +388,7 @@ api_key = YOUR_API_KEY_HERE</code
         >
           Start tracking for free
         </Link>
-        <p class="text-secondary text-sm mt-4">Takes 2 minutes to set up.</p>
+        <p class="text-secondary text-sm mt-4">Takes just minutes to set up.</p>
       </div>
     </div>
   </section>

--- a/app/javascript/pages/WakatimeAlternative.svelte
+++ b/app/javascript/pages/WakatimeAlternative.svelte
@@ -174,7 +174,7 @@
           href="/signin"
           class="px-4 py-2 bg-primary text-on-primary rounded-md font-semibold hover:opacity-90 transition-colors"
         >
-          Login
+          Get Started
         </Link>
       </nav>
     </div>


### PR DESCRIPTION
Makes the following changes
- the "start tracking" buttons in the hero and navbar become "get started" and "sign in" respectively due to several complaints that they were confusing. (#1046)
  <img width="2015" height="1317" alt="image" src="https://github.com/user-attachments/assets/0ef1dab3-b50f-4fe5-8dfb-1fab745b36c5" />

- the features grid item "drill down into every file" is not possible in Hackatime (at least until #1028 is merged!) becomes "use lapse to track time for anything" (this is a unique hackatime-adjacent feature which wakatime doesn't have)
  <img width="2015" height="1099" alt="image" src="https://github.com/user-attachments/assets/0bd9b33f-5509-4c61-9cf0-6f467e1087b1" />

- the features grid item "private leaderboards (coming soon) enable competition within teams" becomes "leaderboards, streaks, and goals boost competition and consistency"

- the "get started in 30 seconds" and "get started in 2 minutes" become "get started in  just minutes"
  <img width="2015" height="537" alt="image" src="https://github.com/user-attachments/assets/a44b7f2b-4622-45bc-9efb-7f861af6dab2" />

- things that make it seem only for coding ("start tracking your code") become "what are you waiting for?" in order to not artifically imply hackatime is **only** coding.
  <img width="2015" height="567" alt="image" src="https://github.com/user-attachments/assets/2dbb6f1b-2041-4c03-8621-4b3bcea02475" />

Overall, this PR aims to make the homepage more accurately reflect the current state of Hackatime by both removing inaccuracies and adding things to advertise unmentioned strengths of the platform. Additionally, it should make the difference between hackatime and wakatime more clear by highlighting features like lapse compatibility.