### PR TITLE
Verify Docker builds successfully in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,30 @@ jobs:
       - name: Run Rails Zeitwerk check
         run: bin/rails zeitwerk:check
 
+  docker_build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        dockerfile: [Dockerfile, Dockerfile.dev]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build ${{ matrix.dockerfile }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: false
+          load: false
+          cache-from: type=gha,scope=${{ matrix.dockerfile }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.dockerfile }}
+
   test:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Summary of the problem
Dockerfiles may unexpectedly break (e.g. when a vendored package is no longer vendored), and it can be hard to tell that it's broken because devs usually don't try rebuilding _both_ the dev setup and the prod setup. As such, Dockerfiles may be broken, which is... not great 😬  

## Describe your changes
Verifies that `Dockerfile` and `Dockerfile.dev` both result in successful builds.

## Screenshots / Media
N/A