### PR TITLE
Add 'today' to dashboard logged time sentence

### DIFF
--- a/app/javascript/pages/Home/signedIn/TodaySentence.svelte
+++ b/app/javascript/pages/Home/signedIn/TodaySentence.svelte
@@ -16,7 +16,7 @@
 
 <p>
   {#if show_logged_time_sentence}
-    Today you've logged
+    Today, you've logged
     {todays_duration_display}
     {#if todays_languages.length > 0 || todays_editors.length > 0}
       across

--- a/app/javascript/pages/Home/signedIn/TodaySentence.svelte
+++ b/app/javascript/pages/Home/signedIn/TodaySentence.svelte
@@ -16,7 +16,7 @@
 
 <p>
   {#if show_logged_time_sentence}
-    You've logged
+    Today you've logged
     {todays_duration_display}
     {#if todays_languages.length > 0 || todays_editors.length > 0}
       across


### PR DESCRIPTION
Instead of: You've logged 37m 22s across Java, JSON (& 2 other languages) using Antigravity and VS Code, it would be: Today you've logged 37m 22s across Java, JSON (& 2 other languages) using Antigravity and VS Code