### PR TITLE
Fix dashboard filters for remapped operating_system and editor values

### DIFF
--- a/app/controllers/concerns/dashboard_data.rb
+++ b/app/controllers/concerns/dashboard_data.rb
@@ -104,13 +104,13 @@ module DashboardData
         arr = params[field].split(",")
         hb = if field == :operating_system
           raw = raw_filter_options.fetch(:operating_system, []).select { |value| arr.include?(h.display_os_name(value)) }
-          raw.any? ? hb.where(field => raw) : hb
+          hb.where(field => raw)
         elsif field == :editor
           raw = raw_filter_options.fetch(:editor, []).select { |value| arr.include?(h.display_editor_name(value)) }
-          raw.any? ? hb.where(field => raw) : hb
+          hb.where(field => raw)
         elsif field == :language
           raw = raw_filter_options.fetch(:language, []).select { |language| arr.include?(language.categorize_language) }
-          raw.any? ? hb.where(field => raw) : hb
+          hb.where(field => raw)
         else
           hb.where(field => arr)
         end

--- a/app/controllers/concerns/dashboard_data.rb
+++ b/app/controllers/concerns/dashboard_data.rb
@@ -95,14 +95,19 @@ module DashboardData
   def dashboard_query_result(raw_filter_options, archived)
     hb = current_user.heartbeats
     result = dashboard_filter_options_result(raw_filter_options, archived)
+    h = ApplicationController.helpers
 
     Time.use_zone(current_user.timezone) do
       dashboard_filters.each do |field|
         next unless params[field].present?
 
         arr = params[field].split(",")
-        hb = if %i[operating_system editor].include?(field)
-          hb.where(field => arr.flat_map { |value| [ value.downcase, value.capitalize ] }.uniq)
+        hb = if field == :operating_system
+          raw = raw_filter_options.fetch(:operating_system, []).select { |value| arr.include?(h.display_os_name(value)) }
+          raw.any? ? hb.where(field => raw) : hb
+        elsif field == :editor
+          raw = raw_filter_options.fetch(:editor, []).select { |value| arr.include?(h.display_editor_name(value)) }
+          raw.any? ? hb.where(field => raw) : hb
         elsif field == :language
           raw = raw_filter_options.fetch(:language, []).select { |language| arr.include?(language.categorize_language) }
           raw.any? ? hb.where(field => raw) : hb

--- a/test/controllers/concerns/dashboard_data_test.rb
+++ b/test/controllers/concerns/dashboard_data_test.rb
@@ -387,6 +387,50 @@ class DashboardDataTest < ActiveSupport::TestCase
     end
   end
 
+  test "selecting a remapped operating_system filter value matches the underlying raw rows" do
+    with_memory_cache_store do
+      Rails.cache.clear
+
+      user = User.create!(timezone: "UTC")
+      create_heartbeat(user, project: "alpha", language: "ruby", editor: "vscode", operating_system: "Mac", category: "coding")
+      create_heartbeat(user, project: "alpha", language: "ruby", editor: "vscode", operating_system: "Mac", category: "coding")
+      create_heartbeat(user, project: "beta", language: "javascript", editor: "zed", operating_system: "linux", category: "coding")
+
+      harness = build_harness(user, params: { operating_system: "macOS" })
+
+      def harness.dashboard_rollups_available?
+        false
+      end
+
+      result = harness.send(:filterable_dashboard_data)
+
+      assert_equal 2, result[:total_heartbeats]
+      assert_equal "alpha", result["top_project"]
+    end
+  end
+
+  test "selecting a remapped editor filter value matches the underlying raw rows" do
+    with_memory_cache_store do
+      Rails.cache.clear
+
+      user = User.create!(timezone: "UTC")
+      create_heartbeat(user, project: "alpha", language: "ruby", editor: "vscode", operating_system: "macos", category: "coding")
+      create_heartbeat(user, project: "alpha", language: "ruby", editor: "vscode", operating_system: "macos", category: "coding")
+      create_heartbeat(user, project: "beta", language: "javascript", editor: "zed", operating_system: "linux", category: "coding")
+
+      harness = build_harness(user, params: { editor: "VSCode" })
+
+      def harness.dashboard_rollups_available?
+        false
+      end
+
+      result = harness.send(:filterable_dashboard_data)
+
+      assert_equal 2, result[:total_heartbeats]
+      assert_equal "alpha", result["top_project"]
+    end
+  end
+
   test "missing today stats and activity graph rollups recalculate only those fragments and schedule one refresh" do
     with_memory_cache_store do
       Rails.cache.clear


### PR DESCRIPTION
## Summary
Fixed dashboard filtering to correctly match user-selected filter values (like "macOS" or "VSCode") with their underlying raw database values (like "mac" or "vscode"). Previously, the filter logic used simple case transformations that didn't account for display name remapping.

## Key Changes
- Updated `dashboard_query_result` to use helper methods (`display_os_name` and `display_editor_name`) for translating user-selected filter values back to raw database values
- Replaced generic case-transformation logic for `operating_system` and `editor` filters with explicit mapping that looks up the raw values from `raw_filter_options`
- Added two new test cases to verify that selecting remapped filter values correctly matches the underlying heartbeat records:
  - Test for `operating_system` filter: selecting "macOS" now correctly matches heartbeats with raw value "Mac"
  - Test for `editor` filter: selecting "VSCode" now correctly matches heartbeats with raw value "vscode"

## Implementation Details
- The fix leverages existing helper methods that define the display-to-raw value mappings
- Uses `raw_filter_options` (which contains the actual database values) to find matches for user-selected display names
- Maintains consistency with the existing `language` filter implementation pattern
- Returns empty result set if no matching raw values are found for the selected display names

https://claude.ai/code/session_01FfmeAWUWPqhZSZqvxaawtt