### PR TITLE
Projects page speedup

### DIFF
--- a/app/controllers/my/project_repo_mappings_controller.rb
+++ b/app/controllers/my/project_repo_mappings_controller.rb
@@ -177,12 +177,12 @@ class My::ProjectRepoMappingsController < InertiaController
   end
 
   def rollup_projects_payload(archived:)
-    DashboardRollupRefreshJob.schedule_for(current_user.id, wait: 0.seconds) if DashboardRollup.dirty?(current_user.id)
-
     rollups = DashboardRollup
       .where(user_id: current_user.id, dimension: DashboardRollup::PROJECT_DETAILS_DIMENSION, bucket_value_present: true)
       .to_a
-    return empty_projects_payload if rollups.empty?
+
+    DashboardRollupRefreshJob.schedule_for(current_user.id, wait: 0.seconds) if DashboardRollup.dirty?(current_user.id) || rollups.empty?
+    return InertiaRails.defer { projects_payload(archived: archived) } if rollups.empty?
 
     mappings = current_user.project_repo_mappings.includes(:repository)
     scoped_mappings = archived ? mappings.archived : mappings.active

--- a/app/controllers/my/project_repo_mappings_controller.rb
+++ b/app/controllers/my/project_repo_mappings_controller.rb
@@ -245,10 +245,6 @@ class My::ProjectRepoMappingsController < InertiaController
     }
   end
 
-  def empty_projects_payload
-    build_projects_payload([])
-  end
-
   def format_duration(seconds)
     helpers.short_time_detailed(seconds).presence || "0m"
   end

--- a/app/controllers/my/project_repo_mappings_controller.rb
+++ b/app/controllers/my/project_repo_mappings_controller.rb
@@ -8,6 +8,7 @@ class My::ProjectRepoMappingsController < InertiaController
 
   def index
     archived = show_archived?
+    projects_data = projects_data_for_index(archived: archived)
 
     render inertia: "Projects/Index", props: {
       page_title: "My Projects",
@@ -18,8 +19,8 @@ class My::ProjectRepoMappingsController < InertiaController
       from: params[:from],
       to: params[:to],
       interval_label: helpers.human_interval_name(selected_interval, from: params[:from], to: params[:to]),
-      total_projects: project_count(archived),
-      projects_data: InertiaRails.defer { projects_payload(archived: archived) }
+      total_projects: projects_data.is_a?(Hash) ? projects_data[:projects].size : project_count(archived),
+      projects_data: projects_data
     }
   end
 
@@ -159,32 +160,82 @@ class My::ProjectRepoMappingsController < InertiaController
       next if archived_names.key?(project_key) != archived
 
       mapping = mappings_by_name[project_key]
-      display_name = project_key.presence || "Unknown"
-      broken = broken_project_name?(project_key, display_name)
-      url_safe = !broken && project_key.present?
-
-      {
-        id: project_card_id(project_key),
-        name: display_name,
-        project_key:,
-        url_safe:,
-        duration_seconds: duration,
-        duration_label: format_duration(duration),
-        duration_percent: 0,
-        repo_url: mapping&.repo_url,
-        repository: repository_payload(mapping&.repository, latest_user_commit_at_by_repo_id),
-        broken_name: broken,
-        manage_enabled: current_user.github_uid.present? && url_safe
-      }
+      project_summary_payload(project_key, duration, mapping, latest_user_commit_at_by_repo_id)
     end.sort_by { |project| -project[:duration_seconds] }
 
+    build_projects_payload(projects)
+  end
+
+  def projects_data_for_index(archived:)
+    return rollup_projects_payload(archived: archived) if rollup_projects_path?
+
+    InertiaRails.defer { projects_payload(archived: archived) }
+  end
+
+  def rollup_projects_path?
+    selected_interval.blank? && params[:from].blank? && params[:to].blank?
+  end
+
+  def rollup_projects_payload(archived:)
+    DashboardRollupRefreshJob.schedule_for(current_user.id, wait: 0.seconds) if DashboardRollup.dirty?(current_user.id)
+
+    rollups = DashboardRollup
+      .where(user_id: current_user.id, dimension: DashboardRollup::PROJECT_DETAILS_DIMENSION, bucket_value_present: true)
+      .to_a
+    return empty_projects_payload if rollups.empty?
+
+    mappings = current_user.project_repo_mappings.includes(:repository)
+    scoped_mappings = archived ? mappings.archived : mappings.active
+    mappings_by_name = scoped_mappings.index_by(&:project_name)
+    archived_names = current_user.project_repo_mappings.archived.pluck(:project_name).index_with(true)
+    repository_ids = scoped_mappings.where.not(repository_id: nil).distinct.pluck(:repository_id)
+    latest_user_commit_at_by_repo_id = Commit.where(user_id: current_user.id, repository_id: repository_ids)
+                                             .group(:repository_id)
+                                             .maximum(:created_at)
+
+    projects = rollups.filter_map do |rollup|
+      project_key = rollup.bucket
+      next if project_key.blank?
+      next if archived_names.key?(project_key) != archived
+
+      duration = rollup.total_seconds.to_i
+      next if duration <= 0
+
+      mapping = mappings_by_name[project_key]
+      project_summary_payload(project_key, duration, mapping, latest_user_commit_at_by_repo_id)
+    end.sort_by { |project| -project[:duration_seconds] }
+
+    build_projects_payload(projects)
+  end
+
+  def project_summary_payload(project_key, duration, mapping, latest_user_commit_at_by_repo_id)
+    display_name = project_key.presence || "Unknown"
+    broken = broken_project_name?(project_key, display_name)
+    url_safe = !broken && project_key.present?
+
+    {
+      id: project_card_id(project_key),
+      name: display_name,
+      project_key:,
+      url_safe:,
+      duration_seconds: duration,
+      duration_label: format_duration(duration),
+      duration_percent: 0,
+      repo_url: mapping&.repo_url,
+      repository: repository_payload(mapping&.repository, latest_user_commit_at_by_repo_id),
+      broken_name: broken,
+      manage_enabled: current_user.github_uid.present? && url_safe
+    }
+  end
+
+  def build_projects_payload(projects)
     max_duration = projects.map { |project| project[:duration_seconds].to_f }.max || 1.0
 
     projects.each do |project|
       project[:duration_percent] = ((project[:duration_seconds].to_f / max_duration) * 100).round(1)
     end
 
-    total_time = projects.sum { |p| p[:duration_seconds] }
+    total_time = projects.sum { |project| project[:duration_seconds] }
 
     {
       total_time_seconds: total_time,
@@ -192,6 +243,10 @@ class My::ProjectRepoMappingsController < InertiaController
       has_activity: total_time.positive?,
       projects: projects
     }
+  end
+
+  def empty_projects_payload
+    build_projects_payload([])
   end
 
   def format_duration(seconds)

--- a/app/models/dashboard_rollup.rb
+++ b/app/models/dashboard_rollup.rb
@@ -1,6 +1,7 @@
 class DashboardRollup < ApplicationRecord
-  DIMENSIONS = %w[total project language editor operating_system category weekly_project activity_graph today_stats filter_options].freeze
+  DIMENSIONS = %w[total project project_details language editor operating_system category weekly_project activity_graph today_stats filter_options].freeze
   TOTAL_DIMENSION = "total".freeze
+  PROJECT_DETAILS_DIMENSION = "project_details".freeze
   ACTIVITY_GRAPH_DIMENSION = "activity_graph".freeze
   TODAY_STATS_DIMENSION = "today_stats".freeze
   FILTER_OPTIONS_DIMENSION = "filter_options".freeze

--- a/app/services/dashboard_data/snapshots.rb
+++ b/app/services/dashboard_data/snapshots.rb
@@ -21,6 +21,51 @@ module DashboardData
       non_null.merge(nil => null_duration)
     end
 
+    def project_details_snapshot(scope:)
+      timeout = Heartbeat.heartbeat_timeout_duration.to_i
+      relation_sql = scope.with_valid_timestamps
+        .where.not(project: [ nil, "" ], time: nil)
+        .select(:id, :time, :project, :language)
+        .to_sql
+
+      rows = Heartbeat.connection.select_all(<<~SQL.squish)
+        SELECT grouped_time,
+               COUNT(*)::integer AS heartbeat_count,
+               MIN(time) AS first_heartbeat,
+               MAX(time) AS last_heartbeat,
+               ARRAY_REMOVE(ARRAY_AGG(DISTINCT NULLIF(language, '')), NULL) AS languages,
+               COALESCE(SUM(diff), 0)::integer AS duration
+        FROM (
+          SELECT project AS grouped_time,
+                 time,
+                 language,
+                 CASE
+                   WHEN LAG(time) OVER (PARTITION BY project ORDER BY time, id) IS NULL THEN 0
+                   ELSE LEAST(time - LAG(time) OVER (PARTITION BY project ORDER BY time, id), #{timeout})
+                 END AS diff
+          FROM (#{relation_sql}) project_detail_heartbeats
+        ) diffs
+        GROUP BY grouped_time
+      SQL
+
+      rows.each_with_object({}) do |row, result|
+        result[row["grouped_time"]] = {
+          total_seconds: row["duration"].to_i,
+          total_heartbeats: row["heartbeat_count"].to_i,
+          first_heartbeat: row["first_heartbeat"],
+          last_heartbeat: row["last_heartbeat"],
+          languages: pg_array(row["languages"]).compact_blank
+        }
+      end
+    end
+
+    def pg_array(value)
+      return value if value.is_a?(Array)
+      return [] if value.blank?
+
+      value.to_s.delete_prefix("{").delete_suffix("}").split(",")
+    end
+
     def weekly_project_stats(user:, scope:)
       ranges = week_ranges(user.timezone)
       result = ranges.to_h { |week_key, *_| [ week_key, {} ] }

--- a/app/services/dashboard_data/snapshots.rb
+++ b/app/services/dashboard_data/snapshots.rb
@@ -63,7 +63,7 @@ module DashboardData
       return value if value.is_a?(Array)
       return [] if value.blank?
 
-      value.to_s.delete_prefix("{").delete_suffix("}").split(",")
+      PG::TextDecoder::Array.new.decode(value.to_s)
     end
 
     def weekly_project_stats(user:, scope:)

--- a/app/services/dashboard_rollup_refresh_service.rb
+++ b/app/services/dashboard_rollup_refresh_service.rb
@@ -36,6 +36,21 @@ class DashboardRollupRefreshService < ApplicationService
         )
       end
     end
+    project_details.each do |project, details|
+      records << build_record(
+        dimension: DashboardRollup::PROJECT_DETAILS_DIMENSION,
+        bucket: project,
+        total_seconds: details.fetch(:total_seconds),
+        now: now,
+        source_heartbeats_count: details.fetch(:total_heartbeats),
+        source_max_heartbeat_time: details.fetch(:last_heartbeat),
+        payload: {
+          first_heartbeat: details.fetch(:first_heartbeat),
+          last_heartbeat: details.fetch(:last_heartbeat),
+          languages: details.fetch(:languages)
+        }
+      )
+    end
 
     DashboardRollup.transaction do
       DashboardRollup.where(user_id: @user.id).delete_all
@@ -111,6 +126,10 @@ class DashboardRollupRefreshService < ApplicationService
 
   def weekly_project_stats
     DashboardData::Snapshots.weekly_project_stats(user: @user, scope: @scope)
+  end
+
+  def project_details
+    DashboardData::Snapshots.project_details_snapshot(scope: @scope)
   end
 
   def activity_graph_payload

--- a/app/services/project_stats_query.rb
+++ b/app/services/project_stats_query.rb
@@ -36,11 +36,14 @@ class ProjectStatsQuery
 
     durations = query.group(:project).duration_seconds
 
-    languages_by_project = query.where.not(language: [ nil, "" ])
-                                .group(:project, :language)
-                                .pluck(:project, :language)
-                                .group_by(&:first)
-                                .transform_values { |pairs| pairs.map(&:last).uniq }
+    project_names_by_name = names.index_with(true)
+    languages_by_project = scoped_heartbeats(stats_start_time, stats_end_time)
+      .where.not(language: [ nil, "" ])
+      .group(:project, :language)
+      .pluck(:project, :language)
+      .select { |project, _| project_names_by_name.key?(project) }
+      .group_by(&:first)
+      .transform_values { |pairs| pairs.map(&:last).uniq }
 
     repo_mappings = @user.project_repo_mappings
                          .where(project_name: names)

--- a/app/services/project_stats_query.rb
+++ b/app/services/project_stats_query.rb
@@ -22,50 +22,51 @@ class ProjectStatsQuery
   end
 
   def project_details(names: nil)
-    names = normalize_names(names)
-    names = project_names if names.empty?
-    return [] if names.empty?
+    requested_names = normalize_names(names)
 
     query = scoped_heartbeats(stats_start_time, stats_end_time)
-            .where(project: names)
-    return [] unless query.exists?
+    query = query.where(project: requested_names) if requested_names.any?
 
-    stats = query.group(:project)
-                 .select("project, COUNT(*) AS heartbeat_count, MIN(time) AS first_heartbeat, MAX(time) AS last_heartbeat")
-                 .index_by(&:project)
+    stats = project_activity_stats(query)
+    return [] if stats.empty?
 
-    durations = query.group(:project).duration_seconds
+    candidate_names = requested_names.presence || stats.keys
+    repo_mappings = @user.project_repo_mappings
+                         .where(project_name: candidate_names)
+                         .index_by(&:project_name)
 
-    project_names_by_name = names.index_with(true)
-    languages_by_project = scoped_heartbeats(stats_start_time, stats_end_time)
+    selected_names = candidate_names.reject do |name|
+      !@include_archived && repo_mappings[name]&.archived?
+    end
+    selected_project_names = selected_names.index_with(true)
+
+    language_scope = scoped_heartbeats(stats_start_time, stats_end_time)
+    language_scope = language_scope.where(project: requested_names) if requested_names.any?
+
+    languages_by_project = language_scope
       .where.not(language: [ nil, "" ])
       .group(:project, :language)
       .pluck(:project, :language)
-      .select { |project, _| project_names_by_name.key?(project) }
+      .select { |project, _| selected_project_names.key?(project) }
       .group_by(&:first)
       .transform_values { |pairs| pairs.map(&:last).uniq }
 
-    repo_mappings = @user.project_repo_mappings
-                         .where(project_name: names)
-                         .index_by(&:project_name)
-
-    names.filter_map do |name|
+    selected_names.filter_map do |name|
       stat = stats[name]
       next unless stat
 
       repo_mapping = repo_mappings[name]
       archived = repo_mapping&.archived? || false
-      next if archived && !@include_archived
 
-      first_heartbeat = format_heartbeat_time(stat.first_heartbeat)
-      last_heartbeat = format_heartbeat_time(stat.last_heartbeat)
+      first_heartbeat = format_heartbeat_time(stat[:first_heartbeat])
+      last_heartbeat = format_heartbeat_time(stat[:last_heartbeat])
 
       {
         name: name,
-        total_seconds: durations[name] || 0,
+        total_seconds: stat[:total_seconds],
         languages: languages_by_project[name] || [],
         repo_url: repo_mapping&.repo_url,
-        total_heartbeats: stat.heartbeat_count || 0,
+        total_heartbeats: stat[:total_heartbeats],
         first_heartbeat: first_heartbeat,
         last_heartbeat: last_heartbeat,
         most_recent_heartbeat: last_heartbeat,
@@ -99,6 +100,38 @@ class ProjectStatsQuery
 
   def archived_project_names
     @archived_project_names ||= @user.project_repo_mappings.archived.pluck(:project_name)
+  end
+
+  def project_activity_stats(scope)
+    timeout = Heartbeat.heartbeat_timeout_duration.to_i
+    base_sql = scope.unscope(:group, :select, :order).select(:id, :project, :time).where.not(time: nil).to_sql
+
+    sql = <<~SQL.squish
+      SELECT grouped_time,
+             COUNT(*)::integer AS heartbeat_count,
+             MIN(time) AS first_heartbeat,
+             MAX(time) AS last_heartbeat,
+             COALESCE(SUM(diff), 0)::integer AS duration
+      FROM (
+        SELECT project AS grouped_time,
+               time,
+               CASE
+                 WHEN LAG(time) OVER (PARTITION BY project ORDER BY time, heartbeats.id) IS NULL THEN 0
+                 ELSE LEAST(time - LAG(time) OVER (PARTITION BY project ORDER BY time, heartbeats.id), #{timeout})
+               END AS diff
+        FROM (#{base_sql}) heartbeats
+      ) diffs
+      GROUP BY grouped_time
+    SQL
+
+    Heartbeat.connection.select_all(sql).each_with_object({}) do |row, hash|
+      hash[row["grouped_time"]] = {
+        total_seconds: row["duration"].to_i,
+        total_heartbeats: row["heartbeat_count"].to_i,
+        first_heartbeat: row["first_heartbeat"],
+        last_heartbeat: row["last_heartbeat"]
+      }
+    end
   end
 
   def discovery_start_time

--- a/app/services/project_stats_query.rb
+++ b/app/services/project_stats_query.rb
@@ -24,10 +24,15 @@ class ProjectStatsQuery
   def project_details(names: nil)
     requested_names = normalize_names(names)
 
+    if requested_names.empty? && rollup_eligible?
+      rollup_details = rollup_project_details
+      return rollup_details if rollup_details
+    end
+
     query = scoped_heartbeats(stats_start_time, stats_end_time)
     query = query.where(project: requested_names) if requested_names.any?
 
-    stats = project_activity_stats(query)
+    stats = DashboardData::Snapshots.project_details_snapshot(scope: query)
     return [] if stats.empty?
 
     candidate_names = requested_names.presence || stats.keys
@@ -38,19 +43,6 @@ class ProjectStatsQuery
     selected_names = candidate_names.reject do |name|
       !@include_archived && repo_mappings[name]&.archived?
     end
-    selected_project_names = selected_names.index_with(true)
-
-    language_scope = scoped_heartbeats(stats_start_time, stats_end_time)
-    language_scope = language_scope.where(project: requested_names) if requested_names.any?
-
-    languages_by_project = language_scope
-      .where.not(language: [ nil, "" ])
-      .group(:project, :language)
-      .pluck(:project, :language)
-      .select { |project, _| selected_project_names.key?(project) }
-      .group_by(&:first)
-      .transform_values { |pairs| pairs.map(&:last).uniq }
-
     selected_names.filter_map do |name|
       stat = stats[name]
       next unless stat
@@ -64,7 +56,7 @@ class ProjectStatsQuery
       {
         name: name,
         total_seconds: stat[:total_seconds],
-        languages: languages_by_project[name] || [],
+        languages: stat[:languages] || [],
         repo_url: repo_mapping&.repo_url,
         total_heartbeats: stat[:total_heartbeats],
         first_heartbeat: first_heartbeat,
@@ -102,36 +94,52 @@ class ProjectStatsQuery
     @archived_project_names ||= @user.project_repo_mappings.archived.pluck(:project_name)
   end
 
-  def project_activity_stats(scope)
-    timeout = Heartbeat.heartbeat_timeout_duration.to_i
-    base_sql = scope.unscope(:group, :select, :order).select(:id, :project, :time).where.not(time: nil).to_sql
+  def rollup_project_details
+    project_detail_rows = DashboardRollup
+      .where(user_id: @user.id, dimension: DashboardRollup::PROJECT_DETAILS_DIMENSION, bucket_value_present: true)
+      .to_a
+    return if project_detail_rows.empty?
 
-    sql = <<~SQL.squish
-      SELECT grouped_time,
-             COUNT(*)::integer AS heartbeat_count,
-             MIN(time) AS first_heartbeat,
-             MAX(time) AS last_heartbeat,
-             COALESCE(SUM(diff), 0)::integer AS duration
-      FROM (
-        SELECT project AS grouped_time,
-               time,
-               CASE
-                 WHEN LAG(time) OVER (PARTITION BY project ORDER BY time, heartbeats.id) IS NULL THEN 0
-                 ELSE LEAST(time - LAG(time) OVER (PARTITION BY project ORDER BY time, heartbeats.id), #{timeout})
-               END AS diff
-        FROM (#{base_sql}) heartbeats
-      ) diffs
-      GROUP BY grouped_time
-    SQL
+    DashboardRollupRefreshJob.schedule_for(@user.id, wait: 0.seconds) if DashboardRollup.dirty?(@user.id)
 
-    Heartbeat.connection.select_all(sql).each_with_object({}) do |row, hash|
-      hash[row["grouped_time"]] = {
-        total_seconds: row["duration"].to_i,
-        total_heartbeats: row["heartbeat_count"].to_i,
-        first_heartbeat: row["first_heartbeat"],
-        last_heartbeat: row["last_heartbeat"]
-      }
+    details_by_project = project_detail_rows.index_by(&:bucket)
+    details_by_project.delete("")
+    return if details_by_project.empty?
+
+    repo_mappings = @user.project_repo_mappings
+      .where(project_name: details_by_project.keys)
+      .index_by(&:project_name)
+
+    selected_names = details_by_project.keys.reject do |name|
+      !@include_archived && repo_mappings[name]&.archived?
     end
+
+    selected_names.filter_map do |name|
+      rollup = details_by_project[name]
+      payload = rollup.payload.to_h
+
+      repo_mapping = repo_mappings[name]
+      first_heartbeat = format_heartbeat_time(payload["first_heartbeat"])
+      last_heartbeat = format_heartbeat_time(payload["last_heartbeat"])
+
+      {
+        name: name,
+        total_seconds: rollup.total_seconds.to_i,
+        languages: Array(payload["languages"]).compact_blank,
+        repo_url: repo_mapping&.repo_url,
+        total_heartbeats: rollup.source_heartbeats_count.to_i,
+        first_heartbeat: first_heartbeat,
+        last_heartbeat: last_heartbeat,
+        most_recent_heartbeat: last_heartbeat,
+        archived: repo_mapping&.archived? || false
+      }
+    end.sort_by { |project| -project[:total_seconds] }
+  end
+
+  def rollup_eligible?
+    @params[:projects].blank? &&
+      %i[start start_date end end_date].none? { |key| @params[key].present? } &&
+      timestamp_value(@default_stats_start).to_f.zero?
   end
 
   def discovery_start_time

--- a/db/migrate/20260518170142_add_heartbeats_user_time_project_language_covering_index.rb
+++ b/db/migrate/20260518170142_add_heartbeats_user_time_project_language_covering_index.rb
@@ -4,7 +4,7 @@ class AddHeartbeatsUserTimeProjectLanguageCoveringIndex < ActiveRecord::Migratio
   def change
     add_index :heartbeats, [ :user_id, :time ],
       name: :idx_heartbeats_user_time_project_language,
-      where: "deleted_at IS NULL AND project IS NOT NULL AND project <> '' AND language IS NOT NULL AND language <> ''",
+      where: "deleted_at IS NULL AND project IS NOT NULL AND project <> ''",
       include: [ :project, :language ],
       algorithm: :concurrently,
       if_not_exists: true

--- a/db/migrate/20260518170142_add_heartbeats_user_time_project_language_covering_index.rb
+++ b/db/migrate/20260518170142_add_heartbeats_user_time_project_language_covering_index.rb
@@ -1,0 +1,12 @@
+class AddHeartbeatsUserTimeProjectLanguageCoveringIndex < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :heartbeats, [ :user_id, :time ],
+      name: :idx_heartbeats_user_time_project_language,
+      where: "deleted_at IS NULL AND project IS NOT NULL AND project <> '' AND language IS NOT NULL AND language <> ''",
+      include: [ :project, :language ],
+      algorithm: :concurrently,
+      if_not_exists: true
+  end
+end

--- a/db/migrate/20260518170142_add_heartbeats_user_time_project_language_covering_index.rb
+++ b/db/migrate/20260518170142_add_heartbeats_user_time_project_language_covering_index.rb
@@ -5,7 +5,7 @@ class AddHeartbeatsUserTimeProjectLanguageCoveringIndex < ActiveRecord::Migratio
     add_index :heartbeats, [ :user_id, :time ],
       name: :idx_heartbeats_user_time_project_language,
       where: "deleted_at IS NULL AND project IS NOT NULL AND project <> ''",
-      include: [ :project, :language ],
+      include: [ :id, :project, :language ],
       algorithm: :concurrently,
       if_not_exists: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -355,7 +355,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_18_170142) do
     t.index ["user_id", "time", "project"], name: "idx_heartbeats_user_time_project_stats", where: "(deleted_at IS NULL)"
     t.index ["user_id", "time"], name: "idx_heartbeats_lb_eligible_user_time", where: "((deleted_at IS NULL) AND ((category)::text = 'coding'::text) AND ((editor IS NULL) OR (lower((editor)::text) <> ALL (ARRAY['arc'::text, 'brave'::text, 'chrome'::text, 'chromium'::text, 'edge'::text, 'firefox'::text, 'floorp'::text, 'librewolf'::text, 'microsoft-edge'::text, 'opera'::text, 'opera-gx'::text, 'safari'::text, 'vivaldi'::text, 'waterfox'::text, 'zen'::text]))))"
     t.index ["user_id", "time"], name: "idx_heartbeats_user_time_active", where: "(deleted_at IS NULL)"
-    t.index ["user_id", "time"], name: "idx_heartbeats_user_time_project_language", where: "((deleted_at IS NULL) AND (project IS NOT NULL) AND ((project)::text <> ''::text) AND (language IS NOT NULL) AND ((language)::text <> ''::text))", include: ["project", "language"]
+    t.index ["user_id", "time"], name: "idx_heartbeats_user_time_project_language", where: "((deleted_at IS NULL) AND (project IS NOT NULL) AND ((project)::text <> ''::text))", include: ["project", "language"]
     t.index ["user_id"], name: "index_heartbeats_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -355,7 +355,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_18_170142) do
     t.index ["user_id", "time", "project"], name: "idx_heartbeats_user_time_project_stats", where: "(deleted_at IS NULL)"
     t.index ["user_id", "time"], name: "idx_heartbeats_lb_eligible_user_time", where: "((deleted_at IS NULL) AND ((category)::text = 'coding'::text) AND ((editor IS NULL) OR (lower((editor)::text) <> ALL (ARRAY['arc'::text, 'brave'::text, 'chrome'::text, 'chromium'::text, 'edge'::text, 'firefox'::text, 'floorp'::text, 'librewolf'::text, 'microsoft-edge'::text, 'opera'::text, 'opera-gx'::text, 'safari'::text, 'vivaldi'::text, 'waterfox'::text, 'zen'::text]))))"
     t.index ["user_id", "time"], name: "idx_heartbeats_user_time_active", where: "(deleted_at IS NULL)"
-    t.index ["user_id", "time"], name: "idx_heartbeats_user_time_project_language", where: "((deleted_at IS NULL) AND (project IS NOT NULL) AND ((project)::text <> ''::text))", include: ["project", "language"]
+    t.index ["user_id", "time"], name: "idx_heartbeats_user_time_project_language", where: "((deleted_at IS NULL) AND (project IS NOT NULL) AND ((project)::text <> ''::text))", include: ["id", "project", "language"]
     t.index ["user_id"], name: "index_heartbeats_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_12_142509) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_18_170142) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -355,6 +355,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_12_142509) do
     t.index ["user_id", "time", "project"], name: "idx_heartbeats_user_time_project_stats", where: "(deleted_at IS NULL)"
     t.index ["user_id", "time"], name: "idx_heartbeats_lb_eligible_user_time", where: "((deleted_at IS NULL) AND ((category)::text = 'coding'::text) AND ((editor IS NULL) OR (lower((editor)::text) <> ALL (ARRAY['arc'::text, 'brave'::text, 'chrome'::text, 'chromium'::text, 'edge'::text, 'firefox'::text, 'floorp'::text, 'librewolf'::text, 'microsoft-edge'::text, 'opera'::text, 'opera-gx'::text, 'safari'::text, 'vivaldi'::text, 'waterfox'::text, 'zen'::text]))))"
     t.index ["user_id", "time"], name: "idx_heartbeats_user_time_active", where: "(deleted_at IS NULL)"
+    t.index ["user_id", "time"], name: "idx_heartbeats_user_time_project_language", where: "((deleted_at IS NULL) AND (project IS NOT NULL) AND ((project)::text <> ''::text) AND (language IS NOT NULL) AND ((language)::text <> ''::text))", include: ["project", "language"]
     t.index ["user_id"], name: "index_heartbeats_on_user_id"
   end
 

--- a/lib/wakatime_service.rb
+++ b/lib/wakatime_service.rb
@@ -1,3 +1,5 @@
+require "digest"
+
 include ApplicationHelper
 include ErrorReporting
 
@@ -25,6 +27,18 @@ class WakatimeService
   end
 
   def generate_summary
+    return cached_summary if @allow_cache
+
+    build_summary
+  end
+
+  def cached_summary
+    Rails.cache.fetch(summary_cache_key, expires_in: 1.minute) do
+      build_summary
+    end
+  end
+
+  def build_summary
     summary = {}
 
     summary[:username] = @user.display_name if @user.present?
@@ -55,6 +69,13 @@ class WakatimeService
     summary[:projects] = generate_summary_chunk(:project) if @specific_filters.include?(:projects)
 
     summary
+  end
+
+  def summary_cache_key
+    scope_digest = Digest::SHA256.hexdigest(@scope.to_sql)
+    filters = @specific_filters.map(&:to_s).sort.join(",")
+
+    [ "wakatime_service", "summary", "v1", scope_digest, filters, @limit ].join(":")
   end
 
   def generate_summary_chunk(group_by)

--- a/test/controllers/my/project_repo_mappings_controller_test.rb
+++ b/test/controllers/my/project_repo_mappings_controller_test.rb
@@ -27,7 +27,7 @@ class My::ProjectRepoMappingsControllerTest < ActionDispatch::IntegrationTest
     assert_equal [ "alpha" ], page.dig("props", "projects_data", "projects").map { |project| project["name"] }
   end
 
-  test "index returns no projects when default rollups are missing" do
+  test "index falls back to deferred project data when default rollups are missing" do
     user = User.create!(timezone: "UTC")
     user.project_repo_mappings.create!(project_name: "alpha")
     create_project_heartbeats(user, "alpha")
@@ -38,9 +38,7 @@ class My::ProjectRepoMappingsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     page = inertia_page
-    assert_nil page["deferredProps"]
-    assert_equal 0, page.dig("props", "total_projects")
-    assert_equal [], page.dig("props", "projects_data", "projects")
+    assert_equal [ "projects_data" ], page.dig("deferredProps", "default")
   end
 
   test "index still defers interval-filtered project data" do

--- a/test/controllers/my/project_repo_mappings_controller_test.rb
+++ b/test/controllers/my/project_repo_mappings_controller_test.rb
@@ -8,10 +8,11 @@ class My::ProjectRepoMappingsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to root_path
   end
 
-  test "index renders projects page with deferred props" do
+  test "index renders project rollups synchronously when available" do
     user = User.create!(timezone: "UTC")
     user.project_repo_mappings.create!(project_name: "alpha")
     create_project_heartbeats(user, "alpha")
+    DashboardRollupRefreshService.new(user: user).call
 
     sign_in_as(user)
     get my_projects_path
@@ -22,6 +23,37 @@ class My::ProjectRepoMappingsControllerTest < ActionDispatch::IntegrationTest
     page = inertia_page
     assert_equal false, page.dig("props", "show_archived")
     assert_equal 1, page.dig("props", "total_projects")
+    assert_nil page["deferredProps"]
+    assert_equal [ "alpha" ], page.dig("props", "projects_data", "projects").map { |project| project["name"] }
+  end
+
+  test "index returns no projects when default rollups are missing" do
+    user = User.create!(timezone: "UTC")
+    user.project_repo_mappings.create!(project_name: "alpha")
+    create_project_heartbeats(user, "alpha")
+
+    sign_in_as(user)
+    get my_projects_path
+
+    assert_response :success
+
+    page = inertia_page
+    assert_nil page["deferredProps"]
+    assert_equal 0, page.dig("props", "total_projects")
+    assert_equal [], page.dig("props", "projects_data", "projects")
+  end
+
+  test "index still defers interval-filtered project data" do
+    user = User.create!(timezone: "UTC")
+    user.project_repo_mappings.create!(project_name: "alpha")
+    create_project_heartbeats(user, "alpha")
+
+    sign_in_as(user)
+    get my_projects_path(interval: "last_7_days")
+
+    assert_response :success
+
+    page = inertia_page
     assert_equal [ "projects_data" ], page.dig("deferredProps", "default")
   end
 
@@ -30,6 +62,7 @@ class My::ProjectRepoMappingsControllerTest < ActionDispatch::IntegrationTest
     mapping = user.project_repo_mappings.create!(project_name: "beta")
     mapping.archive!
     create_project_heartbeats(user, "beta")
+    DashboardRollupRefreshService.new(user: user).call
 
     sign_in_as(user)
     get my_projects_path(show_archived: true)

--- a/test/lib/project_stats_query_test.rb
+++ b/test/lib/project_stats_query_test.rb
@@ -135,6 +135,19 @@ class ProjectStatsQueryTest < ActiveSupport::TestCase
     assert_equal project[:last_heartbeat], project[:most_recent_heartbeat]
   end
 
+  test "project details only returns languages for selected projects" do
+    base = 5.days.ago.to_f
+    create_heartbeat(project: "alpha", language: "Ruby", time: base)
+    create_heartbeat(project: "alpha", language: "TypeScript", time: base + 60)
+    create_heartbeat(project: "beta", language: "Go", time: base + 120)
+
+    query = ProjectStatsQuery.new(user: @user, params: {}, default_discovery_start: 0, default_stats_start: 0)
+
+    project = query.project_details(names: [ "alpha" ]).first
+
+    assert_equal [ "Ruby", "TypeScript" ], project[:languages].sort
+  end
+
   test "project details sorts projects by total_seconds descending" do
     base = 4.days.ago.to_f
     create_heartbeat(project: "alpha", time: base)

--- a/test/lib/project_stats_query_test.rb
+++ b/test/lib/project_stats_query_test.rb
@@ -148,6 +148,68 @@ class ProjectStatsQueryTest < ActiveSupport::TestCase
     assert_equal [ "Ruby", "TypeScript" ], project[:languages].sort
   end
 
+  test "project details uses project detail rollups for default all-time data" do
+    first_time = 5.days.ago.to_f
+    last_time = first_time + 60
+    create_project_detail_rollup(
+      project: "alpha",
+      total_seconds: 999,
+      total_heartbeats: 2,
+      first_heartbeat: first_time,
+      last_heartbeat: last_time,
+      languages: [ "Ruby" ]
+    )
+
+    query = ProjectStatsQuery.new(user: @user, params: {}, default_discovery_start: 0, default_stats_start: 0)
+
+    project = query.project_details.first
+
+    assert_equal "alpha", project[:name]
+    assert_equal 999, project[:total_seconds]
+    assert_equal 2, project[:total_heartbeats]
+    assert_equal [ "Ruby" ], project[:languages]
+    assert_equal formatted_time(first_time), project[:first_heartbeat]
+    assert_equal formatted_time(last_time), project[:most_recent_heartbeat]
+  end
+
+  test "project details does not use rollups when a date range is requested" do
+    base = 5.days.ago.to_f
+    create_heartbeat(project: "alpha", language: "Ruby", time: base)
+    create_heartbeat(project: "alpha", language: "Ruby", time: base + 60)
+    create_project_detail_rollup(project: "alpha", total_seconds: 999)
+
+    query = ProjectStatsQuery.new(
+      user: @user,
+      params: { start: 7.days.ago.iso8601, end: 1.day.ago.iso8601 },
+      default_discovery_start: 0,
+      default_stats_start: 0
+    )
+
+    project = query.project_details.first
+
+    assert_equal 60, project[:total_seconds]
+  end
+
+  test "dashboard rollup refresh writes project details payloads" do
+    base = 5.days.ago.to_f
+    create_heartbeat(project: "alpha", language: "Ruby", time: base)
+    create_heartbeat(project: "alpha", language: "TypeScript", time: base + 60)
+
+    DashboardRollupRefreshService.new(user: @user).call
+
+    rollup = DashboardRollup.find_by!(
+      user: @user,
+      dimension: DashboardRollup::PROJECT_DETAILS_DIMENSION,
+      bucket_value: "alpha"
+    )
+
+    assert_equal 60, rollup.total_seconds
+    assert_equal 2, rollup.source_heartbeats_count
+    assert_in_delta base, rollup.payload["first_heartbeat"], 0.001
+    assert_in_delta base + 60, rollup.payload["last_heartbeat"], 0.001
+    assert_equal [ "Ruby", "TypeScript" ], rollup.payload["languages"].sort
+  end
+
   test "project details sorts projects by total_seconds descending" do
     base = 4.days.ago.to_f
     create_heartbeat(project: "alpha", time: base)
@@ -289,6 +351,23 @@ class ProjectStatsQueryTest < ActiveSupport::TestCase
       project: project,
       language: language,
       time: time
+    )
+  end
+
+  def create_project_detail_rollup(project:, total_seconds:, total_heartbeats: 1, first_heartbeat: 5.days.ago.to_f, last_heartbeat: 5.days.ago.to_f, languages: [])
+    DashboardRollup.create!(
+      user: @user,
+      dimension: DashboardRollup::PROJECT_DETAILS_DIMENSION,
+      bucket_value: project,
+      bucket_value_present: true,
+      total_seconds: total_seconds,
+      source_heartbeats_count: total_heartbeats,
+      source_max_heartbeat_time: last_heartbeat,
+      payload: {
+        first_heartbeat: first_heartbeat,
+        last_heartbeat: last_heartbeat,
+        languages: languages
+      }
     )
   end
 

--- a/test/lib/project_stats_query_test.rb
+++ b/test/lib/project_stats_query_test.rb
@@ -139,13 +139,14 @@ class ProjectStatsQueryTest < ActiveSupport::TestCase
     base = 5.days.ago.to_f
     create_heartbeat(project: "alpha", language: "Ruby", time: base)
     create_heartbeat(project: "alpha", language: "TypeScript", time: base + 60)
+    create_heartbeat(project: "alpha", language: "Visual Basic", time: base + 120)
     create_heartbeat(project: "beta", language: "Go", time: base + 120)
 
     query = ProjectStatsQuery.new(user: @user, params: {}, default_discovery_start: 0, default_stats_start: 0)
 
     project = query.project_details(names: [ "alpha" ]).first
 
-    assert_equal [ "Ruby", "TypeScript" ], project[:languages].sort
+    assert_equal [ "Ruby", "TypeScript", "Visual Basic" ], project[:languages].sort
   end
 
   test "project details uses project detail rollups for default all-time data" do
@@ -194,6 +195,7 @@ class ProjectStatsQueryTest < ActiveSupport::TestCase
     base = 5.days.ago.to_f
     create_heartbeat(project: "alpha", language: "Ruby", time: base)
     create_heartbeat(project: "alpha", language: "TypeScript", time: base + 60)
+    create_heartbeat(project: "alpha", language: "Visual Basic", time: base + 120)
 
     DashboardRollupRefreshService.new(user: @user).call
 
@@ -203,11 +205,11 @@ class ProjectStatsQueryTest < ActiveSupport::TestCase
       bucket_value: "alpha"
     )
 
-    assert_equal 60, rollup.total_seconds
-    assert_equal 2, rollup.source_heartbeats_count
+    assert_equal 120, rollup.total_seconds
+    assert_equal 3, rollup.source_heartbeats_count
     assert_in_delta base, rollup.payload["first_heartbeat"], 0.001
-    assert_in_delta base + 60, rollup.payload["last_heartbeat"], 0.001
-    assert_equal [ "Ruby", "TypeScript" ], rollup.payload["languages"].sort
+    assert_in_delta base + 120, rollup.payload["last_heartbeat"], 0.001
+    assert_equal [ "Ruby", "TypeScript", "Visual Basic" ], rollup.payload["languages"].sort
   end
 
   test "project details sorts projects by total_seconds descending" do

--- a/test/lib/wakatime_service_summary_test.rb
+++ b/test/lib/wakatime_service_summary_test.rb
@@ -1,0 +1,57 @@
+require "test_helper"
+
+class WakatimeServiceSummaryTest < ActiveSupport::TestCase
+  setup do
+    @original_cache = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+    Rails.cache.clear
+    @user = User.create!(username: "wts_#{SecureRandom.hex(4)}")
+  end
+
+  teardown do
+    Rails.cache.clear
+    Rails.cache = @original_cache
+  end
+
+  test "generate_summary uses cache when allowed" do
+    base = Time.current.beginning_of_day.to_i
+    create_heartbeat(project: "cached", language: "Ruby", time: base)
+    create_heartbeat(project: "cached", language: "Ruby", time: base + 60)
+
+    first_summary = summary_for(allow_cache: true)
+
+    create_heartbeat(project: "cached", language: "Ruby", time: base + 120)
+
+    cached_summary = summary_for(allow_cache: true)
+    fresh_summary = summary_for(allow_cache: false)
+
+    assert_equal first_summary[:total_seconds], cached_summary[:total_seconds]
+    assert_operator fresh_summary[:total_seconds], :>, cached_summary[:total_seconds]
+  end
+
+  private
+
+  def summary_for(allow_cache:)
+    WakatimeService.new(
+      user: @user,
+      specific_filters: [ :languages, :projects ],
+      allow_cache: allow_cache,
+      limit: nil,
+      start_date: Time.current.beginning_of_day,
+      end_date: Time.current.end_of_day
+    ).generate_summary
+  end
+
+  def create_heartbeat(project:, language:, time:)
+    @user.heartbeats.create!(
+      entity: "src/main.rb",
+      type: "file",
+      category: "coding",
+      editor: "vscode",
+      language: language,
+      time: time,
+      project: project,
+      source_type: :test_entry
+    )
+  end
+end

--- a/test/system/projects_test.rb
+++ b/test/system/projects_test.rb
@@ -12,6 +12,7 @@ class ProjectsTest < ApplicationSystemTestCase
     archived_mapping = @user.project_repo_mappings.create!(project_name: "archived-project")
     archived_mapping.archive!
     create_project_heartbeats(@user, "archived-project", started_at: 2.days.ago.change(hour: 14))
+    DashboardRollupRefreshService.new(user: @user).call
 
     visit my_projects_path
 


### PR DESCRIPTION
## Summary of the problem
The projects page took 1.5-2.5 seconds to show the projects themselves after the skeleton loaded in, which is... fine, but we can do better!

## Describe your changes
A few things:
- If we can use the all-time rollups, we now use them
- Interval queries are now faster (~5x)

## Screenshots / Media
N/A