### PR TITLE
Gate Jam scripts behind opt-in query param

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -51,6 +51,9 @@
       <meta name="user-is-viewer" content="<%= current_user.admin_level == 'viewer' %>">
     <% end %>
 
+    <% include_external_scripts = !Rails.env.test? %>
+    <% include_jam_scripts = include_external_scripts && params[:jam].present? %>
+
     <%= yield :head %>
 
     <!-- JSON-LD Structured Data -->
@@ -197,12 +200,14 @@
       <%= sanitize Sentry.get_trace_propagation_meta, tags: %w[meta], attributes: %w[name content] %>
     <% end %>
 
-    <!-- Lets users record their screen from your site -->
-    <meta name="jam:team" content="a5978e52-2479-4dd3-9883-593aa7a4f121">
-    <script type="module" src="https://js.jam.dev/recorder.js"></script>
+    <% if include_jam_scripts %>
+      <!-- Lets users record their screen from your site -->
+      <meta name="jam:team" content="a5978e52-2479-4dd3-9883-593aa7a4f121">
+      <script type="module" src="https://js.jam.dev/recorder.js"></script>
 
-    <!-- Captures user events and developer logs -->
-    <script type="module" src="https://js.jam.dev/capture.js"></script>
+      <!-- Captures user events and developer logs -->
+      <script type="module" src="https://js.jam.dev/capture.js"></script>
+    <% end %>
 
     <!--
       If using a TypeScript entrypoint file:

--- a/app/views/layouts/inertia.html.erb
+++ b/app/views/layouts/inertia.html.erb
@@ -39,10 +39,11 @@
     <% end %>
 
     <% include_external_scripts = !Rails.env.test? %>
+    <% include_jam_scripts = include_external_scripts && params[:jam].present? %>
 
     <%= yield :head %>
 
-    <% if include_external_scripts %>
+    <% if include_jam_scripts %>
       <!-- Lets users record their screen from your site -->
       <meta name="jam:team" content="a5978e52-2479-4dd3-9883-593aa7a4f121">
       <script type="module" src="https://js.jam.dev/recorder.js"></script>

--- a/test/controllers/static_pages_controller_test.rb
+++ b/test/controllers/static_pages_controller_test.rb
@@ -1,28 +1,6 @@
 require "test_helper"
 
 class StaticPagesControllerTest < ActionDispatch::IntegrationTest
-  test "does not include Jam scripts by default" do
-    user = User.create!(timezone: "UTC")
-    sign_in_as(user)
-
-    get root_path
-
-    assert_response :success
-    assert_not_includes response.body, "https://js.jam.dev/recorder.js"
-    assert_not_includes response.body, "https://js.jam.dev/capture.js"
-  end
-
-  test "does not include Jam scripts in test env even with jam query param" do
-    user = User.create!(timezone: "UTC")
-    sign_in_as(user)
-
-    get root_path(jam: "1")
-
-    assert_response :success
-    assert_not_includes response.body, "https://js.jam.dev/recorder.js"
-    assert_not_includes response.body, "https://js.jam.dev/capture.js"
-  end
-
   test "signed in homepage dashboard stats preserves grouped durations and weekly project stats" do
     travel_to Time.utc(2026, 4, 14, 12, 0, 0) do
       user = User.create!(timezone: "UTC")

--- a/test/controllers/static_pages_controller_test.rb
+++ b/test/controllers/static_pages_controller_test.rb
@@ -1,6 +1,28 @@
 require "test_helper"
 
 class StaticPagesControllerTest < ActionDispatch::IntegrationTest
+  test "does not include Jam scripts by default" do
+    user = User.create!(timezone: "UTC")
+    sign_in_as(user)
+
+    get root_path
+
+    assert_response :success
+    assert_not_includes response.body, "https://js.jam.dev/recorder.js"
+    assert_not_includes response.body, "https://js.jam.dev/capture.js"
+  end
+
+  test "does not include Jam scripts in test env even with jam query param" do
+    user = User.create!(timezone: "UTC")
+    sign_in_as(user)
+
+    get root_path(jam: "1")
+
+    assert_response :success
+    assert_not_includes response.body, "https://js.jam.dev/recorder.js"
+    assert_not_includes response.body, "https://js.jam.dev/capture.js"
+  end
+
   test "signed in homepage dashboard stats preserves grouped durations and weekly project stats" do
     travel_to Time.utc(2026, 4, 14, 12, 0, 0) do
       user = User.create!(timezone: "UTC")


### PR DESCRIPTION
~2MB bundle is being loaded each time, which is super wasteful. This PR only loads it in when you explicitly ask for it.