### PR TITLE
Add `id` ordering to stats calculations

### DIFF
--- a/app/controllers/api/admin/v1/admin_controller.rb
+++ b/app/controllers/api/admin/v1/admin_controller.rb
@@ -105,7 +105,7 @@ module Api
             WITH heartbeats_with_gaps AS (
               SELECT
                 date_trunc('day', to_timestamp("time"))::date as day,
-                "time" - LAG("time", 1, "time") OVER (PARTITION BY date_trunc('day', to_timestamp("time")) ORDER BY "time") as gap
+                "time" - LAG("time", 1, "time") OVER (PARTITION BY date_trunc('day', to_timestamp("time")) ORDER BY "time", id) as gap
               FROM heartbeats
               WHERE user_id = ? AND time >= ? AND time <= ?
             )

--- a/app/controllers/api/v1/stats_controller.rb
+++ b/app/controllers/api/v1/stats_controller.rb
@@ -273,7 +273,7 @@ class Api::V1::StatsController < ApplicationController
   end
 
   def unique_heartbeat_seconds(heartbeats)
-    timestamps = heartbeats.order(:time).pluck(:time)
+    timestamps = heartbeats.order(:time, :id).pluck(:time)
     return 0 if timestamps.empty?
 
     total_seconds = 0

--- a/app/controllers/concerns/dashboard_data.rb
+++ b/app/controllers/concerns/dashboard_data.rb
@@ -494,9 +494,9 @@ module DashboardData
         SELECT project AS grouped_time,
                #{week_group_sql} AS week_group,
                CASE
-                  WHEN LAG(time) OVER (PARTITION BY project, #{week_group_sql} ORDER BY time, id) IS NULL THEN 0
-                  ELSE LEAST(
-                    time - LAG(time) OVER (PARTITION BY project, #{week_group_sql} ORDER BY time, id),
+                 WHEN LAG(time) OVER (PARTITION BY project, #{week_group_sql} ORDER BY time, id) IS NULL THEN 0
+                 ELSE LEAST(
+                   time - LAG(time) OVER (PARTITION BY project, #{week_group_sql} ORDER BY time, id),
                    #{Heartbeat.heartbeat_timeout_duration.to_i}
                  )
                END AS diff

--- a/app/controllers/concerns/dashboard_data.rb
+++ b/app/controllers/concerns/dashboard_data.rb
@@ -480,7 +480,7 @@ module DashboardData
     relation_sql = scope.with_valid_timestamps
       .where.not(time: nil)
       .where(time: week_ranges.last[1]..week_ranges.first[2])
-      .select(:time, :project)
+      .select(:id, :time, :project)
       .to_sql
 
     quoted_timezone = Heartbeat.connection.quote(timezone)
@@ -494,9 +494,9 @@ module DashboardData
         SELECT project AS grouped_time,
                #{week_group_sql} AS week_group,
                CASE
-                 WHEN LAG(time) OVER (PARTITION BY project, #{week_group_sql} ORDER BY time) IS NULL THEN 0
-                 ELSE LEAST(
-                   time - LAG(time) OVER (PARTITION BY project, #{week_group_sql} ORDER BY time),
+                  WHEN LAG(time) OVER (PARTITION BY project, #{week_group_sql} ORDER BY time, id) IS NULL THEN 0
+                  ELSE LEAST(
+                    time - LAG(time) OVER (PARTITION BY project, #{week_group_sql} ORDER BY time, id),
                    #{Heartbeat.heartbeat_timeout_duration.to_i}
                  )
                END AS diff

--- a/app/models/concerns/heartbeatable.rb
+++ b/app/models/concerns/heartbeatable.rb
@@ -44,13 +44,13 @@ module Heartbeatable
     def to_span(timeout_duration: nil)
       timeout_duration ||= heartbeat_timeout_duration.to_i
 
-      heartbeats = with_valid_timestamps.order(time: :asc)
+      heartbeats = with_valid_timestamps.order(time: :asc, id: :asc)
       return [] if heartbeats.empty?
 
       sql = <<~SQL
         SELECT
           time,
-          LEAD(time) OVER (ORDER BY time) as next_time
+          LEAD(time) OVER (ORDER BY time, id) as next_time
         FROM (#{heartbeats.to_sql}) AS heartbeats
       SQL
 
@@ -136,7 +136,7 @@ module Heartbeatable
       day_group_sql = "DATE_TRUNC('day', to_timestamp(time) AT TIME ZONE users.timezone)"
       streak_diff_sql = <<~SQL.squish
         LEAST(
-          time - LAG(time) OVER (PARTITION BY user_id, #{day_group_sql} ORDER BY time),
+          time - LAG(time) OVER (PARTITION BY user_id, #{day_group_sql} ORDER BY time, #{quoted_table_name}.id),
           #{timeout}
         ) as diff
       SQL
@@ -249,8 +249,8 @@ module Heartbeatable
 
         capped_diffs = scope
           .select("#{group_expr} as grouped_time, CASE
-            WHEN LAG(time) OVER (PARTITION BY #{group_expr} ORDER BY time) IS NULL THEN 0
-            ELSE LEAST(time - LAG(time) OVER (PARTITION BY #{group_expr} ORDER BY time), #{timeout})
+            WHEN LAG(time) OVER (PARTITION BY #{group_expr} ORDER BY time, #{quoted_table_name}.id) IS NULL THEN 0
+            ELSE LEAST(time - LAG(time) OVER (PARTITION BY #{group_expr} ORDER BY time, #{quoted_table_name}.id), #{timeout})
           END as diff")
           .where.not(time: nil)
           .unscope(:group)
@@ -266,8 +266,8 @@ module Heartbeatable
         # when not grouped, return a single value
         capped_diffs = scope
           .select("CASE
-            WHEN LAG(time) OVER (ORDER BY time) IS NULL THEN 0
-            ELSE LEAST(time - LAG(time) OVER (ORDER BY time), #{timeout})
+            WHEN LAG(time) OVER (ORDER BY time, #{quoted_table_name}.id) IS NULL THEN 0
+            ELSE LEAST(time - LAG(time) OVER (ORDER BY time, #{quoted_table_name}.id), #{timeout})
           END as diff")
           .where.not(time: nil)
 
@@ -303,7 +303,7 @@ module Heartbeatable
       # get the heartbeat before the start_time
       boundary_heartbeat = base_scope
         .where("time < ?", start_time)
-        .order(time: :desc)
+        .order(time: :desc, id: :desc)
         .limit(1)
         .first
 
@@ -321,11 +321,11 @@ module Heartbeatable
       timeout = heartbeat_timeout_duration.to_i
       capped_diffs = combined_scope
         .select("time, CASE
-          WHEN LAG(time) OVER (ORDER BY time) IS NULL THEN 0
-          ELSE LEAST(time - LAG(time) OVER (ORDER BY time), #{timeout})
+          WHEN LAG(time) OVER (ORDER BY time, #{quoted_table_name}.id) IS NULL THEN 0
+          ELSE LEAST(time - LAG(time) OVER (ORDER BY time, #{quoted_table_name}.id), #{timeout})
         END as diff")
         .where.not(time: nil)
-        .order(time: :asc)
+        .order(time: :asc, id: :asc)
 
       sql = "SELECT COALESCE(SUM(diff), 0)::integer
              FROM (#{capped_diffs.to_sql}) AS diffs

--- a/app/services/dashboard_rollup_refresh_service.rb
+++ b/app/services/dashboard_rollup_refresh_service.rb
@@ -123,10 +123,10 @@ class DashboardRollupRefreshService < ApplicationService
     week_ranges = dashboard_week_ranges
     result = week_ranges.to_h { |week_key, *_| [ week_key, {} ] }
 
-      relation_sql = @scope.with_valid_timestamps
-        .where.not(time: nil)
-        .where(time: week_ranges.last[1]..week_ranges.first[2])
-        .select(:id, :time, :project)
+    relation_sql = @scope.with_valid_timestamps
+      .where.not(time: nil)
+      .where(time: week_ranges.last[1]..week_ranges.first[2])
+      .select(:id, :time, :project)
       .to_sql
 
     quoted_timezone = Heartbeat.connection.quote(@user.timezone)
@@ -140,9 +140,9 @@ class DashboardRollupRefreshService < ApplicationService
         SELECT project AS grouped_time,
                #{week_group_sql} AS week_group,
                CASE
-                  WHEN LAG(time) OVER (PARTITION BY project, #{week_group_sql} ORDER BY time, id) IS NULL THEN 0
-                  ELSE LEAST(
-                    time - LAG(time) OVER (PARTITION BY project, #{week_group_sql} ORDER BY time, id),
+                 WHEN LAG(time) OVER (PARTITION BY project, #{week_group_sql} ORDER BY time, id) IS NULL THEN 0
+                 ELSE LEAST(
+                   time - LAG(time) OVER (PARTITION BY project, #{week_group_sql} ORDER BY time, id),
                    #{Heartbeat.heartbeat_timeout_duration.to_i}
                  )
                END AS diff

--- a/app/services/dashboard_rollup_refresh_service.rb
+++ b/app/services/dashboard_rollup_refresh_service.rb
@@ -123,10 +123,10 @@ class DashboardRollupRefreshService < ApplicationService
     week_ranges = dashboard_week_ranges
     result = week_ranges.to_h { |week_key, *_| [ week_key, {} ] }
 
-    relation_sql = @scope.with_valid_timestamps
-      .where.not(time: nil)
-      .where(time: week_ranges.last[1]..week_ranges.first[2])
-      .select(:time, :project)
+      relation_sql = @scope.with_valid_timestamps
+        .where.not(time: nil)
+        .where(time: week_ranges.last[1]..week_ranges.first[2])
+        .select(:id, :time, :project)
       .to_sql
 
     quoted_timezone = Heartbeat.connection.quote(@user.timezone)
@@ -140,9 +140,9 @@ class DashboardRollupRefreshService < ApplicationService
         SELECT project AS grouped_time,
                #{week_group_sql} AS week_group,
                CASE
-                 WHEN LAG(time) OVER (PARTITION BY project, #{week_group_sql} ORDER BY time) IS NULL THEN 0
-                 ELSE LEAST(
-                   time - LAG(time) OVER (PARTITION BY project, #{week_group_sql} ORDER BY time),
+                  WHEN LAG(time) OVER (PARTITION BY project, #{week_group_sql} ORDER BY time, id) IS NULL THEN 0
+                  ELSE LEAST(
+                    time - LAG(time) OVER (PARTITION BY project, #{week_group_sql} ORDER BY time, id),
                    #{Heartbeat.heartbeat_timeout_duration.to_i}
                  )
                END AS diff

--- a/app/services/profile_stats_service.rb
+++ b/app/services/profile_stats_service.rb
@@ -62,8 +62,8 @@ class ProfileStatsService
           language,
           editor,
           CASE
-            WHEN LAG(time) OVER (ORDER BY time) IS NULL THEN 0
-            ELSE LEAST(time - LAG(time) OVER (ORDER BY time), #{timeout_quoted})
+            WHEN LAG(time) OVER (ORDER BY time, id) IS NULL THEN 0
+            ELSE LEAST(time - LAG(time) OVER (ORDER BY time, id), #{timeout_quoted})
           END AS diff
         FROM heartbeats
         WHERE user_id = #{user_id}

--- a/test/services/profile_stats_service_test.rb
+++ b/test/services/profile_stats_service_test.rb
@@ -1,0 +1,35 @@
+require "test_helper"
+
+class ProfileStatsServiceTest < ActiveSupport::TestCase
+  setup do
+    Rails.cache.clear
+  end
+
+  test "attributes duplicate timestamp peer gaps by stable id order" do
+    user = User.create!(timezone: "UTC")
+    base_time = Time.utc(2026, 4, 14, 9, 0, 0).to_f
+
+    create_heartbeat(user, time: base_time, project: "seed")
+    create_heartbeat(user, time: base_time + 60, project: "alpha")
+    create_heartbeat(user, time: base_time + 60, project: "beta")
+
+    stats = ProfileStatsService.new(user).stats
+
+    assert_equal 60, stats[:top_projects]["alpha"]
+    assert_not_equal 60, stats[:top_projects]["beta"]
+  end
+
+  private
+
+  def create_heartbeat(user, time:, project:)
+    user.heartbeats.create!(
+      entity: "src/main.rb",
+      type: "file",
+      category: "coding",
+      editor: "vscode",
+      time: time,
+      project: project,
+      source_type: :test_entry
+    )
+  end
+end


### PR DESCRIPTION
## Summary of the problem
Time can change after an autovacuum or reindexing 😬 

## Describe your changes
Adds an `id` ordering.

## Screenshots / Media
N/A