### PR TITLE
Split Inertia pages and prefetch likely routes

### DIFF
--- a/app/javascript/entrypoints/inertia.ts
+++ b/app/javascript/entrypoints/inertia.ts
@@ -11,17 +11,49 @@ const pages = import.meta.glob<InertiaPageModule>("../pages/**/*.svelte");
 
 const prefetchedPages = new Set<string>();
 
+function currentPageName(): string | null {
+  if (typeof document === "undefined") return null;
+
+  const pageJson = document.getElementById("app")?.dataset.page;
+  if (!pageJson) return null;
+
+  try {
+    const page = JSON.parse(pageJson) as { component?: string };
+    return typeof page.component === "string" ? page.component : null;
+  } catch {
+    return null;
+  }
+}
+
+function likelyNextPages(pageName: string | null): string[] {
+  switch (pageName) {
+    case "Home/SignedOut":
+    case "Auth/SignIn":
+      return ["Home/SignedIn"];
+    case "Home/SignedIn":
+      return ["WakatimeSetup/Index"];
+    default:
+      return [];
+  }
+}
+
 function prefetchPage(name: string) {
   const pagePath = `../pages/${name}.svelte`;
   const loadPage = pages[pagePath];
   if (!loadPage || prefetchedPages.has(pagePath)) return;
 
   prefetchedPages.add(pagePath);
-  void loadPage();
+  void loadPage().catch((error) => {
+    prefetchedPages.delete(pagePath);
+    console.debug(
+      `Failed to prefetch Inertia page component: '${name}.svelte'`,
+      error,
+    );
+  });
 }
 
 function prefetchLikelyNextPages() {
-  ["WakatimeSetup/Index", "Home/SignedIn"].forEach(prefetchPage);
+  likelyNextPages(currentPageName()).forEach(prefetchPage);
 }
 
 function schedulePrefetch() {
@@ -44,7 +76,6 @@ createInertiaApp({
   resolve: async (name) => {
     const loadPage = pages[`../pages/${name}.svelte`];
     if (!loadPage) {
-      console.error(`Missing Inertia page component: '${name}.svelte'`);
       throw new Error(`Missing Inertia page component: '${name}.svelte'`);
     }
 

--- a/app/javascript/entrypoints/inertia.ts
+++ b/app/javascript/entrypoints/inertia.ts
@@ -2,9 +2,38 @@ import "@fontsource-variable/spline-sans";
 import { createInertiaApp, type ResolvedComponent } from "@inertiajs/svelte";
 import AppLayout from "../layouts/AppLayout.svelte";
 
-const pages = import.meta.glob<ResolvedComponent>("../pages/**/*.svelte", {
-  eager: true,
-});
+type InertiaPageModule = {
+  default: ResolvedComponent["default"];
+  layout?: ResolvedComponent["layout"] | false;
+};
+
+const pages = import.meta.glob<InertiaPageModule>("../pages/**/*.svelte");
+
+const prefetchedPages = new Set<string>();
+
+function prefetchPage(name: string) {
+  const pagePath = `../pages/${name}.svelte`;
+  const loadPage = pages[pagePath];
+  if (!loadPage || prefetchedPages.has(pagePath)) return;
+
+  prefetchedPages.add(pagePath);
+  void loadPage();
+}
+
+function prefetchLikelyNextPages() {
+  ["WakatimeSetup/Index", "Home/SignedIn"].forEach(prefetchPage);
+}
+
+function schedulePrefetch() {
+  if (typeof window === "undefined") return;
+
+  if ("requestIdleCallback" in window) {
+    window.requestIdleCallback(prefetchLikelyNextPages, { timeout: 1500 });
+    return;
+  }
+
+  globalThis.setTimeout(prefetchLikelyNextPages, 400);
+}
 
 createInertiaApp({
   // see https://inertia-rails.dev/guide/progress-indicators
@@ -12,11 +41,14 @@ createInertiaApp({
     color: "var(--color-primary)",
   },
 
-  resolve: (name) => {
-    const component = pages[`../pages/${name}.svelte`];
-    if (!component) {
+  resolve: async (name) => {
+    const loadPage = pages[`../pages/${name}.svelte`];
+    if (!loadPage) {
       console.error(`Missing Inertia page component: '${name}.svelte'`);
+      throw new Error(`Missing Inertia page component: '${name}.svelte'`);
     }
+
+    const component = await loadPage();
 
     const layout =
       component.layout === false ? undefined : component.layout || AppLayout;
@@ -29,3 +61,5 @@ createInertiaApp({
     },
   },
 });
+
+schedulePrefetch();


### PR DESCRIPTION
We were fetching a 1MB Inertia bundle on every single page load, which was brutal for performance. We now split these!

There is a _slight_ latency penalty when navigating to other pages for the first time, but the JS bundles should be cached and most of them are ~20KB now.

## Before

```
../../public/vite-dev/.vite/manifest-assets.json                                 0.00 kB │ gzip:   0.02 kB
../../public/vite-dev/.vite/manifest.json                                        1.59 kB │ gzip:   0.39 kB
../../public/vite-dev/assets/spline-sans-latin-ext-wght-normal-DGzmlScV.woff2   21.11 kB
../../public/vite-dev/assets/spline-sans-latin-wght-normal-DI10v4rJ.woff2       57.98 kB
../../public/vite-dev/assets/inertia-CUvW_Vbf.css                                1.26 kB │ gzip:   0.56 kB
../../public/vite-dev/assets/application-BMkpKggB.css                          158.52 kB │ gzip:  23.24 kB
../../public/vite-dev/assets/rails_modals-D9DePF5F.js                            1.87 kB │ gzip:   0.90 kB
../../public/vite-dev/assets/Modal-C7Q_EUjF.js                                  97.10 kB │ gzip:  33.82 kB
../../public/vite-dev/assets/inertia-D9eJ6UhU.js                               946.03 kB │ gzip: 295.14 kB
```

## After

```
../../public/vite-test/.vite/manifest-assets.json                                 0.00 kB │ gzip:   0.02 kB
../../public/vite-test/assets/spline-sans-latin-ext-wght-normal-DGzmlScV.woff2   21.11 kB
../../public/vite-test/.vite/manifest.json                                       33.74 kB │ gzip:   3.54 kB
../../public/vite-test/assets/spline-sans-latin-wght-normal-DI10v4rJ.woff2       57.98 kB
../../public/vite-test/assets/ticks-D4tssnxQ.css                                  0.15 kB │ gzip:   0.11 kB
../../public/vite-test/assets/Select-CV-KWLNP.css                                 0.29 kB │ gzip:   0.15 kB
../../public/vite-test/assets/inertia-DR1AF8IK.css                                0.82 kB │ gzip:   0.40 kB
../../public/vite-test/assets/application-BMkpKggB.css                          158.52 kB │ gzip:  23.24 kB
../../public/vite-test/assets/legacy-DEVfVUpQ.js                                  0.05 kB │ gzip:   0.07 kB
../../public/vite-test/assets/TodaySentenceSkeleton-CsnMjZSO.js                   0.25 kB │ gzip:   0.22 kB
../../public/vite-test/assets/svelte-head-BDQIQp8z.js                             0.38 kB │ gzip:   0.28 kB
../../public/vite-test/assets/lifecycle-CLJjGzmY.js                               0.53 kB │ gzip:   0.34 kB
../../public/vite-test/assets/ActivityGraphSkeleton-BPqKf3s3.js                   0.61 kB │ gzip:   0.42 kB
../../public/vite-test/assets/html-BgEGDtRH.js                                    0.73 kB │ gzip:   0.47 kB
../../public/vite-test/assets/New-SQfDj49b.js                                     0.76 kB │ gzip:   0.50 kB
../../public/vite-test/assets/Edit-BP0KDU0x.js                                    0.76 kB │ gzip:   0.51 kB
../../public/vite-test/assets/clone-Bc9woL2n.js                                   0.77 kB │ gzip:   0.43 kB
../../public/vite-test/assets/hidden-input-BP0zz528.js                            0.88 kB │ gzip:   0.54 kB
../../public/vite-test/assets/StatCard-BDe11ZUg.js                                0.97 kB │ gzip:   0.63 kB
../../public/vite-test/assets/SetupNotice-DwwIzVY5.js                             1.00 kB │ gzip:   0.62 kB
../../public/vite-test/assets/Deferred-Bhqw1iWI.js                                1.01 kB │ gzip:   0.62 kB
../../public/vite-test/assets/CTASection-gcGk5SZI.js                              1.03 kB │ gzip:   0.66 kB
../../public/vite-test/assets/NotFound-B5_bmhJ-.js                                1.12 kB │ gzip:   0.71 kB
../../public/vite-test/assets/DashboardSkeleton-BvXUI1Nq.js                       1.42 kB │ gzip:   0.60 kB
../../public/vite-test/assets/Error-Ce8zNdtf.js                                   1.42 kB │ gzip:   0.84 kB
../../public/vite-test/assets/SectionCard--XMcHJyw.js                             1.47 kB │ gzip:   0.82 kB
../../public/vite-test/assets/ProjectTimeline-CLckygu7.js                         1.48 kB │ gzip:   0.84 kB
../../public/vite-test/assets/TodaySentence-DRrQxfaA.js                           1.48 kB │ gzip:   0.75 kB
../../public/vite-test/assets/GitHubLinkBanner-DUsLNSS-.js                        1.52 kB │ gzip:   0.92 kB
../../public/vite-test/assets/DestructiveActionModal-Dab66tnK.js                  1.52 kB │ gzip:   0.88 kB
../../public/vite-test/assets/Stepper-RX5ERzw9.js                                 1.53 kB │ gzip:   0.84 kB
../../public/vite-test/assets/SubsectionNav-DJYbShCF.js                           1.56 kB │ gzip:   0.94 kB
../../public/vite-test/assets/ActivityGraph-CDdAk6S2.js                           1.56 kB │ gzip:   0.87 kB
../../public/vite-test/assets/FAQSection-DpgJzyIr.js                              1.57 kB │ gzip:   0.73 kB
../../public/vite-test/assets/HowItWorks-DpYNOLkm.js                              1.58 kB │ gzip:   0.67 kB
../../public/vite-test/assets/HorizontalBarList-DWzMJeUx.js                       1.66 kB │ gzip:   0.96 kB
../../public/vite-test/assets/PhilosophySection-CTmkTavw.js                       1.69 kB │ gzip:   0.81 kB
../../public/vite-test/assets/input-CFNPqipM.js                                   1.75 kB │ gzip:   0.89 kB
../../public/vite-test/assets/arrays-z9Z6FTo8.js                                  1.75 kB │ gzip:   0.70 kB
../../public/vite-test/assets/Show-qUbK_4B_.js                                    1.84 kB │ gzip:   1.04 kB
../../public/vite-test/assets/SignIn-BCOJqN8-.js                                  1.90 kB │ gzip:   0.98 kB
../../public/vite-test/assets/rails_modals-mma-JhWC.js                            1.90 kB │ gzip:   0.92 kB
../../public/vite-test/assets/BanNotice-lhK7lHp8.js                               2.19 kB │ gzip:   1.18 kB
../../public/vite-test/assets/EditorGrid-B8fZvggm.js                              2.33 kB │ gzip:   1.18 kB
../../public/vite-test/assets/MarketingFooter-CP25XIXR.js                         2.45 kB │ gzip:   0.92 kB
../../public/vite-test/assets/Step2-BBU7Atei.js                                   2.46 kB │ gzip:   1.20 kB
../../public/vite-test/assets/WakatimeDownloadLink--9hhWjZh.js                    2.48 kB │ gzip:   1.33 kB
../../public/vite-test/assets/Notifications-DfoJFrYM.js                           2.67 kB │ gzip:   1.40 kB
../../public/vite-test/assets/Index-CDNwc0aA.js                                   2.74 kB │ gzip:   1.33 kB
../../public/vite-test/assets/Step4-Bf9svDKT.js                                   2.80 kB │ gzip:   1.49 kB
../../public/vite-test/assets/SocialProofUsers-5rWZievp.js                        2.82 kB │ gzip:   1.25 kB
../../public/vite-test/assets/SignedIn-C1grKzTj.js                                3.55 kB │ gzip:   1.66 kB
../../public/vite-test/assets/GoalsProgressCard-bReaqTKS.js                       3.87 kB │ gzip:   1.87 kB
../../public/vite-test/assets/AuthForm-Csjjk4ZQ.js                                3.89 kB │ gzip:   1.73 kB
../../public/vite-test/assets/FeaturesGrid-DqHI9Oph.js                            4.46 kB │ gzip:   2.05 kB
../../public/vite-test/assets/Dashboard-B0H1_Uwz.js                               5.05 kB │ gzip:   1.80 kB
../../public/vite-test/assets/Index-DjJRVQZ6.js                                   5.30 kB │ gzip:   2.10 kB
../../public/vite-test/assets/SignedOut-BSdu7dwj.js                               5.78 kB │ gzip:   2.40 kB
../../public/vite-test/assets/MultiSelect-D0XOg71X.js                             5.93 kB │ gzip:   2.68 kB
../../public/vite-test/assets/Access-DkhFNrsD.js                                  5.94 kB │ gzip:   2.63 kB
../../public/vite-test/assets/IntervalSelect-OGF_391q.js                          6.06 kB │ gzip:   2.54 kB
../../public/vite-test/assets/Shell-D7vT8HGK.js                                   6.06 kB │ gzip:   2.45 kB
../../public/vite-test/assets/New-BerinTJ9.js                                     6.13 kB │ gzip:   2.58 kB
../../public/vite-test/assets/Badges-DWFVUwi_.js                                  6.17 kB │ gzip:   2.35 kB
../../public/vite-test/assets/checkbox-DvIL4GNE.js                                6.22 kB │ gzip:   2.15 kB
../../public/vite-test/assets/Form-lL3kqdVY.js                                    6.41 kB │ gzip:   2.37 kB
../../public/vite-test/assets/Index-C90nMIrX.js                                   6.58 kB │ gzip:   2.31 kB
../../public/vite-test/assets/Show-4YBZc8xk.js                                    6.89 kB │ gzip:   2.42 kB
../../public/vite-test/assets/Show-CtR1z3_s.js                                    6.98 kB │ gzip:   2.61 kB
../../public/vite-test/assets/radio-group-item-DaEIpt-7.js                        7.74 kB │ gzip:   2.76 kB
../../public/vite-test/assets/Integrations-CtZS2aJx.js                            8.27 kB │ gzip:   3.14 kB
../../public/vite-test/assets/Profile-1oqrZtcR.js                                 8.35 kB │ gzip:   2.99 kB
../../public/vite-test/assets/Show-B_wkF74-.js                                    9.44 kB │ gzip:   3.28 kB
../../public/vite-test/assets/Index-OuBudW85.js                                  10.19 kB │ gzip:   3.87 kB
../../public/vite-test/assets/WakatimeAlternative-CnlXdT_H.js                    10.50 kB │ gzip:   3.89 kB
../../public/vite-test/assets/Index-DzNIC_86.js                                  10.52 kB │ gzip:   3.38 kB
../../public/vite-test/assets/Goals-ChyoniV8.js                                  12.92 kB │ gzip:   5.07 kB
../../public/vite-test/assets/AccountMerger-CJZwpuB-.js                          13.14 kB │ gzip:   4.09 kB
../../public/vite-test/assets/popover-D-rRHGJv.js                                14.43 kB │ gzip:   4.27 kB
../../public/vite-test/assets/Data-Budlwiah.js                                   14.75 kB │ gzip:   5.03 kB
../../public/vite-test/assets/Index-C6gy0ZRd.js                                  14.76 kB │ gzip:   5.62 kB
../../public/vite-test/assets/Form-BKmlG8Mb.js                                   15.86 kB │ gzip:   6.28 kB
../../public/vite-test/assets/Step3-BYWqqs7e.js                                  17.62 kB │ gzip:   4.83 kB
../../public/vite-test/assets/PieChart-BGEOm0id.js                               18.98 kB │ gzip:   7.13 kB
../../public/vite-test/assets/Select-CEZe6r7Q.js                                 26.59 kB │ gzip:   7.64 kB
../../public/vite-test/assets/popper-layer-force-mount-CUnks-nu.js               40.24 kB │ gzip:  12.77 kB
../../public/vite-test/assets/ProjectTimelineChart-BnDgUQmX.js                   59.42 kB │ gzip:  18.66 kB
../../public/vite-test/assets/Modal-BEpKyt9-.js                                  96.55 kB │ gzip:  33.59 kB
../../public/vite-test/assets/inertia-BQpv3iqa.js                               148.29 kB │ gzip:  50.07 kB
../../public/vite-test/assets/ticks-CTcCMpAm.js                                 346.02 kB │ gzip: 120.65 kB
```