### PR TITLE
Make leaderboards less laggy + cleaner

### DIFF
--- a/app/javascript/pages/Leaderboards/Index.svelte
+++ b/app/javascript/pages/Leaderboards/Index.svelte
@@ -210,17 +210,6 @@
       </p>
     {/if}
 
-    {#if github_uid_blank}
-      <div
-        class="bg-darker border border-primary rounded-lg p-4 flex flex-col sm:flex-row sm:items-center gap-3"
-      >
-        <span class="text-surface-content"
-          >Connect your GitHub to qualify for the leaderboard.</span
-        >
-        <Button href={githubAuthPath} native size="md">Connect GitHub</Button>
-      </div>
-    {/if}
-
     <div
       class="text-muted text-sm flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
     >
@@ -248,14 +237,14 @@
             type="search"
             bind:value={searchQuery}
             placeholder="Find user"
-            class="h-9 w-full rounded-full border border-primary/30 bg-darkless pl-9 pr-3 text-sm text-surface-content placeholder:text-muted focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30 transition-colors"
+            class="h-9 w-full rounded-full border border-surface-200 bg-darkless pl-9 pr-3 text-sm text-surface-content placeholder:text-muted focus:border-primary/60 focus:outline-none focus:ring-2 focus:ring-primary/30 transition-colors"
           />
         </div>
       {/if}
     </div>
   </div>
 
-  <div class="bg-elevated rounded-xl border border-primary overflow-hidden">
+  <div class="bg-elevated rounded-xl border border-surface-200 overflow-hidden">
     {#if leaderboard}
       <Deferred data="entries">
         {#snippet fallback()}
@@ -274,6 +263,23 @@
         {/snippet}
 
         {#snippet children()}
+          {#if github_uid_blank}
+            <div
+              class="rounded-t-xl border border-yellow/30 bg-yellow/10 p-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between mb-2"
+            >
+              <p class="text-base font-medium text-surface-content">
+                Connect your GitHub to qualify for the leaderboard.
+              </p>
+              <Button
+                href={githubAuthPath}
+                native
+                class="w-full sm:w-fit shrink-0"
+              >
+                Connect GitHub
+              </Button>
+            </div>
+          {/if}
+
           {#if entries && entries.total > 0}
             {#if filteredEntries.length === 0}
               <div class="py-16 text-center px-3">
@@ -297,115 +303,125 @@
                   {@const i = entryRank.get(entry.user_id) ?? 0}
                   <div
                     role="listitem"
-                    class="flex items-center p-2 sm:p-3 hover:bg-dark transition-colors duration-200 gap-2 sm:gap-0 border-b border-gray-800 {entry.is_current_user
+                    class="group relative flex items-center p-2 sm:p-3 hover:bg-dark transition-colors duration-200 gap-2 sm:gap-0 border-b border-gray-800 {entry
+                      .user.profile_path
+                      ? 'cursor-pointer'
+                      : ''} {entry.is_current_user
                       ? 'bg-dark border-l-4 border-l-primary'
                       : ''} {entry.user.red
                       ? 'opacity-40 hover:opacity-60'
                       : ''}"
                   >
+                    {#if entry.user.profile_path}
+                      <Link
+                        href={entry.user.profile_path}
+                        aria-label={`View ${entry.user.display_name}'s profile`}
+                        class="absolute inset-0 z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
+                      ></Link>
+                    {/if}
                     <!-- Rank -->
                     <div
                       class="w-8 sm:w-12 shrink-0 text-center font-medium text-muted"
                     >
                       {#if i <= 2}
-                        <span class="text-xl sm:text-2xl"
-                          >{rankDisplay(i)}</span
+                        <span class="text-xl sm:text-2xl">{rankDisplay(i)}</span
                         >
                       {:else}
                         <span class="text-base sm:text-lg">{i + 1}</span>
                       {/if}
                     </div>
 
-                  <!-- User info -->
-                  <div class="flex-1 mx-1 sm:mx-4 min-w-0">
-                    <div class="flex items-center gap-2">
-                      <div class="user-info flex items-center gap-2 min-w-0">
-                        {#if entry.user.avatar_url}
-                          <img
-                            src={entry.user.avatar_url}
-                            alt="{entry.user.display_name}'s avatar"
-                            class="w-8 h-8 rounded-full aspect-square border border-surface-200 shrink-0"
-                            loading="lazy"
-                          />
-                        {/if}
-                        <span class="inline-flex items-center gap-1 min-w-0">
-                          {#if entry.user.profile_path}
-                            <Link
-                              href={entry.user.profile_path}
-                              class="text-blue hover:underline truncate"
-                            >
-                              {entry.user.display_name}
-                            </Link>
-                          {:else}
-                            <span class="truncate"
-                              >{entry.user.display_name}</span
-                            >
+                    <!-- User info -->
+                    <div class="flex-1 mx-1 sm:mx-4 min-w-0">
+                      <div class="flex items-center gap-2">
+                        <div class="user-info flex items-center gap-2 min-w-0">
+                          {#if entry.user.avatar_url}
+                            <img
+                              src={entry.user.avatar_url}
+                              alt="{entry.user.display_name}'s avatar"
+                              class="w-8 h-8 rounded-full aspect-square border border-surface-200 shrink-0"
+                              loading="lazy"
+                            />
                           {/if}
-                        </span>
-                        {#if entry.user.country_code}
-                          <CountryFlag
-                            countryCode={entry.user.country_code}
-                            class="inline-block w-5 h-5 align-middle shrink-0"
-                          />
+                          <span class="inline-flex items-center gap-1 min-w-0">
+                            {#if entry.user.profile_path}
+                              <Link
+                                href={entry.user.profile_path}
+                                class="relative z-20 text-blue hover:underline truncate"
+                              >
+                                {entry.user.display_name}
+                              </Link>
+                            {:else}
+                              <span class="truncate"
+                                >{entry.user.display_name}</span
+                              >
+                            {/if}
+                          </span>
+                          {#if entry.user.country_code}
+                            <CountryFlag
+                              countryCode={entry.user.country_code}
+                              class="inline-block w-5 h-5 align-middle shrink-0"
+                            />
+                          {/if}
+                        </div>
+
+                        {#if entry.streak_count > 0}
+                          <div
+                            class="inline-flex items-center gap-1 px-2 py-1 bg-linear-to-r {theme.bg} border {theme.bc} rounded-lg transition-all duration-200 {theme.hbg} group shrink-0"
+                            title={entry.streak_count > 30
+                              ? "30+ daily streak"
+                              : `${entry.streak_count} day streak`}
+                          >
+                            <svg
+                              xmlns="http://www.w3.org/2000/svg"
+                              width="16"
+                              height="16"
+                              viewBox="0 0 24 24"
+                              class="{theme.ic} transition-colors duration-200 group-hover:animate-pulse"
+                            >
+                              <path
+                                fill="currentColor"
+                                d="M10 2c0-.88 1.056-1.331 1.692-.722c1.958 1.876 3.096 5.995 1.75 9.12l-.08.174l.012.003c.625.133 1.203-.43 2.303-2.173l.14-.224a1 1 0 0 1 1.582-.153C18.733 9.46 20 12.402 20 14.295C20 18.56 16.409 22 12 22s-8-3.44-8-7.706c0-2.252 1.022-4.716 2.632-6.301l.605-.589c.241-.236.434-.43.618-.624C9.285 5.268 10 3.856 10 2"
+                              />
+                            </svg>
+                            <span
+                              class="text-md font-semibold {theme.tc} transition-colors duration-200"
+                            >
+                              {streakLabel(entry.streak_count)}
+                            </span>
+                          </div>
                         {/if}
                       </div>
-
-                      {#if entry.streak_count > 0}
+                      {#if entry.active_project}
                         <div
-                          class="inline-flex items-center gap-1 px-2 py-1 bg-linear-to-r {theme.bg} border {theme.bc} rounded-lg transition-all duration-200 {theme.hbg} group shrink-0"
-                          title={entry.streak_count > 30
-                            ? "30+ daily streak"
-                            : `${entry.streak_count} day streak`}
+                          class="text-xs italic text-muted truncate mt-0.5 ml-10"
                         >
-                          <svg
-                            xmlns="http://www.w3.org/2000/svg"
-                            width="16"
-                            height="16"
-                            viewBox="0 0 24 24"
-                            class="{theme.ic} transition-colors duration-200 group-hover:animate-pulse"
+                          working on
+                          <a
+                            href={entry.active_project.repo_url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="relative z-20 text-accent hover:text-cyan transition-colors"
                           >
-                            <path
-                              fill="currentColor"
-                              d="M10 2c0-.88 1.056-1.331 1.692-.722c1.958 1.876 3.096 5.995 1.75 9.12l-.08.174l.012.003c.625.133 1.203-.43 2.303-2.173l.14-.224a1 1 0 0 1 1.582-.153C18.733 9.46 20 12.402 20 14.295C20 18.56 16.409 22 12 22s-8-3.44-8-7.706c0-2.252 1.022-4.716 2.632-6.301l.605-.589c.241-.236.434-.43.618-.624C9.285 5.268 10 3.856 10 2"
-                            />
-                          </svg>
-                          <span
-                            class="text-md font-semibold {theme.tc} transition-colors duration-200"
-                          >
-                            {streakLabel(entry.streak_count)}
-                          </span>
+                            {entry.active_project.name}
+                          </a>
                         </div>
                       {/if}
                     </div>
-                    {#if entry.active_project}
-                      <div
-                        class="text-xs italic text-muted truncate mt-0.5 ml-10"
-                      >
-                        working on
-                        <a
-                          href={entry.active_project.repo_url}
-                          target="_blank"
-                          class="text-accent hover:text-cyan transition-colors"
-                        >
-                          {entry.active_project.name}
-                        </a>
-                      </div>
-                    {/if}
-                  </div>
 
-                  <!-- Duration -->
-                  <div
-                    class="shrink-0 font-mono text-xs sm:text-sm text-surface-content font-medium whitespace-nowrap"
-                  >
-                    {secondsToDetailedDisplay(entry.total_seconds)}
+                    <!-- Duration -->
+                    <div
+                      class="shrink-0 font-mono text-xs sm:text-sm text-surface-content font-medium whitespace-nowrap"
+                    >
+                      {secondsToDetailedDisplay(entry.total_seconds)}
+                    </div>
                   </div>
-                </div>
-              {/snippet}
+                {/snippet}
               </WindowVirtualizer>
 
               {#if leaderboard?.finished_generating && leaderboard?.generation_duration_seconds != null}
                 <div
-                  class="px-4 py-2 text-xs italic text-muted border-t border-primary"
+                  class="px-4 py-2 text-xs italic text-muted border-t border-surface-200"
                 >
                   Generated in {leaderboard.generation_duration_seconds} seconds
                 </div>

--- a/app/javascript/pages/Leaderboards/Index.svelte
+++ b/app/javascript/pages/Leaderboards/Index.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { Deferred, Link } from "@inertiajs/svelte";
+  import { WindowVirtualizer } from "virtua/svelte";
   import CountryFlag from "../../components/CountryFlag.svelte";
   import Twemoji from "../../components/Twemoji.svelte";
   import Button from "../../components/Button.svelte";
@@ -16,7 +17,7 @@
     streakLabel,
     tabClass,
   } from "./utils";
-  import { sessions, settingsProfile } from "../../api";
+  import { leaderboards, sessions, settingsProfile } from "../../api";
 
   let {
     period_type,
@@ -38,6 +39,12 @@
 
   const githubAuthPath = sessions.githubNew.path();
   const settingsPath = settingsProfile.mySettings.path();
+  const leaderboardPath = (query: Record<string, string | number>) =>
+    leaderboards.index.path({ query });
+  const resetEntries = (current: Record<string, unknown>) => ({
+    ...current,
+    entries: undefined,
+  });
 
   const dateRangeText = $derived(
     leaderboard?.date_range_text ??
@@ -66,12 +73,11 @@
       <!-- Scope tabs -->
       <div class="inline-flex rounded-full bg-darkless p-1 gap-1">
         <Link
-          href={`/leaderboards?period_type=${period_type}&scope=global`}
+          href={leaderboardPath({ period_type, scope: "global" })}
           component="Leaderboards/Index"
           pageProps={(current) => ({
-            ...current,
+            ...resetEntries(current),
             scope: "global",
-            entries: undefined,
           })}
           class={`${tabClass(scope === "global")} inline-flex items-center justify-center gap-2`}
           preserveScroll
@@ -82,12 +88,11 @@
 
         {#if country.available}
           <Link
-            href={`/leaderboards?period_type=${period_type}&scope=country`}
+            href={leaderboardPath({ period_type, scope: "country" })}
             component="Leaderboards/Index"
             pageProps={(current) => ({
-              ...current,
+              ...resetEntries(current),
               scope: "country",
-              entries: undefined,
             })}
             class={`${tabClass(scope === "country")} inline-flex items-center justify-center gap-2`}
             preserveScroll
@@ -117,12 +122,11 @@
       <!-- Period tabs -->
       <div class="inline-flex rounded-full bg-darkless p-1 gap-1">
         <Link
-          href={`/leaderboards?period_type=daily&scope=${scope}`}
+          href={leaderboardPath({ period_type: "daily", scope })}
           component="Leaderboards/Index"
           pageProps={(current) => ({
-            ...current,
+            ...resetEntries(current),
             period_type: "daily",
-            entries: undefined,
           })}
           class={tabClass(period_type === "daily")}
           preserveScroll
@@ -131,12 +135,11 @@
           <span class="hidden sm:inline">Last 24 Hours</span>
         </Link>
         <Link
-          href={`/leaderboards?period_type=last_7_days&scope=${scope}`}
+          href={leaderboardPath({ period_type: "last_7_days", scope })}
           component="Leaderboards/Index"
           pageProps={(current) => ({
-            ...current,
+            ...resetEntries(current),
             period_type: "last_7_days",
-            entries: undefined,
           })}
           class={tabClass(period_type === "last_7_days")}
           preserveScroll
@@ -197,11 +200,17 @@
 
         {#snippet children()}
           {#if entries && entries.total > 0}
-            <div class="divide-y divide-gray-800">
-              {#each entries.entries as entry, i}
+            <WindowVirtualizer
+              data={entries.entries}
+              getKey={(entry) => entry.user_id}
+              itemSize={64}
+              bufferSize={2_000}
+            >
+              {#snippet children(entry, i)}
                 {@const theme = streakTheme(entry.streak_count)}
                 <div
-                  class="flex items-center p-2 sm:p-3 hover:bg-dark transition-colors duration-200 gap-2 sm:gap-0 {entry.is_current_user
+                  role="listitem"
+                  class="flex items-center p-2 sm:p-3 hover:bg-dark transition-colors duration-200 gap-2 sm:gap-0 border-b border-gray-800 {entry.is_current_user
                     ? 'bg-dark border-l-4 border-l-primary'
                     : ''} {entry.user.red ? 'opacity-40 hover:opacity-60' : ''}"
                 >
@@ -300,8 +309,8 @@
                     {secondsToDetailedDisplay(entry.total_seconds)}
                   </div>
                 </div>
-              {/each}
-            </div>
+              {/snippet}
+            </WindowVirtualizer>
 
             {#if leaderboard?.finished_generating && leaderboard?.generation_duration_seconds != null}
               <div

--- a/app/javascript/pages/Leaderboards/Index.svelte
+++ b/app/javascript/pages/Leaderboards/Index.svelte
@@ -367,7 +367,7 @@
 
                         {#if entry.streak_count > 0}
                           <div
-                            class="inline-flex items-center gap-1 px-2 py-1 bg-linear-to-r {theme.bg} border {theme.bc} rounded-lg transition-all duration-200 {theme.hbg} group shrink-0"
+                            class="inline-flex items-center gap-1 transition-all duration-200 {theme.hbg} group shrink-0"
                             title={entry.streak_count > 30
                               ? "30+ daily streak"
                               : `${entry.streak_count} day streak`}
@@ -377,7 +377,7 @@
                               width="16"
                               height="16"
                               viewBox="0 0 24 24"
-                              class="{theme.ic} transition-colors duration-200 group-hover:animate-pulse"
+                              class={theme.ic}
                             >
                               <path
                                 fill="currentColor"

--- a/app/javascript/pages/Leaderboards/Index.svelte
+++ b/app/javascript/pages/Leaderboards/Index.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { Deferred, Link } from "@inertiajs/svelte";
   import { WindowVirtualizer } from "virtua/svelte";
+  import { Icon, MagnifyingGlass } from "svelte-hero-icons";
   import CountryFlag from "../../components/CountryFlag.svelte";
   import Twemoji from "../../components/Twemoji.svelte";
   import Button from "../../components/Button.svelte";
@@ -37,6 +38,13 @@
     entries?: LeaderboardEntriesPayload;
   } = $props();
 
+  type LeaderboardVirtualizer = {
+    scrollToIndex: (
+      index: number,
+      opts?: { align?: "start" | "center" | "end" },
+    ) => void;
+  };
+
   const githubAuthPath = sessions.githubNew.path();
   const settingsPath = settingsProfile.mySettings.path();
   const leaderboardPath = (query: Record<string, string | number>) =>
@@ -44,6 +52,47 @@
   const resetEntries = (current: Record<string, unknown>) => ({
     ...current,
     entries: undefined,
+  });
+  let virtualizer: LeaderboardVirtualizer | undefined = $state();
+  let searchQuery = $state("");
+
+  const normalizeSearchText = (value: string) => value.trim().toLowerCase();
+
+  const entryMatches = (
+    entry: NonNullable<LeaderboardEntriesPayload["entries"]>[number],
+    normalizedQuery: string,
+  ) => {
+    const searchableText = [
+      entry.user.display_name,
+      entry.user.profile_path,
+      entry.user.country_code,
+      entry.active_project?.name,
+    ]
+      .filter(Boolean)
+      .join(" ")
+      .toLowerCase();
+
+    return searchableText.includes(normalizedQuery);
+  };
+
+  const filteredEntries = $derived.by(() => {
+    if (!entries?.entries) return [];
+    const normalizedQuery = normalizeSearchText(searchQuery);
+    if (!normalizedQuery) return entries.entries;
+    return entries.entries.filter((entry) =>
+      entryMatches(entry, normalizedQuery),
+    );
+  });
+
+  // Map filtered entry back to its original rank in the full leaderboard
+  const entryRank = $derived.by(() => {
+    const map = new Map<number, number>();
+    if (entries?.entries) {
+      entries.entries.forEach((entry, index) => {
+        map.set(entry.user_id, index);
+      });
+    }
+    return map;
   });
 
   const dateRangeText = $derived(
@@ -172,10 +221,36 @@
       </div>
     {/if}
 
-    <div class="text-muted text-sm flex flex-wrap items-center gap-x-2 gap-y-1">
-      {dateRangeText}
-      {#if leaderboard?.finished_generating && leaderboard?.updated_at}
-        <span class="italic">• Updated {timeAgo(leaderboard.updated_at)}.</span>
+    <div
+      class="text-muted text-sm flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
+    >
+      <div class="flex flex-wrap items-center gap-x-2 gap-y-1">
+        {dateRangeText}
+        {#if leaderboard?.finished_generating && leaderboard?.updated_at}
+          <span class="italic"
+            >• Updated {timeAgo(leaderboard.updated_at)}.</span
+          >
+        {/if}
+      </div>
+
+      {#if entries && entries.total > 0}
+        <div class="relative w-full sm:w-64 sm:shrink-0">
+          <label for="leaderboard-search" class="sr-only"
+            >Find a leaderboard user</label
+          >
+          <Icon
+            src={MagnifyingGlass}
+            size="16"
+            class="absolute left-3 top-1/2 -translate-y-1/2 text-muted pointer-events-none"
+          />
+          <input
+            id="leaderboard-search"
+            type="search"
+            bind:value={searchQuery}
+            placeholder="Find user"
+            class="h-9 w-full rounded-full border border-primary/30 bg-darkless pl-9 pr-3 text-sm text-surface-content placeholder:text-muted focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30 transition-colors"
+          />
+        </div>
       {/if}
     </div>
   </div>
@@ -200,30 +275,46 @@
 
         {#snippet children()}
           {#if entries && entries.total > 0}
-            <WindowVirtualizer
-              data={entries.entries}
-              getKey={(entry) => entry.user_id}
-              itemSize={64}
-              bufferSize={2_000}
-            >
-              {#snippet children(entry, i)}
-                {@const theme = streakTheme(entry.streak_count)}
-                <div
-                  role="listitem"
-                  class="flex items-center p-2 sm:p-3 hover:bg-dark transition-colors duration-200 gap-2 sm:gap-0 border-b border-gray-800 {entry.is_current_user
-                    ? 'bg-dark border-l-4 border-l-primary'
-                    : ''} {entry.user.red ? 'opacity-40 hover:opacity-60' : ''}"
-                >
-                  <!-- Rank -->
+            {#if filteredEntries.length === 0}
+              <div class="py-16 text-center px-3">
+                <h3 class="text-xl font-medium text-surface-content mb-2">
+                  No matches
+                </h3>
+                <p class="text-muted">
+                  No users matching "{searchQuery}".
+                </p>
+              </div>
+            {:else}
+              <WindowVirtualizer
+                bind:this={virtualizer}
+                data={filteredEntries}
+                getKey={(entry) => entry.user_id}
+                itemSize={64}
+                bufferSize={2_000}
+              >
+                {#snippet children(entry)}
+                  {@const theme = streakTheme(entry.streak_count)}
+                  {@const i = entryRank.get(entry.user_id) ?? 0}
                   <div
-                    class="w-8 sm:w-12 shrink-0 text-center font-medium text-muted"
+                    role="listitem"
+                    class="flex items-center p-2 sm:p-3 hover:bg-dark transition-colors duration-200 gap-2 sm:gap-0 border-b border-gray-800 {entry.is_current_user
+                      ? 'bg-dark border-l-4 border-l-primary'
+                      : ''} {entry.user.red
+                      ? 'opacity-40 hover:opacity-60'
+                      : ''}"
                   >
-                    {#if i <= 2}
-                      <span class="text-xl sm:text-2xl">{rankDisplay(i)}</span>
-                    {:else}
-                      <span class="text-base sm:text-lg">{i + 1}</span>
-                    {/if}
-                  </div>
+                    <!-- Rank -->
+                    <div
+                      class="w-8 sm:w-12 shrink-0 text-center font-medium text-muted"
+                    >
+                      {#if i <= 2}
+                        <span class="text-xl sm:text-2xl"
+                          >{rankDisplay(i)}</span
+                        >
+                      {:else}
+                        <span class="text-base sm:text-lg">{i + 1}</span>
+                      {/if}
+                    </div>
 
                   <!-- User info -->
                   <div class="flex-1 mx-1 sm:mx-4 min-w-0">
@@ -310,14 +401,15 @@
                   </div>
                 </div>
               {/snippet}
-            </WindowVirtualizer>
+              </WindowVirtualizer>
 
-            {#if leaderboard?.finished_generating && leaderboard?.generation_duration_seconds != null}
-              <div
-                class="px-4 py-2 text-xs italic text-muted border-t border-primary"
-              >
-                Generated in {leaderboard.generation_duration_seconds} seconds
-              </div>
+              {#if leaderboard?.finished_generating && leaderboard?.generation_duration_seconds != null}
+                <div
+                  class="px-4 py-2 text-xs italic text-muted border-t border-primary"
+                >
+                  Generated in {leaderboard.generation_duration_seconds} seconds
+                </div>
+              {/if}
             {/if}
           {:else}
             <div class="py-16 text-center px-3">

--- a/app/services/leaderboard_page_cache.rb
+++ b/app/services/leaderboard_page_cache.rb
@@ -46,7 +46,7 @@ class LeaderboardPageCache
         scope_query = scope_query.joins(:user).where(users: { country_code: country_code })
       end
 
-      scope_query.preload(:user)
+      scope_query.preload(user: :email_addresses)
     end
 
     def serialize_user(user)

--- a/bun.lock
+++ b/bun.lock
@@ -27,6 +27,7 @@
         "tailwindcss": "^4.2.4",
         "tslib": "^2.8.1",
         "typescript": "^6.0.3",
+        "virtua": "^0.49.1",
         "vite": "^8.0.11",
         "vite-plugin-ruby": "^5.2.2",
       },
@@ -530,6 +531,8 @@
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "virtua": ["virtua@0.49.1", "", { "peerDependencies": { "react": ">=16.14.0", "react-dom": ">=16.14.0", "solid-js": ">=1.0", "svelte": ">=5.0", "vue": ">=3.2" }, "optionalPeers": ["react", "react-dom", "solid-js", "svelte", "vue"] }, "sha512-6f79msqg3jzNFdqJiS0FSzhRN1EHlDhR7EvW7emp6z5qQ22VdsReiDHflkpMEMhoAyUuYr69nwT0aagiM7NrUg=="],
 
     "vite": ["vite@8.0.11", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.14", "rolldown": "1.0.0-rc.18", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow=="],
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "tailwindcss": "^4.2.4",
     "tslib": "^2.8.1",
     "typescript": "^6.0.3",
+    "virtua": "^0.49.1",
     "vite": "^8.0.11",
     "vite-plugin-ruby": "^5.2.2"
   },


### PR DESCRIPTION
## Summary of the problem
Because leaderboards had thousands of rows + avatars, the performance was _terrible,_ even on high-powered devices like my MacBook Air M1. We had a Lighthouse score of ~50.

## Describe your changes
Switch to `virtua`'s `WindowVirtualizer`, add a search bar, and make the streak UI less flashy.

## Screenshots / Media

<img width="1552" height="929" alt="Screenshot 2026-05-10 at 23 02 53" src="https://github.com/user-attachments/assets/d165cd7d-21f7-41e9-8be3-4f9d72ee2005" />
