### PR TITLE
Serve stale rollups if old rollup is dirty

### DIFF
--- a/app/controllers/concerns/dashboard_data.rb
+++ b/app/controllers/concerns/dashboard_data.rb
@@ -232,13 +232,6 @@ module DashboardData
     return unless dashboard_rollups_available?
     return unless dashboard_rollup_eligible?
 
-    # `wait: 0` is best-effort. If a per-user refresh is already queued, we reuse
-    # that pending job and fall back to the live query for this request.
-    if DashboardRollup.dirty?(current_user.id)
-      DashboardRollupRefreshJob.schedule_for(current_user.id, wait: 0.seconds)
-      return
-    end
-
     rows = DashboardRollup.where(user_id: current_user.id).to_a
     total_row = rows.find(&:total_dimension?)
     unless total_row
@@ -247,9 +240,9 @@ module DashboardData
     end
 
     source_max_heartbeat_time = dashboard_rollup_source_max_heartbeat_time
-    if dashboard_rollup_time_fingerprint(total_row.source_max_heartbeat_time) != source_max_heartbeat_time
+    if DashboardRollup.dirty?(current_user.id) ||
+        dashboard_rollup_time_fingerprint(total_row.source_max_heartbeat_time) != source_max_heartbeat_time
       DashboardRollupRefreshJob.schedule_for(current_user.id, wait: 0.seconds)
-      return
     end
 
     grouped_rows = rows.reject(&:total_dimension?).group_by(&:dimension)

--- a/test/controllers/concerns/dashboard_data_test.rb
+++ b/test/controllers/concerns/dashboard_data_test.rb
@@ -164,7 +164,8 @@ class DashboardDataTest < ActiveSupport::TestCase
       end
 
       result = nil
-      assert_enqueued_with(job: DashboardRollupRefreshJob, args: [ user.id ]) do
+      assert_enqueued_with(job: DashboardRollupRefreshJob, args: [ user.id ])
+      assert_no_enqueued_jobs(only: DashboardRollupRefreshJob) do
         result = harness.send(:filterable_dashboard_data)
       end
 

--- a/test/controllers/concerns/dashboard_data_test.rb
+++ b/test/controllers/concerns/dashboard_data_test.rb
@@ -135,7 +135,7 @@ class DashboardDataTest < ActiveSupport::TestCase
     end
   end
 
-  test "stale rollup fingerprint falls back to live data and schedules a refresh" do
+  test "dirty rollup serves last rollup and schedules a refresh" do
     with_memory_cache_store do
       Rails.cache.clear
 
@@ -152,6 +152,52 @@ class DashboardDataTest < ActiveSupport::TestCase
 
       DashboardRollupRefreshService.new(user: user).call
 
+      def harness.dashboard_grouped_durations_snapshot(_scope)
+        raise "expected rollup-backed dashboard path"
+      end
+
+      total_row = DashboardRollup.find_by!(user: user, dimension: DashboardRollup::TOTAL_DIMENSION)
+
+      clear_enqueued_jobs
+      travel 1.minute do
+        create_heartbeat(user, project: "beta", language: "javascript", editor: "zed", operating_system: "linux", category: "coding")
+      end
+
+      result = nil
+      assert_enqueued_with(job: DashboardRollupRefreshJob, args: [ user.id ]) do
+        result = harness.send(:filterable_dashboard_data)
+      end
+
+      assert_equal total_row.total_seconds, result[:total_time]
+      assert_equal total_row.source_heartbeats_count, result[:total_heartbeats]
+      assert_equal "alpha", result["top_project"]
+      assert_equal [ "alpha", "beta" ], result[:project]
+    end
+  end
+
+  test "stale rollup fingerprint serves last rollup and schedules a refresh" do
+    with_memory_cache_store do
+      Rails.cache.clear
+
+      user = User.create!(timezone: "UTC")
+      harness = Harness.new
+      harness.current_user = user
+      harness.params = ActionController::Parameters.new
+
+      travel_to Time.utc(2026, 4, 14, 12, 0, 0) do
+        create_heartbeat(user, project: "alpha", language: "ruby", editor: "vscode", operating_system: "macos", category: "coding")
+        travel 1.minute
+        create_heartbeat(user, project: "alpha", language: "ruby", editor: "vscode", operating_system: "macos", category: "coding")
+      end
+
+      DashboardRollupRefreshService.new(user: user).call
+
+      def harness.dashboard_grouped_durations_snapshot(_scope)
+        raise "expected rollup-backed dashboard path"
+      end
+
+      total_row = DashboardRollup.find_by!(user: user, dimension: DashboardRollup::TOTAL_DIMENSION)
+
       travel 1.minute do
         create_heartbeat(user, project: "beta", language: "javascript", editor: "zed", operating_system: "linux", category: "coding")
       end
@@ -164,8 +210,8 @@ class DashboardDataTest < ActiveSupport::TestCase
         result = harness.send(:filterable_dashboard_data)
       end
 
-      assert_equal user.heartbeats.duration_seconds, result[:total_time]
-      assert_equal user.heartbeats.count, result[:total_heartbeats]
+      assert_equal total_row.total_seconds, result[:total_time]
+      assert_equal total_row.source_heartbeats_count, result[:total_heartbeats]
       assert_equal "alpha", result["top_project"]
       assert_equal [ "alpha", "beta" ], result[:project]
     end


### PR DESCRIPTION
Most people would rather see their time be delayed by 30 seconds or so than have to wait 4-5s after a heartbeat is emitted if the new rollup isn't done yet. This PR implements that!

(FWIW, homepage cache is usually ~20 seconds compared to 5 minutes before, so it's still a win!)