### PR TITLE
Revert LAG fix (technically correct, but confusing in practice.)

### DIFF
--- a/app/models/concerns/heartbeatable.rb
+++ b/app/models/concerns/heartbeatable.rb
@@ -223,8 +223,8 @@ module Heartbeatable
 
         capped_diffs = scope
           .select("#{group_expr} as grouped_time, CASE
-            WHEN LAG(time) OVER (ORDER BY time) IS NULL THEN 0
-            ELSE LEAST(time - LAG(time) OVER (ORDER BY time), #{timeout})
+            WHEN LAG(time) OVER (PARTITION BY #{group_expr} ORDER BY time) IS NULL THEN 0
+            ELSE LEAST(time - LAG(time) OVER (PARTITION BY #{group_expr} ORDER BY time), #{timeout})
           END as diff")
           .where.not(time: nil)
           .unscope(:group)


### PR DESCRIPTION
Reverts hackclub/hackatime#1075. This is _technically_ the right move but users are getting confused that their double-counted time is dropping :/