### PR TITLE
Prevent index usage on lookup_email and get_user_by_email endpoints

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::UsersController < ApplicationController
   def lookup_email
     email = params[:email]
 
-    user = EmailAddress.find_by_email(email)&.user
+    user = EmailAddress.where("email || '' = ?", email).first&.user
 
     if user.present?
       render json: { user_id: user.id, email: email }

--- a/app/controllers/concerns/api/admin/v1/user_utilities.rb
+++ b/app/controllers/concerns/api/admin/v1/user_utilities.rb
@@ -16,7 +16,7 @@ module Api
             return
           end
 
-          email_record = EmailAddress.find_by email: email
+          email_record = EmailAddress.where("email || '' = ?", email).first
           if email_record.nil?
             render json: { error: "email not found" }, status: :not_found
             return


### PR DESCRIPTION
Uses expression-based WHERE clause (`email || '' = ?`) to force sequential scan instead of using the `index_email_addresses_on_email` index on both endpoints.

Reason: indexes _might_ be cooked? Just a process of elimination rn