### PR TITLE
Fix Postgres fields_hash spam

### DIFF
--- a/app/controllers/api/hackatime/v1/hackatime_controller.rb
+++ b/app/controllers/api/hackatime/v1/hackatime_controller.rb
@@ -287,11 +287,19 @@ class Api::Hackatime::V1::HackatimeController < ApplicationController
       new_heartbeat = @user.heartbeats.find_by(fields_hash: fields_hash)
 
       unless new_heartbeat
-        begin
-          new_heartbeat = Heartbeat.create!(attrs)
-        rescue ActiveRecord::RecordNotUnique
-          # The unique index is on fields_hash, while attrs includes unindexed
-          # request metadata such as ip_address. Re-find by the indexed key.
+        now = Time.current
+        insert_attrs = attrs.merge(
+          fields_hash: fields_hash,
+          created_at: now,
+          updated_at: now
+        )
+        result = Heartbeat.insert(insert_attrs, unique_by: :index_heartbeats_on_fields_hash_when_not_deleted)
+
+        if result.any?
+          new_heartbeat = Heartbeat.find(result.first["id"])
+          # FIXME: this is ugly
+          DashboardRollupRefreshJob.schedule_for(@user.id)
+        else
           new_heartbeat = @user.heartbeats.find_by!(fields_hash: fields_hash)
         end
       end

--- a/app/controllers/api/hackatime/v1/hackatime_controller.rb
+++ b/app/controllers/api/hackatime/v1/hackatime_controller.rb
@@ -293,11 +293,16 @@ class Api::Hackatime::V1::HackatimeController < ApplicationController
           created_at: now,
           updated_at: now
         )
-        result = Heartbeat.insert(insert_attrs, unique_by: :index_heartbeats_on_fields_hash_when_not_deleted)
+        result = Heartbeat.insert(
+          insert_attrs,
+          unique_by: :index_heartbeats_on_fields_hash_when_not_deleted,
+          returning: Heartbeat.column_names
+        )
 
         if result.any?
-          new_heartbeat = Heartbeat.find(result.first["id"])
-          # FIXME: this is ugly
+          new_heartbeat = Heartbeat.new(result.first)
+          # This uses insert for deduplication, so model validations/callbacks are skipped.
+          # Keep manual fields_hash and rollup scheduling in sync with Heartbeat callbacks.
           DashboardRollupRefreshJob.schedule_for(@user.id)
         else
           new_heartbeat = @user.heartbeats.find_by!(fields_hash: fields_hash)

--- a/app/controllers/api/hackatime/v1/hackatime_controller.rb
+++ b/app/controllers/api/hackatime/v1/hackatime_controller.rb
@@ -295,7 +295,7 @@ class Api::Hackatime::V1::HackatimeController < ApplicationController
         )
         result = Heartbeat.insert(
           insert_attrs,
-          unique_by: :index_heartbeats_on_fields_hash_when_not_deleted,
+          unique_by: :fields_hash,
           returning: Heartbeat.column_names
         )
 

--- a/test/controllers/api/hackatime/v1/hackatime_controller_test.rb
+++ b/test/controllers/api/hackatime/v1/hackatime_controller_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require "stringio"
 
 class Api::Hackatime::V1::HackatimeControllerTest < ActionDispatch::IntegrationTest
   test "single text plain heartbeat normalizes hash payloads" do
@@ -219,7 +220,11 @@ class Api::Hackatime::V1::HackatimeControllerTest < ActionDispatch::IntegrationT
     assert_response :accepted
     heartbeat = Heartbeat.order(:id).last
 
-    # Second request with same data should not create a duplicate
+    log_output = StringIO.new
+    previous_logger = Rails.logger
+    Rails.logger = ActiveSupport::Logger.new(log_output)
+
+    # Second request with same data should not create a duplicate or log a uniqueness error
     assert_no_difference("Heartbeat.count") do
       post "/api/hackatime/v1/users/current/heartbeats",
         params: payload.to_json,
@@ -231,6 +236,9 @@ class Api::Hackatime::V1::HackatimeControllerTest < ActionDispatch::IntegrationT
     end
     assert_response :accepted
     assert_equal heartbeat.id, JSON.parse(response.body)["id"]
+    assert_no_match(/RecordNotUnique|duplicate key|unique/i, log_output.string)
+  ensure
+    Rails.logger = previous_logger if previous_logger
   end
 
   test "bulk heartbeat normalizes permitted params" do


### PR DESCRIPTION
Uses `ON CONFLICT DO NOTHING` to not spam my Postgres logs...