### PR TITLE
Map user agent IDs during WakaTime imports

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -174,7 +174,7 @@ module ApplicationHelper
     return "Unknown" if editor.blank?
 
     case editor.downcase
-    when "vscode", "vs code" then "VS Code"
+    when "vscode", "vs code" then "VSCode"
     when "pycharm" then "PyCharm"
     when "intellij", "intellijidea" then "IntelliJ IDEA"
     when "webstorm" then "WebStorm"

--- a/app/jobs/heartbeat_import_remote_download_job.rb
+++ b/app/jobs/heartbeat_import_remote_download_job.rb
@@ -29,7 +29,10 @@ class HeartbeatImportRemoteDownloadJob < ApplicationJob
     )
 
     file_content = client.download_dump(download_url)
-    file_path = HeartbeatImportRunner.persist_remote_download(run:, file_content:)
+    import_context = if run.wakatime_dump?
+      { user_agents_by_id: client.list_user_agents.index_by { |user_agent| user_agent[:id] } }
+    end
+    file_path = HeartbeatImportRunner.persist_remote_download(run:, file_content:, import_context:)
 
     HeartbeatImportJob.perform_later(run.id, file_path)
   rescue HeartbeatImportDumpClient::AuthenticationError, HeartbeatImportDumpClient::RequestError => e

--- a/app/lib/language_utils.rb
+++ b/app/lib/language_utils.rb
@@ -46,12 +46,42 @@ module LanguageUtils
     end
   end
 
+  def self.filename_map
+    @filename_map ||= begin
+      map = {}
+      data.each do |name, info|
+        (info["filenames"] || []).each { |filename| map[filename.downcase] = name }
+      end
+      map
+    end
+  end
+
+  def self.blank_or_unknown?(raw)
+    raw.blank? || raw.to_s.strip.casecmp("unknown").zero?
+  end
+
+  def self.detect_from_filename(entity)
+    return nil if entity.blank?
+
+    filename_map[File.basename(entity).downcase]
+  end
+
   # Detect language from a file entity's extension.
   def self.detect_from_extension(entity)
     return nil if entity.blank?
     ext = File.extname(entity).downcase
     return nil if ext.blank?
     extension_map[ext]
+  end
+
+  def self.detect_from_entity(entity)
+    detect_from_filename(entity) || detect_from_extension(entity)
+  end
+
+  def self.fill_missing_language(raw, entity:)
+    return raw unless blank_or_unknown?(raw)
+
+    detect_from_entity(entity)
   end
 
   # Canonical display name: "js" → "JavaScript", "cpp" → "C++"

--- a/app/services/heartbeat_import_dump_client.rb
+++ b/app/services/heartbeat_import_dump_client.rb
@@ -58,6 +58,11 @@ class HeartbeatImportDumpClient
     raise TransientError, e.message
   end
 
+  def list_user_agents
+    body = request_json(method: :get, path: "/users/current/user_agents")
+    Array(body["data"]).map { |user_agent| normalize_user_agent(user_agent) }
+  end
+
   def self.base_url_for(source_kind)
     BASE_URLS.fetch(source_kind.to_s)
   end
@@ -139,6 +144,17 @@ class HeartbeatImportDumpClient
       has_failed: ActiveModel::Type::Boolean.new.cast(payload[:has_failed]),
       expires: payload[:expires],
       created_at: payload[:created_at]
+    }
+  end
+
+  def normalize_user_agent(user_agent)
+    payload = user_agent.respond_to?(:with_indifferent_access) ? user_agent.with_indifferent_access : user_agent.to_h.with_indifferent_access
+
+    {
+      id: payload[:id].to_s,
+      value: payload[:value].to_s,
+      editor: payload[:editor].presence,
+      os: payload[:os].presence
     }
   end
 

--- a/app/services/heartbeat_import_runner.rb
+++ b/app/services/heartbeat_import_runner.rb
@@ -182,10 +182,13 @@ class HeartbeatImportRunner < ApplicationService
     report_error(e, message: "HeartbeatImportDumpJob failed") # Track unexpected errors
   ensure
     FileUtils.rm_f(file_path) if file_path.present?
+    FileUtils.rm_f(import_context_path_for(file_path)) if file_path.present?
     ActiveRecord::Base.connection_pool.release_connection
   end
 
   def self.import_file_streaming(file_path, user, run)
+    import_context = load_import_context(file_path)
+
     File.open(file_path, "rb") do |file|
       magic_bytes = file.read(2)
       file.rewind
@@ -200,6 +203,7 @@ class HeartbeatImportRunner < ApplicationService
         result = HeartbeatImportService.import_from_file(
           io,
           user,
+          user_agents_by_id: import_context.fetch("user_agents_by_id", {}),
           progress_interval: PROGRESS_INTERVAL,
           on_progress: lambda { |processed_count|
             run.update_columns(
@@ -227,12 +231,31 @@ class HeartbeatImportRunner < ApplicationService
     file_path.to_s
   end
 
-  def self.persist_remote_download(run:, file_content:)
+  def self.persist_remote_download(run:, file_content:, import_context: nil)
     FileUtils.mkdir_p(TMP_DIR)
 
     file_path = TMP_DIR.join("#{run.id}-remote.json")
     File.binwrite(file_path, file_content) # Write raw bytes, let run_import handle decompression
+
+    if import_context.present?
+      File.write(import_context_path_for(file_path.to_s), JSON.generate(import_context))
+    end
+
     file_path.to_s
+  end
+
+  def self.import_context_path_for(file_path)
+    "#{file_path}.context.json"
+  end
+
+  def self.load_import_context(file_path)
+    context_path = import_context_path_for(file_path)
+    return {} unless File.exist?(context_path)
+
+    JSON.parse(File.read(context_path))
+  rescue JSON::ParserError => e
+    report_error(e, message: "Failed to parse heartbeat import context for #{file_path}")
+    {}
   end
 
   def self.queue_remote_download(run:, download_url:, remote_dump_status: nil, remote_percent_complete: nil)

--- a/app/services/heartbeat_import_service.rb
+++ b/app/services/heartbeat_import_service.rb
@@ -1,7 +1,7 @@
 class HeartbeatImportService
   BATCH_SIZE = 50_000
 
-  def self.import_from_file(file_content, user, on_progress: nil, progress_interval: 250)
+  def self.import_from_file(file_content, user, on_progress: nil, progress_interval: 250, user_agents_by_id: {})
     start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     user_id = user.id
     imported_count = 0
@@ -15,6 +15,7 @@ class HeartbeatImportService
 
       begin
         time_value = hb["time"].is_a?(String) ? Time.parse(hb["time"]).to_f : hb["time"].to_f
+        normalized = normalize_imported_heartbeat(hb, user_agents_by_id:)
 
         attrs = {
           user_id: user_id,
@@ -23,12 +24,12 @@ class HeartbeatImportService
           type: hb["type"],
           category: hb["category"] || "coding",
           project: hb["project"],
-          language: hb["language"],
-          editor: hb["editor"],
-          operating_system: hb["operating_system"],
-          machine: hb["machine"] || hb["machine_name_id"],
+          language: normalized[:language],
+          editor: normalized[:editor],
+          operating_system: normalized[:operating_system],
+          machine: normalized[:machine],
           branch: hb["branch"],
-          user_agent: hb["user_agent"] || hb["user_agent_id"],
+          user_agent: normalized[:user_agent],
           is_write: hb["is_write"] || false,
           line_additions: hb["line_additions"],
           line_deletions: hb["line_deletions"],
@@ -97,6 +98,22 @@ class HeartbeatImportService
     total_count
   end
 
+  def self.normalize_imported_heartbeat(heartbeat, user_agents_by_id: {})
+    hb = heartbeat.respond_to?(:with_indifferent_access) ? heartbeat.with_indifferent_access : heartbeat.to_h.with_indifferent_access
+    user_agent_id = hb[:user_agent_id].to_s
+    user_agent_info = user_agents_by_id[user_agent_id] || {}
+    resolved_user_agent = hb[:user_agent].presence || user_agent_info[:value].presence || hb[:user_agent_id].presence
+    parsed_user_agent = parse_user_agent(resolved_user_agent)
+
+    {
+      language: LanguageUtils.fill_missing_language(hb[:language], entity: hb[:entity]),
+      editor: hb[:editor].presence || user_agent_info[:editor].presence || parsed_user_agent[:editor].presence,
+      operating_system: hb[:operating_system].presence || user_agent_info[:os].presence || parsed_user_agent[:os].presence,
+      machine: hb[:machine].presence || hb[:machine_name_id].presence,
+      user_agent: resolved_user_agent
+    }
+  end
+
   def self.flush_batch(seen_hashes)
     return 0 if seen_hashes.empty?
 
@@ -112,6 +129,17 @@ class HeartbeatImportService
       result.length
     end
   end
+
+  def self.parse_user_agent(user_agent)
+    return { editor: nil, os: nil } if user_agent.blank?
+
+    parsed = WakatimeService.parse_user_agent(user_agent)
+    {
+      editor: parsed[:editor].presence,
+      os: parsed[:os].presence
+    }
+  end
+  private_class_method :parse_user_agent
 
   class HeartbeatSaxHandler < Oj::Saj
     def initialize(&block)

--- a/app/services/heartbeat_import_service.rb
+++ b/app/services/heartbeat_import_service.rb
@@ -101,7 +101,7 @@ class HeartbeatImportService
   def self.normalize_imported_heartbeat(heartbeat, user_agents_by_id: {})
     hb = heartbeat.respond_to?(:with_indifferent_access) ? heartbeat.with_indifferent_access : heartbeat.to_h.with_indifferent_access
     user_agent_id = hb[:user_agent_id].to_s
-    user_agent_info = user_agents_by_id[user_agent_id] || {}
+    user_agent_info = (user_agents_by_id[user_agent_id] || {}).with_indifferent_access
     resolved_user_agent = hb[:user_agent].presence || user_agent_info[:value].presence || hb[:user_agent_id].presence
     parsed_user_agent = parse_user_agent(resolved_user_agent)
 

--- a/test/jobs/heartbeat_import_remote_download_job_test.rb
+++ b/test/jobs/heartbeat_import_remote_download_job_test.rb
@@ -36,6 +36,19 @@ class HeartbeatImportRemoteDownloadJobTest < ActiveJob::TestCase
         HeartbeatImportRemoteDownloadJob.perform_now(run.id, "https://wakatime.s3.amazonaws.com/export.json")
       end
     end
+
+    context_path = HeartbeatImportRunner.import_context_path_for(
+      HeartbeatImportRunner::TMP_DIR.join("#{run.id}-remote.json").to_s
+    )
+    context = JSON.parse(File.read(context_path))
+
+    assert_equal "vscode", context.dig("user_agents_by_id", "ua-123", "editor")
+    assert_equal "darwin", context.dig("user_agents_by_id", "ua-123", "os")
+    assert_equal "wakatime/v1.102.1 (darwin-arm64) go1.22.0 vscode/1.0.0",
+      context.dig("user_agents_by_id", "ua-123", "value")
+  ensure
+    FileUtils.rm_f(HeartbeatImportRunner::TMP_DIR.join("#{run.id}-remote.json"))
+    FileUtils.rm_f(context_path) if defined?(context_path)
   end
 
   test "marks the run as failed when the direct download is rejected" do

--- a/test/jobs/heartbeat_import_remote_download_job_test.rb
+++ b/test/jobs/heartbeat_import_remote_download_job_test.rb
@@ -15,6 +15,7 @@ class HeartbeatImportRemoteDownloadJobTest < ActiveJob::TestCase
   end
 
   test "downloads the remote dump and enqueues the import job" do
+    run = nil
     run = User.create!(timezone: "UTC").heartbeat_import_runs.create!(
       source_kind: :wakatime_dump,
       state: :downloading_dump,
@@ -47,7 +48,7 @@ class HeartbeatImportRemoteDownloadJobTest < ActiveJob::TestCase
     assert_equal "wakatime/v1.102.1 (darwin-arm64) go1.22.0 vscode/1.0.0",
       context.dig("user_agents_by_id", "ua-123", "value")
   ensure
-    FileUtils.rm_f(HeartbeatImportRunner::TMP_DIR.join("#{run.id}-remote.json"))
+    FileUtils.rm_f(HeartbeatImportRunner::TMP_DIR.join("#{run.id}-remote.json")) if run
     FileUtils.rm_f(context_path) if defined?(context_path)
   end
 

--- a/test/jobs/heartbeat_import_remote_download_job_test.rb
+++ b/test/jobs/heartbeat_import_remote_download_job_test.rb
@@ -16,15 +16,19 @@ class HeartbeatImportRemoteDownloadJobTest < ActiveJob::TestCase
 
   test "downloads the remote dump and enqueues the import job" do
     run = User.create!(timezone: "UTC").heartbeat_import_runs.create!(
-      source_kind: :wakatime_download_link,
+      source_kind: :wakatime_dump,
       state: :downloading_dump,
       remote_dump_status: "Manual download link received",
-      message: "Downloading data dump..."
+      message: "Downloading data dump...",
+      encrypted_api_key: "secret"
     )
 
     fake_client = Object.new
     fake_client.define_singleton_method(:download_dump) do |_url|
       '{"heartbeats":[]}'
+    end
+    fake_client.define_singleton_method(:list_user_agents) do
+      [ { id: "ua-123", value: "wakatime/v1.102.1 (darwin-arm64) go1.22.0 vscode/1.0.0", editor: "vscode", os: "darwin" } ]
     end
 
     with_dump_client(fake_client) do


### PR DESCRIPTION
Unlike Hackatime v1, WakaTime uses user agent IDs to save storage space (side note: actually not a bad idea), but we were mistakenly using the user agent IDs as the user agent string itself. This PR fixes that!