### PR TITLE
Add HackaStreak extension to the list

### DIFF
--- a/app/javascript/pages/Extensions/Index.svelte
+++ b/app/javascript/pages/Extensions/Index.svelte
@@ -20,7 +20,7 @@
       description:
         "Check a user's Hackatime streak in Slack.",
       install: "https://hackclub.enterprise.slack.com/archives/C0AJLGZ73NE",
-      buttonLabel: "Try out!",
+      buttonLabel: "Try it out!",
     },
   ];
 </script>

--- a/app/javascript/pages/Extensions/Index.svelte
+++ b/app/javascript/pages/Extensions/Index.svelte
@@ -14,6 +14,13 @@
         "A Tamagotchi system. Code, fill your cup, and get your pet rewards.",
       install: "https://github.com/joysudo/catatime/releases/",
     },
+    {
+      name: "HackaStreak",
+      source: "https://github.com/hippogriff101/HackaStreak",
+      description:
+        "Check a user Hackatime Streak through Slack!",
+      install: "https://hackclub.enterprise.slack.com/archives/C0AJLGZ73NE",
+    },
   ];
 </script>
 

--- a/app/javascript/pages/Extensions/Index.svelte
+++ b/app/javascript/pages/Extensions/Index.svelte
@@ -18,7 +18,7 @@
       name: "HackaStreak",
       source: "https://github.com/hippogriff101/HackaStreak",
       description:
-        "Check a user's Hackatime Streak through Slack!",
+        "Check a user's Hackatime streak in Slack.",
       install: "https://hackclub.enterprise.slack.com/archives/C0AJLGZ73NE",
     },
   ];

--- a/app/javascript/pages/Extensions/Index.svelte
+++ b/app/javascript/pages/Extensions/Index.svelte
@@ -18,7 +18,7 @@
       name: "HackaStreak",
       source: "https://github.com/hippogriff101/HackaStreak",
       description:
-        "Check a user Hackatime Streak through Slack!",
+        "Check a user's Hackatime Streak through Slack!",
       install: "https://hackclub.enterprise.slack.com/archives/C0AJLGZ73NE",
     },
   ];

--- a/app/javascript/pages/Extensions/Index.svelte
+++ b/app/javascript/pages/Extensions/Index.svelte
@@ -20,6 +20,7 @@
       description:
         "Check a user's Hackatime streak in Slack.",
       install: "https://hackclub.enterprise.slack.com/archives/C0AJLGZ73NE",
+      buttonLabel: "Try out!",
     },
   ];
 </script>
@@ -57,7 +58,7 @@
             rel="noopener noreferrer"
             class="flex items-center justify-center gap-2 px-4 py-2 rounded bg-primary text-on-primary font-medium text-sm hover:opacity-90 transition-opacity"
           >
-            <span>Install</span>
+            <span>{extension.buttonLabel ?? "Install"}</span>
             <svg
               xmlns="http://www.w3.org/2000/svg"
               width="16"

--- a/app/javascript/pages/Extensions/Index.svelte
+++ b/app/javascript/pages/Extensions/Index.svelte
@@ -17,8 +17,7 @@
     {
       name: "HackaStreak",
       source: "https://github.com/hippogriff101/HackaStreak",
-      description:
-        "Check a user's Hackatime streak in Slack.",
+      description: "Check a user's Hackatime streak in Slack.",
       install: "https://hackclub.enterprise.slack.com/archives/C0AJLGZ73NE",
       buttonLabel: "Try it out!",
     },


### PR DESCRIPTION
I'm not sure if it is clear as the button says 'install' but this is a project on slack? I'm not sure how I would change it from 'Install' to 'Try out!'?

<img width="366" height="137" alt="image" src="https://github.com/user-attachments/assets/fb23b6b4-116a-475a-a202-8bd1b9042b82" />
