### PR TITLE
Make Cache::HomeStatsJob faster with rollup sums

### DIFF
--- a/app/jobs/cache/home_stats_job.rb
+++ b/app/jobs/cache/home_stats_job.rb
@@ -4,12 +4,14 @@ class Cache::HomeStatsJob < Cache::ActivityJob
   private
 
   def calculate
-    totals = DashboardRollup.where(dimension: DashboardRollup::TOTAL_DIMENSION)
-    active_totals = totals.where("total_seconds > 0")
+    users_tracked, seconds_tracked = DashboardRollup
+      .where(dimension: DashboardRollup::TOTAL_DIMENSION)
+      .where(total_seconds: 1..)
+      .pick(Arel.sql("COUNT(*), COALESCE(SUM(total_seconds), 0)"))
 
     {
-      users_tracked: active_totals.count,
-      seconds_tracked: active_totals.sum(:total_seconds)
+      users_tracked: users_tracked || 0,
+      seconds_tracked: seconds_tracked || 0
     }
   end
 end

--- a/app/jobs/cache/home_stats_job.rb
+++ b/app/jobs/cache/home_stats_job.rb
@@ -4,14 +4,12 @@ class Cache::HomeStatsJob < Cache::ActivityJob
   private
 
   def calculate
-    # seconds_by_user = Heartbeat.group(:user_id).duration_seconds
-    # {
-    #   users_tracked: seconds_by_user.size,
-    #   seconds_tracked: seconds_by_user.values.sum
-    # }
+    totals = DashboardRollup.where(dimension: DashboardRollup::TOTAL_DIMENSION)
+    active_totals = totals.where("total_seconds > 0")
+
     {
-      users_tracked: 23_000,
-      seconds_tracked: 3_600_000_000 # 1 million hours
+      users_tracked: active_totals.count,
+      seconds_tracked: active_totals.sum(:total_seconds)
     }
   end
 end

--- a/db/migrate/20260421215522_add_index_dashboard_rollups_total_dimension.rb
+++ b/db/migrate/20260421215522_add_index_dashboard_rollups_total_dimension.rb
@@ -1,0 +1,7 @@
+class AddIndexDashboardRollupsTotalDimension < ActiveRecord::Migration[8.1]
+  def change
+    add_index :dashboard_rollups, :dimension,
+      name: "index_dashboard_rollups_on_dimension_total",
+      where: "dimension = 'total' AND total_seconds > 0"
+  end
+end

--- a/db/migrate/20260421215522_add_index_dashboard_rollups_total_dimension.rb
+++ b/db/migrate/20260421215522_add_index_dashboard_rollups_total_dimension.rb
@@ -2,6 +2,7 @@ class AddIndexDashboardRollupsTotalDimension < ActiveRecord::Migration[8.1]
   def change
     add_index :dashboard_rollups, :dimension,
       name: "index_dashboard_rollups_on_dimension_total",
-      where: "dimension = 'total' AND total_seconds > 0"
+      where: "dimension = 'total' AND total_seconds > 0",
+      if_not_exists: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_18_154638) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_21_215522) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -89,6 +89,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_18_154638) do
     t.integer "total_seconds", default: 0, null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
+    t.index ["dimension"], name: "index_dashboard_rollups_on_dimension_total", where: "(((dimension)::text = 'total'::text) AND (total_seconds > 0))"
     t.index ["user_id", "dimension", "bucket_value_present", "bucket_value"], name: "idx_dashboard_rollups_user_dimension_bucket", unique: true
     t.index ["user_id", "dimension"], name: "index_dashboard_rollups_on_user_id_and_dimension"
     t.index ["user_id"], name: "index_dashboard_rollups_on_user_id"


### PR DESCRIPTION
## Summary
- Replaces hardcoded home stats with fast rollup-backed queries
- `users_tracked`: count of DashboardRollup total rows with total_seconds > 0
- `seconds_tracked`: sum of total_seconds from those same rows

## Why
The old query (`Heartbeat.group(:user_id).duration_seconds`) was too slow at scale and had been temporarily replaced with hardcoded values. This uses the existing `dashboard_rollups` table (indexed on `user_id, dimension`) so it scales with users instead of heartbeats.