### PR TITLE
Precompute filters, today's sentence, and activity graph

### DIFF
--- a/app/controllers/concerns/dashboard_data.rb
+++ b/app/controllers/concerns/dashboard_data.rb
@@ -3,13 +3,14 @@ module DashboardData
 
   FILTER_OPTIONS_CACHE_VERSION = "v1".freeze
   WEEKLY_PROJECT_DIMENSION = "weekly_project".freeze
+  DASHBOARD_TIMEZONE_SETTINGS_PATH = "/my/settings#user_timezone".freeze
 
   private
 
   def filterable_dashboard_data
     filters = dashboard_filters
     interval = params[:interval]
-    key = [ current_user ] + filters.map { |f| params[f] } + [ interval.to_s, params[:from], params[:to] ]
+    key = [ current_user ] + filters.map { |field| params[field] } + [ interval.to_s, params[:from], params[:to] ]
 
     if dashboard_rollup_eligible?
       build_filterable_dashboard_data(filters, interval)
@@ -21,54 +22,19 @@ module DashboardData
   end
 
   def activity_graph_data
-    tz = current_user.timezone
-    key = "user_#{current_user.id}_daily_durations_#{tz}"
-    durations = Rails.cache.fetch(key, expires_in: 1.minute) do
-      Time.use_zone(tz) { current_user.heartbeats.daily_durations(user_timezone: tz).to_h }
-    end
+    row = dashboard_rollup_fragment_row(DashboardRollup::ACTIVITY_GRAPH_DIMENSION)
+    return dashboard_activity_graph_from_rollup(row) if dashboard_activity_graph_rollup_valid?(row)
 
-    {
-      start_date: 365.days.ago.to_date.iso8601,
-      end_date: Time.current.to_date.iso8601,
-      duration_by_date: durations.transform_keys { |d| d.to_date.iso8601 }.transform_values(&:to_i),
-      busiest_day_seconds: 8.hours.to_i,
-      timezone_label: ActiveSupport::TimeZone[tz].to_s,
-      timezone_settings_path: "/my/settings#user_timezone"
-    }
+    dashboard_schedule_rollup_refresh(wait: 0.seconds) if dashboard_rollups_available?
+    dashboard_live_activity_graph_data
   end
 
   def today_stats_data
-    h = ApplicationController.helpers
-    Time.use_zone(current_user.timezone) do
-      rows = current_user.heartbeats.today
-        .select(:language, :editor,
-                "COUNT(*) OVER (PARTITION BY language) as language_count",
-                "COUNT(*) OVER (PARTITION BY editor) as editor_count")
-        .distinct.to_a
+    row = dashboard_rollup_fragment_row(DashboardRollup::TODAY_STATS_DIMENSION)
+    return dashboard_today_stats_from_rollup(row) if dashboard_today_stats_rollup_valid?(row)
 
-      lang_counts = rows
-        .map { |r| [ r.language&.categorize_language, r.language_count ] }
-        .reject { |l, _| l.blank? }
-        .group_by(&:first).transform_values { |p| p.sum(&:last) }
-        .sort_by { |_, c| -c }
-
-      ed_counts = rows
-        .map { |r| [ r.editor, r.editor_count ] }
-        .reject { |e, _| e.blank? }.uniq
-        .sort_by { |_, c| -c }
-
-      todays_languages = lang_counts.map { |l, _| h.display_language_name(l) }
-      todays_editors = ed_counts.map { |e, _| h.display_editor_name(e) }
-      todays_duration = current_user.heartbeats.today.duration_seconds
-      show_logged_time_sentence = todays_duration > 1.minute && (todays_languages.any? || todays_editors.any?)
-
-      {
-        show_logged_time_sentence: show_logged_time_sentence,
-        todays_duration_display: h.short_time_detailed(todays_duration.to_i),
-        todays_languages: todays_languages,
-        todays_editors: todays_editors
-      }
-    end
+    dashboard_schedule_rollup_refresh(wait: 0.seconds) if dashboard_rollups_available?
+    dashboard_live_today_stats_data
   end
 
   def dashboard_filters
@@ -84,12 +50,21 @@ module DashboardData
     result[:selected_interval] = interval.to_s
     result[:selected_from] = params[:from].to_s
     result[:selected_to] = params[:to].to_s
-    filters.each { |f| result["selected_#{f}"] = params[f]&.split(",") || [] }
+    filters.each { |field| result["selected_#{field}"] = params[field]&.split(",") || [] }
 
     result
   end
 
   def dashboard_raw_filter_options
+    if dashboard_rollup_eligible?
+      rollup_options = dashboard_rollup_filter_options
+      return rollup_options if rollup_options
+    end
+
+    dashboard_live_raw_filter_options
+  end
+
+  def dashboard_live_raw_filter_options
     cache_keys = dashboard_filters.index_with do |field|
       "user_#{current_user.id}_dashboard_filter_options_#{field}_#{FILTER_OPTIONS_CACHE_VERSION}"
     end
@@ -101,6 +76,21 @@ module DashboardData
     end
 
     cache_keys.transform_values { |cache_key| cached.fetch(cache_key, []) }
+  end
+
+  def dashboard_rollup_filter_options
+    return unless dashboard_rollups_available?
+
+    row = dashboard_rollup_fragment_row(DashboardRollup::FILTER_OPTIONS_DIMENSION)
+    payload = row&.payload
+    unless payload.is_a?(Hash) && dashboard_filters.all? { |field| payload[field.to_s].is_a?(Array) || payload[field].is_a?(Array) }
+      dashboard_schedule_rollup_refresh(wait: 0.seconds)
+      return
+    end
+
+    dashboard_filters.index_with do |field|
+      Array(payload[field.to_s] || payload[field])
+    end
   end
 
   def dashboard_query_result(raw_filter_options, archived)
@@ -138,7 +128,7 @@ module DashboardData
   end
 
   def dashboard_rollup_result(raw_filter_options, archived)
-    snapshot = dashboard_rollup_snapshot
+    snapshot = dashboard_aggregate_rollup_snapshot
     return unless snapshot
 
     result = dashboard_filter_options_result(raw_filter_options, archived)
@@ -228,32 +218,27 @@ module DashboardData
     end
   end
 
-  def dashboard_rollup_snapshot
+  def dashboard_aggregate_rollup_snapshot
     return unless dashboard_rollups_available?
     return unless dashboard_rollup_eligible?
 
-    rows = DashboardRollup.where(user_id: current_user.id).to_a
-    total_row = rows.find(&:total_dimension?)
+    total_row = dashboard_rollup_total_row
     unless total_row
-      DashboardRollupRefreshJob.schedule_for(current_user.id, wait: 0.seconds)
+      dashboard_schedule_rollup_refresh(wait: 0.seconds)
       return
     end
 
-    if DashboardRollup.dirty?(current_user.id)
-      DashboardRollupRefreshJob.schedule_for(current_user.id, wait: 0.seconds)
-    elsif dashboard_rollup_time_fingerprint(total_row.source_max_heartbeat_time) != dashboard_rollup_source_max_heartbeat_time
-      DashboardRollupRefreshJob.schedule_for(current_user.id, wait: 0.seconds)
-    end
-
-    grouped_rows = rows.reject(&:total_dimension?).group_by(&:dimension)
+    dashboard_schedule_rollup_refresh(wait: 0.seconds) if dashboard_aggregate_rollup_stale?(total_row)
 
     {
       total_time: total_row.total_seconds,
       total_heartbeats: total_row.source_heartbeats_count.to_i,
       grouped_durations: dashboard_filters.index_with do |field|
-        grouped_rows.fetch(field.to_s, []).to_h { |row| [ row.bucket, row.total_seconds ] }
+        dashboard_rollup_rows_by_dimension.fetch(field.to_s, []).to_h { |row| [ row.bucket, row.total_seconds ] }
       end,
-      weekly_project_stats: dashboard_rollup_weekly_project_stats(grouped_rows.fetch(WEEKLY_PROJECT_DIMENSION, []))
+      weekly_project_stats: dashboard_rollup_weekly_project_stats(
+        dashboard_rollup_rows_by_dimension.fetch(WEEKLY_PROJECT_DIMENSION, [])
+      )
     }
   end
 
@@ -268,6 +253,175 @@ module DashboardData
     DashboardRollup.table_exists?
   rescue ActiveRecord::StatementInvalid
     false
+  end
+
+  def dashboard_rollup_rows
+    return [] unless dashboard_rollups_available?
+
+    @dashboard_rollup_rows ||= DashboardRollup.where(user_id: current_user.id).to_a
+  end
+
+  def dashboard_rollup_rows_by_dimension
+    @dashboard_rollup_rows_by_dimension ||= dashboard_rollup_rows.group_by(&:dimension)
+  end
+
+  def dashboard_rollup_fragment_row(dimension)
+    dashboard_rollup_rows_by_dimension.fetch(dimension.to_s, []).first
+  end
+
+  def dashboard_rollup_total_row
+    @dashboard_rollup_total_row ||= dashboard_rollup_rows.find(&:total_dimension?)
+  end
+
+  def dashboard_aggregate_rollup_stale?(total_row)
+    DashboardRollup.dirty?(current_user.id) ||
+      dashboard_rollup_time_fingerprint(total_row.source_max_heartbeat_time) != dashboard_rollup_source_max_heartbeat_time
+  end
+
+  def dashboard_schedule_rollup_refresh(wait:)
+    return if @dashboard_rollup_refresh_scheduled
+
+    DashboardRollupRefreshJob.schedule_for(current_user.id, wait: wait)
+    @dashboard_rollup_refresh_scheduled = true
+  end
+
+  def dashboard_activity_graph_rollup_valid?(row)
+    payload = row&.payload
+    return false unless payload.is_a?(Hash)
+
+    start_date, end_date = dashboard_activity_graph_date_range(current_user.timezone)
+    payload["timezone"] == current_user.timezone &&
+      payload["start_date"] == start_date &&
+      payload["end_date"] == end_date &&
+      payload["duration_by_date"].is_a?(Hash)
+  end
+
+  def dashboard_today_stats_rollup_valid?(row)
+    payload = row&.payload
+    return false unless payload.is_a?(Hash)
+
+    payload["timezone"] == current_user.timezone &&
+      payload["today_date"] == dashboard_today_date &&
+      payload.key?("todays_duration_seconds") &&
+      payload["todays_language_categories"].is_a?(Array) &&
+      payload["todays_editor_keys"].is_a?(Array)
+  end
+
+  def dashboard_live_activity_graph_data
+    timezone = current_user.timezone
+    start_date, end_date = dashboard_activity_graph_date_range(timezone)
+    durations = Rails.cache.fetch(current_user.activity_graph_cache_key(timezone), expires_in: 1.minute) do
+      Time.use_zone(timezone) { current_user.heartbeats.daily_durations(user_timezone: timezone).to_h }
+    end
+
+    dashboard_activity_graph_result(
+      start_date: start_date,
+      end_date: end_date,
+      duration_by_date: durations,
+      timezone: timezone
+    )
+  end
+
+  def dashboard_activity_graph_from_rollup(row)
+    payload = row.payload || {}
+
+    dashboard_activity_graph_result(
+      start_date: payload["start_date"],
+      end_date: payload["end_date"],
+      duration_by_date: payload["duration_by_date"],
+      timezone: payload["timezone"] || current_user.timezone
+    )
+  end
+
+  def dashboard_activity_graph_result(start_date:, end_date:, duration_by_date:, timezone:)
+    {
+      start_date: start_date,
+      end_date: end_date,
+      duration_by_date: duration_by_date.to_h.transform_keys { |date| date.to_s }.transform_values(&:to_i),
+      busiest_day_seconds: 8.hours.to_i,
+      timezone_label: ActiveSupport::TimeZone[timezone]&.to_s || timezone,
+      timezone_settings_path: DASHBOARD_TIMEZONE_SETTINGS_PATH
+    }
+  end
+
+  def dashboard_live_today_stats_data
+    snapshot = dashboard_today_stats_snapshot(current_user.heartbeats)
+    dashboard_today_stats_result(
+      todays_duration_seconds: snapshot[:todays_duration_seconds],
+      todays_language_categories: snapshot[:todays_language_categories],
+      todays_editor_keys: snapshot[:todays_editor_keys]
+    )
+  end
+
+  def dashboard_today_stats_from_rollup(row)
+    payload = row.payload || {}
+
+    dashboard_today_stats_result(
+      todays_duration_seconds: payload["todays_duration_seconds"],
+      todays_language_categories: payload["todays_language_categories"],
+      todays_editor_keys: payload["todays_editor_keys"]
+    )
+  end
+
+  def dashboard_today_stats_result(todays_duration_seconds:, todays_language_categories:, todays_editor_keys:)
+    h = ApplicationController.helpers
+    todays_languages = Array(todays_language_categories).filter_map do |language|
+      h.display_language_name(language) if language.present?
+    end
+    todays_editors = Array(todays_editor_keys).filter_map do |editor|
+      h.display_editor_name(editor) if editor.present?
+    end
+    todays_duration = todays_duration_seconds.to_i
+    show_logged_time_sentence = todays_duration > 1.minute && (todays_languages.any? || todays_editors.any?)
+
+    {
+      show_logged_time_sentence: show_logged_time_sentence,
+      todays_duration_display: h.short_time_detailed(todays_duration),
+      todays_languages: todays_languages,
+      todays_editors: todays_editors
+    }
+  end
+
+  def dashboard_today_stats_snapshot(scope)
+    Time.use_zone(current_user.timezone) do
+      rows = scope.today
+        .select(:language, :editor,
+                "COUNT(*) OVER (PARTITION BY language) as language_count",
+                "COUNT(*) OVER (PARTITION BY editor) as editor_count")
+        .distinct.to_a
+
+      language_categories = rows
+        .map { |row| [ row.language&.categorize_language, row.language_count ] }
+        .reject { |language, _| language.blank? }
+        .group_by(&:first)
+        .transform_values { |pairs| pairs.sum(&:last) }
+        .sort_by { |_, count| -count }
+        .map(&:first)
+
+      editor_keys = rows
+        .map { |row| [ row.editor, row.editor_count ] }
+        .reject { |editor, _| editor.blank? }
+        .uniq
+        .sort_by { |_, count| -count }
+        .map(&:first)
+
+      {
+        today_date: Date.current.iso8601,
+        todays_duration_seconds: scope.today.duration_seconds.to_i,
+        todays_language_categories: language_categories,
+        todays_editor_keys: editor_keys
+      }
+    end
+  end
+
+  def dashboard_today_date
+    Time.use_zone(current_user.timezone) { Date.current.iso8601 }
+  end
+
+  def dashboard_activity_graph_date_range(timezone)
+    Time.use_zone(timezone) do
+      [ 365.days.ago.to_date.iso8601, Date.current.iso8601 ]
+    end
   end
 
   def dashboard_rollup_source_max_heartbeat_time
@@ -357,9 +511,11 @@ module DashboardData
   end
 
   def dashboard_week_ranges
-    (0..11).map do |w|
-      week_start = w.weeks.ago.beginning_of_week
-      [ week_start.to_date.iso8601, week_start.to_f, w.weeks.ago.end_of_week.to_f ]
+    Time.use_zone(current_user.timezone) do
+      (0..11).map do |week_offset|
+        week_start = week_offset.weeks.ago.beginning_of_week
+        [ week_start.to_date.iso8601, week_start.to_f, week_offset.weeks.ago.end_of_week.to_f ]
+      end
     end
   end
 end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -134,6 +134,8 @@ class StaticPagesController < InertiaController
   end
 
   def signed_in_props
+    dashboard_stats = initial_dashboard_stats_prop
+
     {
       flavor_text: @flavor_text.to_s,
       trust_level_red: current_user&.trust_level == "red",
@@ -144,7 +146,7 @@ class StaticPagesController < InertiaController
       github_uid_blank: current_user&.github_uid.blank?,
       github_auth_path: github_auth_path,
       wakatime_setup_path: my_wakatime_setup_path,
-      dashboard_stats: InertiaRails.defer { dashboard_stats_payload }
+      dashboard_stats: dashboard_stats || InertiaRails.defer { dashboard_stats_payload }
     }
   end
 
@@ -184,5 +186,20 @@ class StaticPagesController < InertiaController
     Rails.cache.fetch(cache_key, expires_in: 1.minute) do
       ProgrammingGoalsProgressService.new(user: current_user, goals: goals).call
     end
+  end
+
+  def initial_dashboard_stats_prop
+    return unless dashboard_rollup_eligible?
+    return unless dashboard_rollups_available?
+
+    rows = DashboardRollup.where(user_id: current_user.id).to_a
+    total_row = rows.find(&:total_dimension?)
+    return unless total_row
+
+    @dashboard_rollup_rows = rows
+    @dashboard_rollup_rows_by_dimension = rows.group_by(&:dimension)
+    @dashboard_rollup_total_row = total_row
+
+    dashboard_stats_payload
   end
 end

--- a/app/models/dashboard_rollup.rb
+++ b/app/models/dashboard_rollup.rb
@@ -1,6 +1,9 @@
 class DashboardRollup < ApplicationRecord
-  DIMENSIONS = %w[total project language editor operating_system category weekly_project].freeze
+  DIMENSIONS = %w[total project language editor operating_system category weekly_project activity_graph today_stats filter_options].freeze
   TOTAL_DIMENSION = "total".freeze
+  ACTIVITY_GRAPH_DIMENSION = "activity_graph".freeze
+  TODAY_STATS_DIMENSION = "today_stats".freeze
+  FILTER_OPTIONS_DIMENSION = "filter_options".freeze
   DIRTY_CACHE_KEY_PREFIX = "dashboard_rollup_dirty".freeze
 
   belongs_to :user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -236,7 +236,8 @@ class User < ApplicationRecord
     compliment_text: 2
   }
 
-  after_save :invalidate_activity_graph_cache, if: :saved_change_to_timezone?
+  after_update_commit :invalidate_activity_graph_cache, if: :saved_change_to_timezone?
+  after_update_commit :schedule_dashboard_rollup_refresh, if: :saved_change_to_timezone?
 
   def flipper_id
     "User;#{id}"
@@ -244,6 +245,10 @@ class User < ApplicationRecord
 
   def active_remote_heartbeat_import_run?
     heartbeat_import_runs.remote_imports.active_imports.exists?
+  end
+
+  def activity_graph_cache_key(timezone = self.timezone)
+    "user_#{id}_daily_durations_#{timezone}"
   end
 
   def format_extension_text(duration)
@@ -340,7 +345,15 @@ class User < ApplicationRecord
   private
 
   def invalidate_activity_graph_cache
-    Rails.cache.delete("user_#{id}_daily_durations")
+    previous_timezone, current_timezone = previous_changes.fetch("timezone", [ nil, timezone ])
+
+    [ previous_timezone, current_timezone ].compact.uniq.each do |cache_timezone|
+      Rails.cache.delete(activity_graph_cache_key(cache_timezone))
+    end
+  end
+
+  def schedule_dashboard_rollup_refresh
+    DashboardRollupRefreshJob.schedule_for(id, wait: 0.seconds)
   end
 
   def track_signup

--- a/app/services/dashboard_rollup_refresh_service.rb
+++ b/app/services/dashboard_rollup_refresh_service.rb
@@ -9,7 +9,13 @@ class DashboardRollupRefreshService < ApplicationService
 
   def call
     now = Time.current
-    records = [ build_total_record(now) ]
+    records = [
+      build_total_record(now),
+      build_filter_options_record(now),
+      build_activity_graph_record(now),
+      build_today_stats_record(now)
+    ]
+
     GROUPED_DIMENSIONS.each do |dimension|
       grouped_durations(dimension).each do |bucket, total_seconds|
         records << build_record(
@@ -52,7 +58,37 @@ class DashboardRollupRefreshService < ApplicationService
     )
   end
 
-  def build_record(dimension:, bucket:, total_seconds:, now:, source_heartbeats_count: nil, source_max_heartbeat_time: nil)
+  def build_activity_graph_record(now)
+    build_record(
+      dimension: DashboardRollup::ACTIVITY_GRAPH_DIMENSION,
+      bucket: nil,
+      total_seconds: 0,
+      now: now,
+      payload: activity_graph_payload
+    )
+  end
+
+  def build_filter_options_record(now)
+    build_record(
+      dimension: DashboardRollup::FILTER_OPTIONS_DIMENSION,
+      bucket: nil,
+      total_seconds: 0,
+      now: now,
+      payload: filter_options_payload
+    )
+  end
+
+  def build_today_stats_record(now)
+    build_record(
+      dimension: DashboardRollup::TODAY_STATS_DIMENSION,
+      bucket: nil,
+      total_seconds: 0,
+      now: now,
+      payload: today_stats_payload
+    )
+  end
+
+  def build_record(dimension:, bucket:, total_seconds:, now:, source_heartbeats_count: nil, source_max_heartbeat_time: nil, payload: nil)
     {
       user_id: @user.id,
       dimension: dimension.to_s,
@@ -61,6 +97,7 @@ class DashboardRollupRefreshService < ApplicationService
       total_seconds: total_seconds.to_i,
       source_heartbeats_count: source_heartbeats_count,
       source_max_heartbeat_time: source_max_heartbeat_time,
+      payload: payload,
       created_at: now,
       updated_at: now
     }
@@ -123,9 +160,65 @@ class DashboardRollupRefreshService < ApplicationService
   end
 
   def dashboard_week_ranges
-    (0..11).map do |w|
-      week_start = w.weeks.ago.beginning_of_week
-      [ week_start.to_date.iso8601, week_start.to_f, w.weeks.ago.end_of_week.to_f ]
+    Time.use_zone(@user.timezone) do
+      (0..11).map do |w|
+        week_start = w.weeks.ago.beginning_of_week
+        [ week_start.to_date.iso8601, week_start.to_f, w.weeks.ago.end_of_week.to_f ]
+      end
+    end
+  end
+
+  def activity_graph_payload
+    Time.use_zone(@user.timezone) do
+      end_date = Date.current
+      start_date = 365.days.ago.to_date
+      durations = @scope.daily_durations(user_timezone: @user.timezone).to_h
+
+      {
+        timezone: @user.timezone,
+        start_date: start_date.iso8601,
+        end_date: end_date.iso8601,
+        duration_by_date: durations.transform_keys { |date| date.to_date.iso8601 }.transform_values(&:to_i)
+      }
+    end
+  end
+
+  def filter_options_payload
+    GROUPED_DIMENSIONS.index_with do |dimension|
+      @scope.distinct.pluck(dimension).compact_blank.sort
+    end
+  end
+
+  def today_stats_payload
+    Time.use_zone(@user.timezone) do
+      rows = @scope.today
+        .select(:language, :editor,
+                "COUNT(*) OVER (PARTITION BY language) as language_count",
+                "COUNT(*) OVER (PARTITION BY editor) as editor_count")
+        .distinct.to_a
+
+      language_categories = rows
+        .map { |row| [ row.language&.categorize_language, row.language_count ] }
+        .reject { |language, _| language.blank? }
+        .group_by(&:first)
+        .transform_values { |pairs| pairs.sum(&:last) }
+        .sort_by { |_, count| -count }
+        .map(&:first)
+
+      editor_keys = rows
+        .map { |row| [ row.editor, row.editor_count ] }
+        .reject { |editor, _| editor.blank? }
+        .uniq
+        .sort_by { |_, count| -count }
+        .map(&:first)
+
+      {
+        timezone: @user.timezone,
+        today_date: Date.current.iso8601,
+        todays_duration_seconds: @scope.today.duration_seconds.to_i,
+        todays_language_categories: language_categories,
+        todays_editor_keys: editor_keys
+      }
     end
   end
 end

--- a/db/migrate/20260418154638_add_payload_to_dashboard_rollups.rb
+++ b/db/migrate/20260418154638_add_payload_to_dashboard_rollups.rb
@@ -1,0 +1,5 @@
+class AddPayloadToDashboardRollups < ActiveRecord::Migration[8.1]
+  def change
+    add_column :dashboard_rollups, :payload, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_14_131447) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_18_154638) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -83,6 +83,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_14_131447) do
     t.boolean "bucket_value_present", default: true, null: false
     t.datetime "created_at", null: false
     t.string "dimension", null: false
+    t.jsonb "payload"
     t.integer "source_heartbeats_count"
     t.float "source_max_heartbeat_time"
     t.integer "total_seconds", default: 0, null: false

--- a/test/controllers/concerns/dashboard_data_test.rb
+++ b/test/controllers/concerns/dashboard_data_test.rb
@@ -31,11 +31,11 @@ class DashboardDataTest < ActiveSupport::TestCase
 
       create_heartbeat(user, project: "alpha", language: "ruby", editor: "vscode", operating_system: "macos", category: "coding")
 
-      first = harness.send(:dashboard_raw_filter_options)
+      first = harness.send(:dashboard_live_raw_filter_options)
 
       create_heartbeat(user, project: "beta", language: "javascript", editor: "zed", operating_system: "linux", category: "browsing")
 
-      second = harness.send(:dashboard_raw_filter_options)
+      second = harness.send(:dashboard_live_raw_filter_options)
 
       assert_equal [ "alpha" ], first.fetch(:project)
       assert_equal [ "alpha" ], second.fetch(:project)
@@ -100,6 +100,10 @@ class DashboardDataTest < ActiveSupport::TestCase
         raise "expected rollup-backed dashboard path"
       end
 
+      def harness.dashboard_live_raw_filter_options
+        raise "expected rollup-backed filter options path"
+      end
+
       result = harness.send(:filterable_dashboard_data)
 
       assert_equal user.heartbeats.duration_seconds, result[:total_time]
@@ -132,6 +136,35 @@ class DashboardDataTest < ActiveSupport::TestCase
 
       assert_equal user.heartbeats.duration_seconds, result[:total_time]
       assert_equal "alpha", result["top_project"]
+    end
+  end
+
+  test "homepage rollup path falls back to live filter options when filter option rollup is missing" do
+    with_memory_cache_store do
+      Rails.cache.clear
+
+      user = User.create!(timezone: "UTC")
+      harness = build_harness(user)
+
+      travel_to Time.utc(2026, 4, 14, 12, 0, 0) do
+        create_heartbeat(user, project: "alpha", language: "ruby", editor: "vscode", operating_system: "macos", category: "coding")
+        travel 1.minute
+        create_heartbeat(user, project: "alpha", language: "ruby", editor: "vscode", operating_system: "macos", category: "coding")
+      end
+
+      DashboardRollupRefreshService.new(user: user).call
+      DashboardRollup.find_by!(user: user, dimension: DashboardRollup::FILTER_OPTIONS_DIMENSION).destroy!
+
+      clear_enqueued_jobs
+      Rails.cache.delete(DashboardRollupRefreshJob.enqueue_cache_key(user.id))
+
+      result = nil
+      assert_enqueued_with(job: DashboardRollupRefreshJob, args: [ user.id ]) do
+        result = harness.send(:filterable_dashboard_data)
+      end
+
+      assert_equal [ "alpha" ], result[:project]
+      assert_equal [ "Ruby" ], result[:language]
     end
   end
 
@@ -172,7 +205,7 @@ class DashboardDataTest < ActiveSupport::TestCase
       assert_equal total_row.total_seconds, result[:total_time]
       assert_equal total_row.source_heartbeats_count, result[:total_heartbeats]
       assert_equal "alpha", result["top_project"]
-      assert_equal [ "alpha", "beta" ], result[:project]
+      assert_equal [ "alpha" ], result[:project]
     end
   end
 
@@ -214,11 +247,205 @@ class DashboardDataTest < ActiveSupport::TestCase
       assert_equal total_row.total_seconds, result[:total_time]
       assert_equal total_row.source_heartbeats_count, result[:total_heartbeats]
       assert_equal "alpha", result["top_project"]
-      assert_equal [ "alpha", "beta" ], result[:project]
+      assert_equal [ "alpha" ], result[:project]
+    end
+  end
+
+  test "today stats and activity graph can be served from rollups" do
+    with_memory_cache_store do
+      Rails.cache.clear
+
+      travel_to Time.utc(2026, 4, 14, 12, 0, 0) do
+        user = User.create!(timezone: "UTC")
+        harness = build_harness(user)
+
+        create_heartbeat_at(user, "2026-04-14 09:00:00 UTC", project: "alpha", language: "ruby", editor: "vscode", operating_system: "macos", category: "coding")
+        create_heartbeat_at(user, "2026-04-14 09:01:00 UTC", project: "alpha", language: "ruby", editor: "vscode", operating_system: "macos", category: "coding")
+        create_heartbeat_at(user, "2026-04-14 09:02:00 UTC", project: "alpha", language: "ruby", editor: "vscode", operating_system: "macos", category: "coding")
+
+        DashboardRollupRefreshService.new(user: user).call
+
+        def harness.dashboard_live_today_stats_data
+          raise "expected rollup-backed today stats path"
+        end
+
+        def harness.dashboard_live_activity_graph_data
+          raise "expected rollup-backed activity graph path"
+        end
+
+        today_stats = harness.send(:today_stats_data)
+        activity_graph = harness.send(:activity_graph_data)
+
+        assert today_stats[:show_logged_time_sentence]
+        assert_equal [ ApplicationController.helpers.display_language_name("ruby") ], today_stats[:todays_languages]
+        assert_equal [ ApplicationController.helpers.display_editor_name("vscode") ], today_stats[:todays_editors]
+        assert_equal ApplicationController.helpers.short_time_detailed(120), today_stats[:todays_duration_display]
+        assert_equal "2025-04-14", activity_graph[:start_date]
+        assert_equal "2026-04-14", activity_graph[:end_date]
+        assert_equal 120, activity_graph[:duration_by_date]["2026-04-14"]
+      end
+    end
+  end
+
+  test "invalid today stats rollup recalculates only today stats and schedules a refresh" do
+    with_memory_cache_store do
+      Rails.cache.clear
+
+      travel_to Time.utc(2026, 4, 14, 12, 0, 0) do
+        user = User.create!(timezone: "UTC")
+        harness = build_harness(user)
+
+        create_heartbeat_at(user, "2026-04-14 09:00:00 UTC", project: "alpha", language: "ruby", editor: "vscode", operating_system: "macos", category: "coding")
+        create_heartbeat_at(user, "2026-04-14 09:01:00 UTC", project: "alpha", language: "ruby", editor: "vscode", operating_system: "macos", category: "coding")
+        create_heartbeat_at(user, "2026-04-14 09:02:00 UTC", project: "alpha", language: "ruby", editor: "vscode", operating_system: "macos", category: "coding")
+
+        DashboardRollupRefreshService.new(user: user).call
+
+        today_row = DashboardRollup.find_by!(user: user, dimension: DashboardRollup::TODAY_STATS_DIMENSION)
+        today_row.update!(payload: today_row.payload.merge("today_date" => "2026-04-13"))
+
+        def harness.dashboard_grouped_durations_snapshot(_scope)
+          raise "expected rollup-backed dashboard path"
+        end
+
+        def harness.dashboard_live_today_stats_data
+          { source: :live_today }
+        end
+
+        def harness.dashboard_live_activity_graph_data
+          raise "expected rollup-backed activity graph path"
+        end
+
+        clear_enqueued_jobs
+        Rails.cache.delete(DashboardRollupRefreshJob.enqueue_cache_key(user.id))
+
+        aggregate = nil
+        today_stats = nil
+        activity_graph = nil
+
+        assert_enqueued_with(job: DashboardRollupRefreshJob, args: [ user.id ]) do
+          aggregate = harness.send(:filterable_dashboard_data)
+          today_stats = harness.send(:today_stats_data)
+          activity_graph = harness.send(:activity_graph_data)
+        end
+
+        assert_equal 120, aggregate[:total_time]
+        assert_equal({ source: :live_today }, today_stats)
+        assert_equal 120, activity_graph[:duration_by_date]["2026-04-14"]
+        assert_equal 1, enqueued_jobs.count { |job| job[:job] == DashboardRollupRefreshJob }
+      end
+    end
+  end
+
+  test "invalid activity graph rollup recalculates only activity graph and schedules a refresh" do
+    with_memory_cache_store do
+      Rails.cache.clear
+
+      travel_to Time.utc(2026, 4, 14, 12, 0, 0) do
+        user = User.create!(timezone: "UTC")
+        harness = build_harness(user)
+
+        create_heartbeat_at(user, "2026-04-14 09:00:00 UTC", project: "alpha", language: "ruby", editor: "vscode", operating_system: "macos", category: "coding")
+        create_heartbeat_at(user, "2026-04-14 09:01:00 UTC", project: "alpha", language: "ruby", editor: "vscode", operating_system: "macos", category: "coding")
+        create_heartbeat_at(user, "2026-04-14 09:02:00 UTC", project: "alpha", language: "ruby", editor: "vscode", operating_system: "macos", category: "coding")
+
+        DashboardRollupRefreshService.new(user: user).call
+
+        activity_row = DashboardRollup.find_by!(user: user, dimension: DashboardRollup::ACTIVITY_GRAPH_DIMENSION)
+        activity_row.update!(payload: activity_row.payload.merge("end_date" => "2026-04-13"))
+
+        def harness.dashboard_grouped_durations_snapshot(_scope)
+          raise "expected rollup-backed dashboard path"
+        end
+
+        def harness.dashboard_live_today_stats_data
+          raise "expected rollup-backed today stats path"
+        end
+
+        def harness.dashboard_live_activity_graph_data
+          { source: :live_activity }
+        end
+
+        clear_enqueued_jobs
+        Rails.cache.delete(DashboardRollupRefreshJob.enqueue_cache_key(user.id))
+
+        aggregate = nil
+        today_stats = nil
+        activity_graph = nil
+
+        assert_enqueued_with(job: DashboardRollupRefreshJob, args: [ user.id ]) do
+          aggregate = harness.send(:filterable_dashboard_data)
+          today_stats = harness.send(:today_stats_data)
+          activity_graph = harness.send(:activity_graph_data)
+        end
+
+        assert_equal 120, aggregate[:total_time]
+        assert today_stats[:show_logged_time_sentence]
+        assert_equal({ source: :live_activity }, activity_graph)
+        assert_equal 1, enqueued_jobs.count { |job| job[:job] == DashboardRollupRefreshJob }
+      end
+    end
+  end
+
+  test "missing today stats and activity graph rollups recalculate only those fragments and schedule one refresh" do
+    with_memory_cache_store do
+      Rails.cache.clear
+
+      travel_to Time.utc(2026, 4, 14, 12, 0, 0) do
+        user = User.create!(timezone: "UTC")
+        harness = build_harness(user)
+
+        create_heartbeat_at(user, "2026-04-14 09:00:00 UTC", project: "alpha", language: "ruby", editor: "vscode", operating_system: "macos", category: "coding")
+        create_heartbeat_at(user, "2026-04-14 09:01:00 UTC", project: "alpha", language: "ruby", editor: "vscode", operating_system: "macos", category: "coding")
+        create_heartbeat_at(user, "2026-04-14 09:02:00 UTC", project: "alpha", language: "ruby", editor: "vscode", operating_system: "macos", category: "coding")
+
+        DashboardRollupRefreshService.new(user: user).call
+        DashboardRollup.where(
+          user: user,
+          dimension: [ DashboardRollup::TODAY_STATS_DIMENSION, DashboardRollup::ACTIVITY_GRAPH_DIMENSION ]
+        ).delete_all
+
+        def harness.dashboard_grouped_durations_snapshot(_scope)
+          raise "expected rollup-backed dashboard path"
+        end
+
+        def harness.dashboard_live_today_stats_data
+          { source: :live_today }
+        end
+
+        def harness.dashboard_live_activity_graph_data
+          { source: :live_activity }
+        end
+
+        clear_enqueued_jobs
+        Rails.cache.delete(DashboardRollupRefreshJob.enqueue_cache_key(user.id))
+
+        aggregate = nil
+        today_stats = nil
+        activity_graph = nil
+
+        assert_enqueued_with(job: DashboardRollupRefreshJob, args: [ user.id ]) do
+          aggregate = harness.send(:filterable_dashboard_data)
+          today_stats = harness.send(:today_stats_data)
+          activity_graph = harness.send(:activity_graph_data)
+        end
+
+        assert_equal 120, aggregate[:total_time]
+        assert_equal({ source: :live_today }, today_stats)
+        assert_equal({ source: :live_activity }, activity_graph)
+        assert_equal 1, enqueued_jobs.count { |job| job[:job] == DashboardRollupRefreshJob }
+      end
     end
   end
 
   private
+
+  def build_harness(user, params: {})
+    harness = Harness.new
+    harness.current_user = user
+    harness.params = ActionController::Parameters.new(params)
+    harness
+  end
 
   def with_memory_cache_store
     original_cache = Rails.cache
@@ -232,6 +459,19 @@ class DashboardDataTest < ActiveSupport::TestCase
     Heartbeat.create!(
       user: user,
       time: Time.current.to_f,
+      project: project,
+      language: language,
+      editor: editor,
+      operating_system: operating_system,
+      category: category,
+      source_type: :test_entry
+    )
+  end
+
+  def create_heartbeat_at(user, timestamp, project:, language:, editor:, operating_system:, category:)
+    Heartbeat.create!(
+      user: user,
+      time: Time.parse(timestamp).to_f,
       project: project,
       language: language,
       editor: editor,

--- a/test/controllers/static_pages_controller_test.rb
+++ b/test/controllers/static_pages_controller_test.rb
@@ -1,6 +1,32 @@
 require "test_helper"
 
 class StaticPagesControllerTest < ActionDispatch::IntegrationTest
+  test "signed in homepage includes dashboard stats immediately when rollups exist" do
+    travel_to Time.utc(2026, 4, 14, 12, 0, 0) do
+      user = User.create!(timezone: "UTC")
+      sign_in_as(user)
+
+      create_heartbeat(user, "2026-04-07 09:00:00 UTC", project: "alpha", language: "ruby", editor: "vscode", operating_system: "macos", category: "coding")
+      create_heartbeat(user, "2026-04-07 09:01:00 UTC", project: "alpha", language: "ruby", editor: "vscode", operating_system: "macos", category: "coding")
+      create_heartbeat(user, "2026-04-13 10:00:00 UTC", project: "alpha", language: "ruby", editor: "vscode", operating_system: "macos", category: "coding")
+      create_heartbeat(user, "2026-04-13 10:01:00 UTC", project: "alpha", language: "ruby", editor: "vscode", operating_system: "macos", category: "coding")
+
+      DashboardRollupRefreshService.new(user: user).call
+
+      get root_path
+
+      assert_response :success
+      assert_inertia_component "Home/SignedIn"
+      assert_nil inertia_page["deferredProps"]
+
+      dashboard_stats = inertia_page.dig("props", "dashboard_stats")
+
+      assert_equal 240, dashboard_stats.dig("filterable_dashboard_data", "total_time")
+      assert_equal "2026-04-14", dashboard_stats.dig("activity_graph", "end_date")
+      assert_equal false, dashboard_stats.dig("today_stats", "show_logged_time_sentence")
+    end
+  end
+
   test "signed in homepage dashboard stats preserves grouped durations and weekly project stats" do
     travel_to Time.utc(2026, 4, 14, 12, 0, 0) do
       user = User.create!(timezone: "UTC")
@@ -30,7 +56,10 @@ class StaticPagesControllerTest < ActionDispatch::IntegrationTest
       assert_response :success
 
       page = JSON.parse(response.body)
-      stats = page.dig("props", "dashboard_stats", "filterable_dashboard_data")
+      dashboard_stats = page.dig("props", "dashboard_stats")
+      stats = dashboard_stats["filterable_dashboard_data"]
+      today_stats = dashboard_stats["today_stats"]
+      activity_graph = dashboard_stats["activity_graph"]
 
       assert_equal 480, stats["total_time"]
       assert_equal 6, stats["total_heartbeats"]
@@ -56,6 +85,14 @@ class StaticPagesControllerTest < ActionDispatch::IntegrationTest
         },
         stats["weekly_project_stats"].slice("2026-04-13", "2026-04-06")
       )
+
+      assert_equal false, today_stats["show_logged_time_sentence"]
+      assert_equal [], today_stats["todays_languages"]
+      assert_equal [], today_stats["todays_editors"]
+
+      assert_equal "2025-04-14", activity_graph["start_date"]
+      assert_equal "2026-04-14", activity_graph["end_date"]
+      assert_equal 300, activity_graph["duration_by_date"]["2026-04-13"]
     end
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,6 +1,19 @@
 require "test_helper"
 
 class UserTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  setup do
+    clear_enqueued_jobs
+    @original_queue_adapter = ActiveJob::Base.queue_adapter
+    ActiveJob::Base.queue_adapter = :test
+  end
+
+  teardown do
+    clear_enqueued_jobs
+    ActiveJob::Base.queue_adapter = @original_queue_adapter
+  end
+
   test "theme defaults to gruvbox dark" do
     user = User.new
 
@@ -71,5 +84,32 @@ class UserTest < ActiveSupport::TestCase
     )
 
     assert user.active_remote_heartbeat_import_run?
+  end
+
+  test "changing timezone invalidates activity graph caches and schedules a dashboard rollup refresh" do
+    with_memory_cache_store do
+      Rails.cache.clear
+
+      user = User.create!(timezone: "UTC")
+      Rails.cache.write(user.activity_graph_cache_key("UTC"), { "2026-04-14" => 60 })
+      Rails.cache.write(user.activity_graph_cache_key("America/New_York"), { "2026-04-14" => 60 })
+
+      assert_enqueued_with(job: DashboardRollupRefreshJob, args: [ user.id ]) do
+        user.update!(timezone: "America/New_York")
+      end
+
+      assert_not Rails.cache.exist?(user.activity_graph_cache_key("UTC"))
+      assert_not Rails.cache.exist?(user.activity_graph_cache_key("America/New_York"))
+    end
+  end
+
+  private
+
+  def with_memory_cache_store
+    original_cache = Rails.cache
+    Rails.cache = ActiveSupport::Cache.lookup_store(:memory_store)
+    yield
+  ensure
+    Rails.cache = original_cache
   end
 end

--- a/test/services/dashboard_rollup_refresh_service_test.rb
+++ b/test/services/dashboard_rollup_refresh_service_test.rb
@@ -2,31 +2,55 @@ require "test_helper"
 
 class DashboardRollupRefreshServiceTest < ActiveSupport::TestCase
   test "rebuilds dashboard rollups from current heartbeat aggregates" do
-    user = User.create!(timezone: "UTC")
+    travel_to Time.utc(2026, 4, 14, 12, 0, 0) do
+      user = User.create!(timezone: "UTC")
 
-    create_heartbeat(user, "2026-04-07 09:00:00 UTC", project: "alpha", language: "ruby", editor: "vscode", operating_system: "macos", category: "coding")
-    create_heartbeat(user, "2026-04-07 09:01:00 UTC", project: "alpha", language: "ruby", editor: "vscode", operating_system: "macos", category: "coding")
-    create_heartbeat(user, "2026-04-13 10:00:00 UTC", project: nil, language: "ruby", editor: "vscode", operating_system: "macos", category: "coding")
-    create_heartbeat(user, "2026-04-13 10:01:00 UTC", project: nil, language: "ruby", editor: "vscode", operating_system: "macos", category: "coding")
-    create_heartbeat(user, "2026-04-13 10:03:00 UTC", project: "beta", language: "javascript", editor: "zed", operating_system: "linux", category: "coding")
-    create_heartbeat(user, "2026-04-13 10:05:00 UTC", project: "beta", language: "javascript", editor: "zed", operating_system: "linux", category: "browsing")
+      create_heartbeat(user, "2026-04-07 09:00:00 UTC", project: "alpha", language: "ruby", editor: "vscode", operating_system: "macos", category: "coding")
+      create_heartbeat(user, "2026-04-07 09:01:00 UTC", project: "alpha", language: "ruby", editor: "vscode", operating_system: "macos", category: "coding")
+      create_heartbeat(user, "2026-04-13 10:00:00 UTC", project: nil, language: "ruby", editor: "vscode", operating_system: "macos", category: "coding")
+      create_heartbeat(user, "2026-04-13 10:01:00 UTC", project: nil, language: "ruby", editor: "vscode", operating_system: "macos", category: "coding")
+      create_heartbeat(user, "2026-04-13 10:03:00 UTC", project: "beta", language: "javascript", editor: "zed", operating_system: "linux", category: "coding")
+      create_heartbeat(user, "2026-04-13 10:05:00 UTC", project: "beta", language: "javascript", editor: "zed", operating_system: "linux", category: "browsing")
+      create_heartbeat(user, "2026-04-14 09:00:00 UTC", project: "alpha", language: "ruby", editor: "vscode", operating_system: "macos", category: "coding")
+      create_heartbeat(user, "2026-04-14 09:01:00 UTC", project: "alpha", language: "ruby", editor: "vscode", operating_system: "macos", category: "coding")
 
-    DashboardRollupRefreshService.new(user: user).call
+      DashboardRollupRefreshService.new(user: user).call
 
-    total_row = DashboardRollup.find_by!(user: user, dimension: DashboardRollup::TOTAL_DIMENSION)
+      total_row = DashboardRollup.find_by!(user: user, dimension: DashboardRollup::TOTAL_DIMENSION)
+      filter_options_row = DashboardRollup.find_by!(user: user, dimension: DashboardRollup::FILTER_OPTIONS_DIMENSION)
+      activity_graph_row = DashboardRollup.find_by!(user: user, dimension: DashboardRollup::ACTIVITY_GRAPH_DIMENSION)
+      today_stats_row = DashboardRollup.find_by!(user: user, dimension: DashboardRollup::TODAY_STATS_DIMENSION)
 
-    assert_equal user.heartbeats.duration_seconds, total_row.total_seconds
-    assert_equal user.heartbeats.count, total_row.source_heartbeats_count
-    assert_equal user.heartbeats.maximum(:time), total_row.source_max_heartbeat_time
+      assert_equal user.heartbeats.duration_seconds, total_row.total_seconds
+      assert_equal user.heartbeats.count, total_row.source_heartbeats_count
+      assert_equal user.heartbeats.maximum(:time), total_row.source_max_heartbeat_time
 
-    assert_equal(
-      user.heartbeats.group(:project).duration_seconds,
-      DashboardRollup.where(user: user, dimension: "project").to_h { |row| [ row.bucket, row.total_seconds ] }
-    )
-    assert_equal(
-      user.heartbeats.group(:language).duration_seconds,
-      DashboardRollup.where(user: user, dimension: "language").to_h { |row| [ row.bucket, row.total_seconds ] }
-    )
+      assert_equal(
+        user.heartbeats.group(:project).duration_seconds,
+        DashboardRollup.where(user: user, dimension: "project").to_h { |row| [ row.bucket, row.total_seconds ] }
+      )
+      assert_equal(
+        user.heartbeats.group(:language).duration_seconds,
+        DashboardRollup.where(user: user, dimension: "language").to_h { |row| [ row.bucket, row.total_seconds ] }
+      )
+
+      assert_equal [ "alpha", "beta" ], filter_options_row.payload["project"]
+      assert_equal [ "javascript", "ruby" ], filter_options_row.payload["language"]
+      assert_equal [ "vscode", "zed" ], filter_options_row.payload["editor"]
+      assert_equal [ "linux", "macos" ], filter_options_row.payload["operating_system"]
+      assert_equal [ "browsing", "coding" ], filter_options_row.payload["category"]
+
+      assert_equal "UTC", activity_graph_row.payload["timezone"]
+      assert_equal "2025-04-14", activity_graph_row.payload["start_date"]
+      assert_equal "2026-04-14", activity_graph_row.payload["end_date"]
+      assert_equal 60, activity_graph_row.payload.fetch("duration_by_date").fetch("2026-04-14")
+
+      assert_equal "UTC", today_stats_row.payload["timezone"]
+      assert_equal "2026-04-14", today_stats_row.payload["today_date"]
+      assert_equal 60, today_stats_row.payload["todays_duration_seconds"]
+      assert_equal [ "Ruby" ], today_stats_row.payload["todays_language_categories"]
+      assert_equal [ "vscode" ], today_stats_row.payload["todays_editor_keys"]
+    end
   end
 
   private


### PR DESCRIPTION
In computer science, there are a few easy ways to speed something up:

- Make it do less
- Make it use less (resources)
- or: do it when the user isn't looking!

We don't use Timescale or ClickHouse at the moment. We should! However, this is a good stopgap for now - especially since this week's query optimisation PR made calculating the time for today/this week/this month a lot faster.

This PR adds the filters, today's sentence, and activity graph to the stored rollups. And if we have all the data we need, we no longer show the skeleton at all, instead opting to add it directly to the HTML.