### PR TITLE
Add `counter_culture` to heartbeats

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,10 @@ Skip running checks which aren't relevant to your changes. However, at the very 
 - **Auth**: `ensure_authenticated!` for APIs, token via `Authorization` header or `?api_key=`
 - **CSS**: Using Tailwind CSS, no inline styles, use utility classes. We define some custom classes in `config/tailwind.config.js` and `app/assets/tailwind/application.css`.
 
+## Heartbeat Counters
+
+`users.active_heartbeats_count` is a cached count of non-deleted heartbeats. Use it only through `User#active_heartbeats_count_or_count` so users that have not been backfilled still fall back to an exact count. Heartbeat bulk writes (`insert_all`, `update_all`, soft-delete/anonymization/merge paths) bypass callbacks, so update the counter explicitly when changing active heartbeat rows outside normal ActiveRecord create/update flows.
+
 ## Inertia Components
 
 On Inertia pages, use the `<Button />` component for buttons, not `<button>` tags.

--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,9 @@ gem "thruster", require: false
 # For query count tracking
 gem "query_count"
 
+# `counter_cache` on steroids
+gem "counter_culture"
+
 # Compact request logging
 gem "lograge"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,6 +138,9 @@ GEM
       zeitwerk (>= 2.5.0)
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
+    counter_culture (3.13.1)
+      activerecord (>= 4.2)
+      activesupport (>= 4.2)
     countries (8.1.0)
       unaccent (~> 0.3)
     crack (1.0.1)
@@ -667,6 +670,7 @@ DEPENDENCIES
   bullet
   capybara
   cloudflare-rails
+  counter_culture
   countries
   debug
   doorkeeper (~> 5.8)

--- a/app/controllers/admin/account_merger_controller.rb
+++ b/app/controllers/admin/account_merger_controller.rb
@@ -94,6 +94,8 @@ class Admin::AccountMergerController < InertiaController
     ActiveRecord::Base.transaction do
       # 1. Move heartbeats from newer to older
       heartbeat_count = Heartbeat.where(user_id: newer_user.id).update_all(user_id: older_user.id)
+      Heartbeat.adjust_active_count_for(older_user.id, heartbeat_count) if heartbeat_count.positive?
+      Heartbeat.adjust_active_count_for(newer_user.id, -heartbeat_count) if heartbeat_count.positive?
       results << "#{heartbeat_count} heartbeats moved"
 
       # 2. Transfer API keys from newer to older

--- a/app/controllers/concerns/api/admin/v1/user_utilities.rb
+++ b/app/controllers/concerns/api/admin/v1/user_utilities.rb
@@ -454,7 +454,7 @@ module Api
           query = query.where(editor: editor) if editor.present?
           query = query.where(machine: machine) if machine.present?
 
-          total_count = query.count
+          total_count = unfiltered_heartbeats_request? ? user.active_heartbeats_count_or_count : query.count
           source_types = Heartbeat.source_types.invert
           heartbeats = query.order(time: :asc).limit(limit).offset(offset).pluck(*HEARTBEAT_RESPONSE_COLUMNS).map do |id, time, lineno, cursorpos, is_write, project, language, entity, branch, category, editor, machine, user_agent, ip_address, lines, source_type|
             {
@@ -556,6 +556,10 @@ module Api
         rescue ActiveRecord::RecordNotFound
           render json: { error: "user not found" }, status: :not_found
           nil
+        end
+
+        def unfiltered_heartbeats_request?
+          params.values_at(:start_date, :end_date, :project, :language, :entity, :editor, :machine).all?(&:blank?)
         end
 
         def parse_date_param

--- a/app/controllers/settings/imports_exports_controller.rb
+++ b/app/controllers/settings/imports_exports_controller.rb
@@ -22,7 +22,7 @@ class Settings::ImportsExportsController < Settings::BaseController
     {
       data_export: InertiaRails.defer {
         {
-          total_heartbeats: number_with_delimiter(@user.heartbeats.count),
+          total_heartbeats: number_with_delimiter(@user.active_heartbeats_count_or_count),
           total_coding_time: @user.heartbeats.duration_simple,
           heartbeats_last_7_days: number_with_delimiter(@user.heartbeats.where("time >= ?", 7.days.ago.to_f).count),
           is_restricted: (@user.trust_level == "red")

--- a/app/jobs/one_time/transfer_user_data_job.rb
+++ b/app/jobs/one_time/transfer_user_data_job.rb
@@ -41,7 +41,9 @@ class OneTime::TransferUserDataJob < ApplicationJob
   end
 
   def transfer_heartbeats
-    Heartbeat.where(user_id: @source_user_id).update_all(user_id: @target_user_id)
+    heartbeat_count = Heartbeat.where(user_id: @source_user_id).update_all(user_id: @target_user_id)
+    Heartbeat.adjust_active_count_for(@target_user_id, heartbeat_count) if heartbeat_count.positive?
+    Heartbeat.adjust_active_count_for(@source_user_id, -heartbeat_count) if heartbeat_count.positive?
   end
 
   def source_user

--- a/app/models/heartbeat.rb
+++ b/app/models/heartbeat.rb
@@ -87,6 +87,7 @@ class Heartbeat < ApplicationRecord
   self.inheritance_column = nil
 
   belongs_to :user
+  counter_culture :user, column_name: proc { |heartbeat| heartbeat.deleted_at.nil? ? "active_heartbeats_count" : nil }
 
   validates :time, presence: true
 
@@ -111,13 +112,21 @@ class Heartbeat < ApplicationRecord
   end
 
   def soft_delete
+    was_active = deleted_at.nil?
     update_column(:deleted_at, Time.current)
+    self.class.adjust_active_count_for(user_id, -1) if was_active
     DashboardRollupRefreshJob.schedule_for(user_id)
   end
 
   def restore
+    was_deleted = deleted_at.present?
     update_column(:deleted_at, nil)
+    self.class.adjust_active_count_for(user_id, 1) if was_deleted
     DashboardRollupRefreshJob.schedule_for(user_id)
+  end
+
+  def self.adjust_active_count_for(user_id, amount)
+    User.where(id: user_id).update_all([ "active_heartbeats_count = COALESCE(active_heartbeats_count, 0) + ?", amount ])
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,7 @@ class User < ApplicationRecord
 
   after_create :subscribe_to_default_lists
   after_create_commit :schedule_onboarding_check_in_email
+  before_create :initialize_active_heartbeats_count
   before_validation :normalize_username
   encrypts :slack_access_token, :github_access_token, :hca_access_token
 
@@ -390,6 +391,12 @@ class User < ApplicationRecord
     heartbeats.where(source_type: :direct_entry).order(time: :desc).first
   end
 
+  def active_heartbeats_count_or_count
+    return active_heartbeats_count if active_heartbeats_count_backfilled?
+
+    heartbeats.count
+  end
+
   def create_email_signin_token(continue_param: nil)
     sign_in_tokens.create!(auth_type: :email, continue_param: continue_param)
   end
@@ -436,6 +443,11 @@ class User < ApplicationRecord
 
   def subscribe_to_default_lists
     subscribe("weekly_summary")
+  end
+
+  def initialize_active_heartbeats_count
+    self.active_heartbeats_count = 0 if active_heartbeats_count.nil?
+    self.active_heartbeats_count_backfilled = true
   end
 
   def schedule_onboarding_check_in_email

--- a/app/services/anonymize_user_service.rb
+++ b/app/services/anonymize_user_service.rb
@@ -76,7 +76,8 @@ class AnonymizeUserService < ApplicationService
     user.goals.destroy_all
 
     # tombstone
-    Heartbeat.unscoped.where(user_id: user.id, deleted_at: nil).update_all(deleted_at: Time.current)
+    tombstoned_heartbeats_count = Heartbeat.unscoped.where(user_id: user.id, deleted_at: nil).update_all(deleted_at: Time.current)
+    Heartbeat.adjust_active_count_for(user.id, -tombstoned_heartbeats_count) if tombstoned_heartbeats_count.positive?
 
     user.access_grants.destroy_all
     user.access_tokens.destroy_all

--- a/app/services/heartbeat_ingest.rb
+++ b/app/services/heartbeat_ingest.rb
@@ -121,6 +121,7 @@ class HeartbeatIngest
     end
 
     self.class.schedule_rollup_refresh(user: @user) if result.any? && @schedule_rollup_refresh
+    Heartbeat.adjust_active_count_for(@user.id, 1) if result.any?
     [ persisted, !result.any? ]
   end
 
@@ -196,7 +197,7 @@ class HeartbeatIngest
 
     ActiveRecord::Base.logger.silence do
       Heartbeat.insert_all(records, unique_by: [ :fields_hash ]).length
-    end
+    end.tap { |persisted_count| Heartbeat.adjust_active_count_for(@user.id, persisted_count) if persisted_count.positive? }
   end
 
   def parse_user_agent(user_agent)

--- a/db/migrate/20260521192204_add_active_heartbeats_count_to_users.rb
+++ b/db/migrate/20260521192204_add_active_heartbeats_count_to_users.rb
@@ -1,0 +1,6 @@
+class AddActiveHeartbeatsCountToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :active_heartbeats_count, :bigint
+    add_column :users, :active_heartbeats_count_backfilled, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_18_170142) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_21_192204) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -631,6 +631,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_18_170142) do
   end
 
   create_table "users", force: :cascade do |t|
+    t.bigint "active_heartbeats_count"
+    t.boolean "active_heartbeats_count_backfilled", default: false, null: false
     t.integer "admin_level", default: 0, null: false
     t.boolean "allow_public_stats_lookup", default: true, null: false
     t.string "country_code"


### PR DESCRIPTION
## Summary of the problem
It takes ~300ms to find all-time heartbeat counts for larger (1m+ heartbeats) users due to the sheer amount of rows. This can be very slow.

## Describe your changes
Adds `counter_culture`, which lets us find counts much faster, at the expense of slightly slower writes (but the indexes take up most of the write time anyway).

## Screenshots / Media
N/A