### PR TITLE
`hackatime.local` + reduce log spam

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -59,7 +59,7 @@ Run the Vite build with SSR (server-side-rendering):
 app# bin/vite build --ssr
 ```
 
-Now, let's start up the app!
+Now, let's start up the app! Run this _outside your container's shell:_
 
 ```bash
 app# bin/dev

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -36,6 +36,19 @@ RUN bun install
 COPY Gemfile Gemfile.lock ./
 RUN bundle install
 
+# Rebuild native extensions for default gems that ship without compiled
+# extensions in the base image. Without this, Bundler floods every command
+# with "Source locally installed gems is ignoring..." warnings.
+RUN gem pristine --extensions json erb bigdecimal rdoc
+
+# The ruby:4.0.3 base image ships rdoc 7.0.3 in the system gem path with a
+# rubygems plugin that auto-loads it on every gem/bundler invocation. The
+# Gemfile resolves to rdoc 7.2.0 (also auto-loaded via its own plugin), so
+# both versions get required and we get "already initialized constant"
+# warnings on every command. Removing the system copy leaves only the
+# bundled rdoc 7.2.0 to be loaded.
+RUN gem uninstall -i /usr/local/lib/ruby/gems/4.0.0 -I -x rdoc -v 7.0.3 || true
+
 # Add a script to be executed every time the container starts
 COPY entrypoint.dev.sh /usr/bin/
 RUN chmod +x /usr/bin/entrypoint.dev.sh

--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,9 @@ gem "thruster", require: false
 # For query count tracking
 gem "query_count"
 
+# Compact request logging
+gem "lograge"
+
 # Rate limiting
 gem "rack-attack"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -287,6 +287,11 @@ GEM
     lint_roller (1.1.0)
     llhttp (0.6.1)
     logger (1.7.0)
+    lograge (0.14.0)
+      actionpack (>= 4)
+      activesupport (>= 4)
+      railties (>= 4)
+      request_store (~> 1.0)
     loofah (2.25.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -672,6 +677,7 @@ DEPENDENCIES
   kamal
   letter_opener
   letter_opener_web (~> 3.0)
+  lograge
   mailkick
   maxminddb
   memory_profiler

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,4 +1,4 @@
 web: bin/dev-web
-css: bin/rails tailwindcss:watch >/dev/null 2>&1
-vite: bin/vite dev >/dev/null 2>&1
-ssr: bin/vite ssr >/dev/null 2>&1
+css: bin/rails tailwindcss:watch >/dev/null
+vite: bin/vite dev >/dev/null
+ssr: bin/vite ssr >/dev/null

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,4 +1,4 @@
-web: bin/rails server -b 0.0.0.0
-css: bin/rails tailwindcss:watch
-vite: bin/vite dev
-ssr: bin/vite ssr
+web: bin/dev-web
+css: bin/rails tailwindcss:watch >/dev/null 2>&1
+vite: bin/vite dev >/dev/null 2>&1
+ssr: bin/vite ssr >/dev/null 2>&1

--- a/bin/dev
+++ b/bin/dev
@@ -1,23 +1,71 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
+set -e
 
-export PORT="${PORT:-3000}"
+# When invoked inside the docker container, just run the Procfile with foreman
+# (or whatever process manager is available). Detection: the docker entrypoint
+# sets RUNNING_INSIDE_CONTAINER, and /.dockerenv exists in every container.
+if [ -n "$RUNNING_INSIDE_CONTAINER" ] || [ -f /.dockerenv ]; then
+  export PORT="${PORT:-3000}"
 
-if command -v overmind 1> /dev/null 2>&1
-then
-  overmind start -f Procfile.dev "$@"
-  exit $?
+  if command -v overmind >/dev/null 2>&1; then
+    exec overmind start -f Procfile.dev "$@"
+  fi
+
+  if command -v hivemind >/dev/null 2>&1; then
+    echo "Hivemind is installed. Running the application with Hivemind..."
+    exec hivemind Procfile.dev "$@"
+  fi
+
+  if gem list --no-installed --exact --silent foreman; then
+    echo "Installing foreman..."
+    gem install foreman
+  fi
+
+  exec foreman start -f Procfile.dev "$@"
 fi
 
-if command -v hivemind 1> /dev/null 2>&1
-then
-  echo "Hivemind is installed. Running the application with Hivemind..."
-  exec hivemind Procfile.dev "$@"
-  exit $?
+# --- Host-side path: set up portless, then delegate to the container ---
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+PORTLESS="./node_modules/.bin/portless"
+MARKER="tmp/.portless-installed"
+
+if [ ! -x "$PORTLESS" ]; then
+  echo "==> portless not found in node_modules; running 'bun install'..."
+  bun install
 fi
 
-if gem list --no-installed --exact --silent foreman; then
-  echo "Installing foreman..."
-  gem install foreman
+mkdir -p tmp
+
+if [ ! -f "$MARKER" ]; then
+  cat <<'EOM'
+
+==> portless one-time setup
+    This is a ONE-TIME procedure. It will:
+      - add a local CA cert to your system trust store (sudo)
+      - start the portless HTTPS proxy on port 443 (sudo)
+      - register hackatime.localhost -> port 3000
+    After this, bin/dev will no longer prompt for your password.
+
+EOM
+  sudo -v
+  sudo "$PORTLESS" trust
+  sudo "$PORTLESS" proxy start --https
+  "$PORTLESS" alias hackatime 3000
+  touch "$MARKER"
+  echo "==> portless setup complete. https://hackatime.localhost is live."
+else
+  # Subsequent runs: no sudo. The proxy daemon survives until reboot/stop.
+  # Make sure the alias is registered (idempotent, no-op if already there).
+  "$PORTLESS" alias hackatime 3000 >/dev/null
 fi
 
-foreman start -f Procfile.dev "$@"
+# Bring the dev container up if it isn't already running.
+if ! docker compose ps --status running --services 2>/dev/null | grep -qx web; then
+  echo "==> Starting docker compose services..."
+  docker compose up -d
+fi
+
+# Hand off to the container, which will hit the in-container branch above.
+exec docker compose exec -e RUNNING_INSIDE_CONTAINER=1 web bin/dev "$@"

--- a/bin/dev
+++ b/bin/dev
@@ -7,21 +7,13 @@ set -e
 if [ -n "$RUNNING_INSIDE_CONTAINER" ] || [ -f /.dockerenv ]; then
   export PORT="${PORT:-3000}"
 
-  if command -v overmind >/dev/null 2>&1; then
-    exec overmind start -f Procfile.dev "$@"
-  fi
-
-  if command -v hivemind >/dev/null 2>&1; then
-    echo "Hivemind is installed. Running the application with Hivemind..."
-    exec hivemind Procfile.dev "$@"
-  fi
-
-  if gem list --no-installed --exact --silent foreman; then
+  if ! gem list -i --exact foreman >/dev/null; then
     echo "Installing foreman..."
     gem install foreman
   fi
 
-  exec foreman start -f Procfile.dev "$@"
+  foreman_path="$(ruby -e 'print File.join(Gem.bindir, "foreman")')"
+  exec bash -c '"$1" start --color -f Procfile.dev "${@:2}" 2>&1 | grep --line-buffered -vE "^[0-9:]+ [a-z]+\.1[[:space:]]+\| started with pid "' bash "$foreman_path" "$@"
 fi
 
 # --- Host-side path: set up portless, then delegate to the container ---
@@ -29,7 +21,7 @@ PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$PROJECT_ROOT"
 
 PORTLESS="./node_modules/.bin/portless"
-MARKER="tmp/.portless-installed"
+MARKER="tmp/.portless-local-installed"
 
 if [ ! -x "$PORTLESS" ]; then
   echo "==> portless not found in node_modules; running 'bun install'..."
@@ -45,20 +37,21 @@ if [ ! -f "$MARKER" ]; then
     This is a ONE-TIME procedure. It will:
       - add a local CA cert to your system trust store (sudo)
       - start the portless HTTPS proxy on port 443 (sudo)
-      - register hackatime.localhost -> port 3000
+      - register hackatime.local -> port 3000
     After this, bin/dev will no longer prompt for your password.
 
 EOM
   sudo -v
   sudo "$PORTLESS" trust
-  sudo "$PORTLESS" proxy start --https
-  "$PORTLESS" alias hackatime 3000
+  "$PORTLESS" proxy stop >/dev/null 2>&1 || true
+  sudo "$PORTLESS" proxy start --https --lan
+  "$PORTLESS" alias hackatime 3000 --force
   touch "$MARKER"
-  echo "==> portless setup complete. https://hackatime.localhost is live."
+  echo "==> portless setup complete. https://hackatime.local is live."
 else
   # Subsequent runs: no sudo. The proxy daemon survives until reboot/stop.
   # Make sure the alias is registered (idempotent, no-op if already there).
-  "$PORTLESS" alias hackatime 3000 >/dev/null
+  "$PORTLESS" alias hackatime 3000 --force >/dev/null
 fi
 
 # Bring the dev container up if it isn't already running.

--- a/bin/dev-web
+++ b/bin/dev-web
@@ -1,0 +1,28 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "pty"
+
+PUBLIC_DEV_URL = "https://hackatime.local"
+$stdout.sync = true
+
+reader, _writer, pid = PTY.spawn("bin/rails", "server", "-b", "0.0.0.0")
+
+%w[INT TERM].each do |signal|
+  Signal.trap(signal) do
+    Process.kill(signal, pid)
+  rescue Errno::ESRCH
+    nil
+  end
+end
+
+begin
+  reader.each_line do |line|
+    print line.sub(%r{http://0\.0\.0\.0:3000}, PUBLIC_DEV_URL)
+  end
+rescue Errno::EIO
+  # PTY raises EIO when the child process exits.
+end
+
+Process.wait(pid)
+exit $?.exitstatus || 1

--- a/bin/dev-web
+++ b/bin/dev-web
@@ -6,7 +6,7 @@ require "pty"
 PUBLIC_DEV_URL = "https://hackatime.local"
 $stdout.sync = true
 
-reader, _writer, pid = PTY.spawn("bin/rails", "server", "-b", "0.0.0.0")
+reader, writer, pid = PTY.spawn("bin/rails", "server", "-b", "0.0.0.0")
 
 %w[INT TERM].each do |signal|
   Signal.trap(signal) do
@@ -25,4 +25,5 @@ rescue Errno::EIO
 end
 
 Process.wait(pid)
+writer.close unless writer.closed?
 exit $?.exitstatus || 1

--- a/bun.lock
+++ b/bun.lock
@@ -26,6 +26,7 @@
         "vite-plugin-ruby": "^5.2.1",
       },
       "devDependencies": {
+        "portless": "^0.10.3",
         "prettier": "^3.8.3",
         "prettier-plugin-svelte": "^3.5.1",
       },
@@ -432,6 +433,8 @@
     "pirates": ["pirates@4.0.7", "", {}, "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="],
 
     "plur": ["plur@6.0.0", "", { "dependencies": { "irregular-plurals": "^4.2.0" } }, "sha512-Y9wXQivjRX0REtwpA9+n0bYYypWESn3cWtW2vazymw711qn+AQXxzZjRqhANYGBLIMC1UzVdpwe/1hHQwHfwng=="],
+
+    "portless": ["portless@0.10.3", "", { "os": [ "linux", "win32", "darwin", ], "bin": { "portless": "dist/cli.js" } }, "sha512-lXbVUsNiwWMKJGMi49HhTMW0lS7u0EzawonDZQ+yglSnHioiQK18Y4Fe0Ilk+TuXej71E/nTOHIFIBjUGvTm9w=="],
 
     "postcss": ["postcss@8.5.10", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ=="],
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -66,8 +66,9 @@ Rails.application.configure do
   # Raise an error on page load if there are pending migrations.
   config.active_record.migration_error = :page_load
 
-  # Highlight code that triggered database queries in logs.
-  config.active_record.verbose_query_logs = true
+  # Keep SQL logs readable. The source line backtrace doubles every SQL log line
+  # and points at our development SQL filter instead of the application code.
+  config.active_record.verbose_query_logs = false
 
   # Append comments with runtime information tags to SQL queries in logs.
   config.active_record.query_log_tags_enabled = true
@@ -76,8 +77,11 @@ Rails.application.configure do
   config.active_job.queue_adapter = :good_job
   # config.solid_queue.connects_to = { database: { writing: :queue } }
 
-  # Highlight code that enqueued background job in logs.
-  config.active_job.verbose_enqueue_logs = true
+  # ActiveJob cache refreshes can run inline during requests and drown out page
+  # logs. Keep failures visible through Rails.logger calls in job code, but hide
+  # the framework's perform/enqueue chatter in development.
+  config.active_job.verbose_enqueue_logs = false
+  config.active_job.logger = ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new(nil))
 
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true

--- a/config/initializers/development_sql_log_filter.rb
+++ b/config/initializers/development_sql_log_filter.rb
@@ -1,0 +1,22 @@
+if Rails.env.development?
+  module DevelopmentSqlLogFilter
+    GOOD_JOB_TABLE_PATTERN = /\A\s*(?:WITH\b.*?\bFROM|SELECT\b.*?\bFROM|INSERT\s+INTO|UPDATE|DELETE\s+FROM)\s+"good_job(?:s|_[^"]+)"/im
+    FRAMEWORK_SQL_PATTERN = /\A\s*(?:BEGIN|COMMIT|ROLLBACK|SAVEPOINT|RELEASE SAVEPOINT|SET\b|LISTEN\b|UNLISTEN\b|SELECT\s+"schema_migrations"\.)/i
+
+    def sql(event)
+      payload = event.payload
+      sql = payload[:sql].to_s
+
+      return if payload[:name].to_s.start_with?("GoodJob::")
+      return if sql.include?("job='")
+      return if sql.match?(FRAMEWORK_SQL_PATTERN)
+      return if sql.match?(GOOD_JOB_TABLE_PATTERN)
+
+      super
+    end
+  end
+
+  ActiveSupport.on_load(:active_record) do
+    ActiveRecord::LogSubscriber.prepend(DevelopmentSqlLogFilter)
+  end
+end

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -4,5 +4,9 @@
 # Use this to limit dissemination of sensitive information.
 # See the ActiveSupport::ParameterFilter documentation for supported notations and behaviors.
 Rails.application.config.filter_parameters += [
-  :passw, :email, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn, :cvv, :cvc
+  :passw, :email, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn, :cvv, :cvc,
+  :_json, :hackatime, :heartbeat, :heartbeats,
+  :branch, :category, :cursorpos, :dependencies, :editor, :entity, :is_write, :language,
+  :line_additions, :line_deletions, :lineno, :lines, :machine, :operating_system,
+  :plugin, :project, :project_root_count, :time, :type, :user_agent
 ]

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -7,6 +7,7 @@ Rails.application.configure do
   if Rails.env.development?
     config.good_job.execution_mode = :async # Run jobs in background threads in development
     config.good_job.poll_interval = 5 # Poll every 5 seconds for scheduled jobs
+    config.good_job.logger = ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new(nil))
   else
     config.good_job.execution_mode = :external # Use external execution mode in production and staging
   end

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -1,0 +1,7 @@
+Rails.application.configure do
+  config.lograge.enabled = true
+  config.lograge.ignore_actions = [ "Api::Hackatime::V1::HackatimeController#push_heartbeats" ]
+  config.lograge.ignore_custom = lambda do |event|
+    event.payload[:path] == "/up"
+  end
+end

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "vite-plugin-ruby": "^5.2.1"
   },
   "devDependencies": {
+    "portless": "^0.10.3",
     "prettier": "^3.8.3",
     "prettier-plugin-svelte": "^3.5.1"
   },


### PR DESCRIPTION
This PR does a few things:
- Dev domain is now `hackatime.local`, with HTTPS!
- No more spam from `css` or `vite` processes in dev
- `bin/dev` works directly
- Ignores `push_heartbeats` logs in prod :yay: