### PR TITLE
Unify user search around `User.fuzzy_ranked_search`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,3 +122,7 @@ Files under `app/javascript/api/` are gitignored and regenerated on every build:
 - **CI**: regenerated in the `frontend` and `test_system` jobs before Vite/svelte-check run; the `test` job triggers regeneration via Rails boot.
 
 After adding a route to `EXPORTED_ROUTES`, just refresh the page (or run `docker compose exec web bin/rake js_from_routes:generate`) — there's nothing to commit.
+
+## Searching for users
+- Need to show users to a human (search UI, picker)? → `fuzzy_ranked_search`
+- Need to find IDs to filter something else by? → `search_identity`

--- a/app/controllers/admin/account_merger_controller.rb
+++ b/app/controllers/admin/account_merger_controller.rb
@@ -6,19 +6,10 @@ class Admin::AccountMergerController < InertiaController
   def show = render(inertia: "Admin/AccountMerger")
 
   def search_users
-    query_term = params[:query].to_s.downcase.strip
+    query_term = params[:query].to_s.strip
     return render json: [] if query_term.blank?
 
-    users = User.search_identity(query_term)
-      .includes(:email_addresses)
-      .select(
-        "users.*, " \
-        "CASE WHEN LOWER(users.username) = #{ActiveRecord::Base.connection.quote(query_term)} " \
-        "THEN 0 ELSE 1 END AS exact_match_rank"
-      )
-      .order(Arel.sql("exact_match_rank ASC, users.username ASC"))
-      .limit(20)
-
+    users = User.fuzzy_ranked_search(query_term, limit: 20).includes(:email_addresses)
     render json: users.map { |user| format_user(user) }
   end
 

--- a/app/controllers/api/admin/v1/timeline_controller.rb
+++ b/app/controllers/api/admin/v1/timeline_controller.rb
@@ -46,20 +46,10 @@ module Api
         end
 
         def search_users
-          query_term = params[:query].to_s.downcase
+          query_term = params[:query].to_s
           return render_error("Query parameter is required") if query_term.blank?
 
-          if query_term.match?(/^\d+$/) && (match = User.find_by(id: query_term.to_i))
-            return render json: { users: [ user_summary(match) ] }
-          end
-
-          users = User.where(
-            "LOWER(username) LIKE :query OR LOWER(slack_username) LIKE :query OR CAST(id AS TEXT) LIKE :query OR EXISTS (SELECT 1 FROM email_addresses WHERE email_addresses.user_id = users.id AND LOWER(email_addresses.email) LIKE :query)",
-            query: "%#{query_term}%"
-          ).order(Arel.sql("CASE WHEN LOWER(username) = #{ActiveRecord::Base.connection.quote(query_term)} THEN 0 ELSE 1 END, username ASC"))
-            .limit(20)
-            .select(:id, :username, :slack_username, :github_username, :slack_avatar_url, :github_avatar_url)
-
+          users = User.fuzzy_ranked_search(query_term, limit: 20)
           render json: { users: users.map { |u| user_summary(u) } }
         end
 

--- a/app/controllers/concerns/api/admin/v1/user_utilities.rb
+++ b/app/controllers/concerns/api/admin/v1/user_utilities.rb
@@ -33,16 +33,12 @@ module Api
         def search_users_fuzzy
           return render_error("bro dont have a query") if params[:query].blank?
 
-          # Execute the relation's SQL directly to skip ActiveRecord object
-          # instantiation on this per-keystroke endpoint. `matched_email` is
-          # picked in SQL by UserFuzzySearch so there's no second query for
-          # email_addresses.
           relation = User.fuzzy_ranked_search(params[:query], limit: 10)
           rows = User.connection.execute(relation.to_sql).to_a
 
           render json: {
             users: rows.filter_map { |row|
-              next unless row["matched_email"] # preserve historical INNER JOIN behavior (only users with an email)
+              next unless row["matched_email"] # only users with an email
               {
                 id: row["id"],
                 username: row["username"],

--- a/app/controllers/concerns/api/admin/v1/user_utilities.rb
+++ b/app/controllers/concerns/api/admin/v1/user_utilities.rb
@@ -33,10 +33,6 @@ module Api
         def search_users_fuzzy
           return render_error("bro dont have a query") if params[:query].blank?
 
-          # select_all applies AR's type map so id/rank_score come back typed
-          # (Integer/Numeric) instead of the raw strings `connection.execute`
-          # would return, matching the Swagger schema. Still cheaper than full
-          # AR object instantiation since we skip model construction overhead.
           relation = User.fuzzy_ranked_search(params[:query], limit: 10)
           rows = User.connection.select_all(relation.to_sql).to_a
 

--- a/app/controllers/concerns/api/admin/v1/user_utilities.rb
+++ b/app/controllers/concerns/api/admin/v1/user_utilities.rb
@@ -33,72 +33,24 @@ module Api
         def search_users_fuzzy
           return render_error("bro dont have a query") if params[:query].blank?
 
-          query = ActiveRecord::Base.sanitize_sql_like(params[:query])
+          users = User.fuzzy_ranked_search(params[:query], limit: 10).includes(:email_addresses)
 
-          user_search_query = <<-SQL
-            SELECT
-              id, username, slack_username, github_username,
-              slack_avatar_url, github_avatar_url, email
-            FROM (
-              SELECT
-                users.id,
-                users.username,
-                users.slack_username,
-                users.github_username,
-                users.slack_avatar_url,
-                users.github_avatar_url,
-                email_addresses.email,
-                (
-                  CASE WHEN users.id::text = :query THEN 1000 ELSE 0 END +
-                  CASE WHEN users.slack_uid = :query THEN 1000 ELSE 0 END +
-                  CASE
-                    WHEN users.username ILIKE :query THEN 100
-                    WHEN users.username ILIKE :query || '%' THEN 50
-                    WHEN users.username ILIKE '%' || :query || '%' THEN 10
-                    ELSE 0
-                  END +
-                  CASE
-                    WHEN users.github_username ILIKE :query THEN 100
-                    WHEN users.github_username ILIKE :query || '%' THEN 50
-                    WHEN users.github_username ILIKE '%' || :query || '%' THEN 10
-                    ELSE 0
-                  END +
-                  CASE
-                    WHEN users.slack_username ILIKE :query THEN 100
-                    WHEN users.slack_username ILIKE :query || '%' THEN 50
-                    WHEN users.slack_username ILIKE '%' || :query || '%' THEN 10
-                    ELSE 0
-                  END +
-                  CASE
-                    WHEN email_addresses.email ILIKE :query THEN 100
-                    WHEN email_addresses.email ILIKE :query || '%' THEN 50
-                    WHEN email_addresses.email ILIKE '%' || :query || '%' THEN 10
-                    ELSE 0
-                  END
-                ) AS rank_score
-              FROM
-                users
-                INNER JOIN email_addresses ON users.id=email_addresses.user_id
-              WHERE
-                users.id::text = :query
-                OR users.slack_uid = :query
-                OR users.username ILIKE '%' || :query || '%'
-                OR users.github_username ILIKE '%' || :query || '%'
-                OR users.slack_username ILIKE '%' || :query || '%'
-                OR email_addresses.email ILIKE '%' || :query || '%'
-            ) AS ranked_users
-            WHERE
-              rank_score > 0
-            ORDER BY
-              rank_score DESC,
-              username ASC
-            LIMIT 10
-          SQL
-
-          sanitized_query = ActiveRecord::Base.sanitize_sql([ user_search_query, query: query ])
-          result = ActiveRecord::Base.connection.execute(sanitized_query)
-
-          render json: { users: result.to_a }
+          render json: {
+            users: users.filter_map { |user|
+              email = user.email_addresses.first&.email
+              next unless email # preserve historical INNER JOIN behavior (only users with an email)
+              {
+                id: user.id,
+                username: user.username,
+                slack_username: user.slack_username,
+                github_username: user.github_username,
+                slack_avatar_url: user.slack_avatar_url,
+                github_avatar_url: user.github_avatar_url,
+                email: email,
+                rank_score: user.rank_score
+              }
+            }
+          }
         end
 
         def get_users_by_ip

--- a/app/controllers/concerns/api/admin/v1/user_utilities.rb
+++ b/app/controllers/concerns/api/admin/v1/user_utilities.rb
@@ -356,10 +356,6 @@ module Api
 
         private
 
-        # Pick the email that best matches the query so the response reflects
-        # the address the rank score came from (mirrors the per-email scoring
-        # tiers in UserFuzzySearch). Falls back to the first email if none
-        # match; returns nil if the user has no emails.
         def best_matching_email(user, lower_query)
           emails = user.email_addresses.filter_map(&:email)
           return nil if emails.empty?

--- a/app/controllers/concerns/api/admin/v1/user_utilities.rb
+++ b/app/controllers/concerns/api/admin/v1/user_utilities.rb
@@ -34,10 +34,11 @@ module Api
           return render_error("bro dont have a query") if params[:query].blank?
 
           users = User.fuzzy_ranked_search(params[:query], limit: 10).includes(:email_addresses)
+          lower_query = params[:query].to_s.strip.downcase
 
           render json: {
             users: users.filter_map { |user|
-              email = user.email_addresses.first&.email
+              email = best_matching_email(user, lower_query)
               next unless email # preserve historical INNER JOIN behavior (only users with an email)
               {
                 id: user.id,
@@ -354,6 +355,24 @@ module Api
         end
 
         private
+
+        # Pick the email that best matches the query so the response reflects
+        # the address the rank score came from (mirrors the per-email scoring
+        # tiers in UserFuzzySearch). Falls back to the first email if none
+        # match; returns nil if the user has no emails.
+        def best_matching_email(user, lower_query)
+          emails = user.email_addresses.filter_map(&:email)
+          return nil if emails.empty?
+
+          emails.max_by do |email|
+            e = email.downcase
+            if e == lower_query then 3
+            elsif e.start_with?(lower_query) then 2
+            elsif e.include?(lower_query) then 1
+            else 0
+            end
+          end
+        end
 
         def can_write!
           render_forbidden("no perms lmaooo") unless current_user.admin_level.in?(AuthHelpers::ADMIN_LEVELS)

--- a/app/controllers/concerns/api/admin/v1/user_utilities.rb
+++ b/app/controllers/concerns/api/admin/v1/user_utilities.rb
@@ -33,22 +33,25 @@ module Api
         def search_users_fuzzy
           return render_error("bro dont have a query") if params[:query].blank?
 
-          users = User.fuzzy_ranked_search(params[:query], limit: 10).includes(:email_addresses)
-          lower_query = params[:query].to_s.strip.downcase
+          # Execute the relation's SQL directly to skip ActiveRecord object
+          # instantiation on this per-keystroke endpoint. `matched_email` is
+          # picked in SQL by UserFuzzySearch so there's no second query for
+          # email_addresses.
+          relation = User.fuzzy_ranked_search(params[:query], limit: 10)
+          rows = User.connection.execute(relation.to_sql).to_a
 
           render json: {
-            users: users.filter_map { |user|
-              email = best_matching_email(user, lower_query)
-              next unless email # preserve historical INNER JOIN behavior (only users with an email)
+            users: rows.filter_map { |row|
+              next unless row["matched_email"] # preserve historical INNER JOIN behavior (only users with an email)
               {
-                id: user.id,
-                username: user.username,
-                slack_username: user.slack_username,
-                github_username: user.github_username,
-                slack_avatar_url: user.slack_avatar_url,
-                github_avatar_url: user.github_avatar_url,
-                email: email,
-                rank_score: user.rank_score
+                id: row["id"],
+                username: row["username"],
+                slack_username: row["slack_username"],
+                github_username: row["github_username"],
+                slack_avatar_url: row["slack_avatar_url"],
+                github_avatar_url: row["github_avatar_url"],
+                email: row["matched_email"],
+                rank_score: row["rank_score"]
               }
             }
           }
@@ -355,20 +358,6 @@ module Api
         end
 
         private
-
-        def best_matching_email(user, lower_query)
-          emails = user.email_addresses.filter_map(&:email)
-          return nil if emails.empty?
-
-          emails.max_by do |email|
-            e = email.downcase
-            if e == lower_query then 3
-            elsif e.start_with?(lower_query) then 2
-            elsif e.include?(lower_query) then 1
-            else 0
-            end
-          end
-        end
 
         def can_write!
           render_forbidden("no perms lmaooo") unless current_user.admin_level.in?(AuthHelpers::ADMIN_LEVELS)

--- a/app/controllers/concerns/api/admin/v1/user_utilities.rb
+++ b/app/controllers/concerns/api/admin/v1/user_utilities.rb
@@ -33,12 +33,16 @@ module Api
         def search_users_fuzzy
           return render_error("bro dont have a query") if params[:query].blank?
 
+          # select_all applies AR's type map so id/rank_score come back typed
+          # (Integer/Numeric) instead of the raw strings `connection.execute`
+          # would return, matching the Swagger schema. Still cheaper than full
+          # AR object instantiation since we skip model construction overhead.
           relation = User.fuzzy_ranked_search(params[:query], limit: 10)
-          rows = User.connection.execute(relation.to_sql).to_a
+          rows = User.connection.select_all(relation.to_sql).to_a
 
           render json: {
             users: rows.filter_map { |row|
-              next unless row["matched_email"] # only users with an email
+              next unless row["has_any_email"] # gate: preserve legacy INNER JOIN behavior
               {
                 id: row["id"],
                 username: row["username"],

--- a/app/models/concerns/user_fuzzy_search.rb
+++ b/app/models/concerns/user_fuzzy_search.rb
@@ -2,11 +2,6 @@ module UserFuzzySearch
   extend ActiveSupport::Concern
 
   class_methods do
-    # Ranked fuzzy search across id/slack_uid/username/github_username/slack_username/email.
-    # Returns a Relation with a virtual `rank_score` attribute on each record. Pass the
-    # raw user-supplied term — the method downcases internally for case-insensitive LIKE
-    # matching but uses the term verbatim for case-sensitive exact comparisons against
-    # `users.slack_uid` and `users.id::text`.
     def fuzzy_ranked_search(term, limit: 20)
       term = term.to_s.strip
       return none if term.blank?

--- a/app/models/concerns/user_fuzzy_search.rb
+++ b/app/models/concerns/user_fuzzy_search.rb
@@ -2,51 +2,88 @@ module UserFuzzySearch
   extend ActiveSupport::Concern
 
   class_methods do
+    # Ranked fuzzy search across id/slack_uid/username/github_username/slack_username/email.
+    # Returns a Relation with two virtual attributes per record:
+    #
+    #   * `rank_score`    — weighted match score: id/slack_uid exact = 1000,
+    #                       field exact = 100, prefix = 50, contains = 10
+    #   * `matched_email` — the email_addresses row that best matches the query
+    #                       (exact > prefix > contains; NULL if the user matched
+    #                       on a non-email field).
+    #
+    # Pass the raw user-supplied term. The method uses ILIKE for case-insensitive
+    # matching but compares `users.slack_uid` and the numeric `users.id` lookup
+    # case-sensitively, so callers must NOT pre-downcase or mixed-case Slack UIDs
+    # miss the 1000-point exact path.
+    #
+    # Implementation note: the candidate-ID lookup uses UNION over per-column
+    # index-using subqueries rather than a flat OR across joined tables, because
+    # PG can't `BitmapOr` across tables joined with OR. Each subquery hits its
+    # column's gin_trgm_ops index (users.{username,slack_username,github_username},
+    # email_addresses.email) or B-tree index (users.slack_uid, users.id) — added
+    # in 20260526120000_add_trgm_indexes_for_admin_user_search.rb.
     def fuzzy_ranked_search(term, limit: 20)
       term = term.to_s.strip
       return none if term.blank?
 
-      sanitized = sanitize_sql_like(term.downcase)
+      sanitized = sanitize_sql_like(term)
+      numeric_id = (term.match?(/\A\d+\z/) ? term.to_i : nil)
       binds = {
         exact: term,
-        lower: term.downcase,
+        ilike_exact: sanitized,
         prefix: "#{sanitized}%",
         contains: "%#{sanitized}%"
       }
 
+      candidate_parts = [
+        "SELECT id FROM users WHERE slack_uid = :exact",
+        "SELECT id FROM users WHERE username ILIKE :contains",
+        "SELECT id FROM users WHERE github_username ILIKE :contains",
+        "SELECT id FROM users WHERE slack_username ILIKE :contains",
+        "SELECT user_id AS id FROM email_addresses WHERE email ILIKE :contains"
+      ]
+      candidate_parts << "SELECT id FROM users WHERE id = #{numeric_id}" if numeric_id
+
+      candidates_sql = sanitize_sql_for_conditions([ candidate_parts.join(" UNION "), binds ])
+
       rank_sql = sanitize_sql_for_conditions([ <<~SQL.squish, binds ])
         CASE WHEN users.id::text = :exact THEN 1000 ELSE 0 END +
         CASE WHEN users.slack_uid = :exact THEN 1000 ELSE 0 END +
-        CASE WHEN LOWER(users.username) = :lower THEN 100
-             WHEN LOWER(users.username) LIKE :prefix THEN 50
-             WHEN LOWER(users.username) LIKE :contains THEN 10
+        CASE WHEN users.username ILIKE :ilike_exact THEN 100
+             WHEN users.username ILIKE :prefix THEN 50
+             WHEN users.username ILIKE :contains THEN 10
              ELSE 0 END +
-        CASE WHEN LOWER(users.github_username) = :lower THEN 100
-             WHEN LOWER(users.github_username) LIKE :prefix THEN 50
-             WHEN LOWER(users.github_username) LIKE :contains THEN 10
+        CASE WHEN users.github_username ILIKE :ilike_exact THEN 100
+             WHEN users.github_username ILIKE :prefix THEN 50
+             WHEN users.github_username ILIKE :contains THEN 10
              ELSE 0 END +
-        CASE WHEN LOWER(users.slack_username) = :lower THEN 100
-             WHEN LOWER(users.slack_username) LIKE :prefix THEN 50
-             WHEN LOWER(users.slack_username) LIKE :contains THEN 10
+        CASE WHEN users.slack_username ILIKE :ilike_exact THEN 100
+             WHEN users.slack_username ILIKE :prefix THEN 50
+             WHEN users.slack_username ILIKE :contains THEN 10
              ELSE 0 END +
         COALESCE(MAX(
-          CASE WHEN LOWER(email_addresses.email) = :lower THEN 100
-               WHEN LOWER(email_addresses.email) LIKE :prefix THEN 50
-               WHEN LOWER(email_addresses.email) LIKE :contains THEN 10
+          CASE WHEN email_addresses.email ILIKE :ilike_exact THEN 100
+               WHEN email_addresses.email ILIKE :prefix THEN 50
+               WHEN email_addresses.email ILIKE :contains THEN 10
                ELSE 0 END
         ), 0)
       SQL
 
-      left_joins(:email_addresses)
-        .select(Arel.sql("users.*, (#{rank_sql}) AS rank_score"))
-        .where(
-          "users.id::text = :exact OR users.slack_uid = :exact OR " \
-          "LOWER(users.username) LIKE :contains OR " \
-          "LOWER(users.github_username) LIKE :contains OR " \
-          "LOWER(users.slack_username) LIKE :contains OR " \
-          "LOWER(email_addresses.email) LIKE :contains",
-          binds
+      matched_email_sql = sanitize_sql_for_conditions([ <<~SQL.squish, binds ])
+        COALESCE(
+          MAX(CASE WHEN email_addresses.email ILIKE :ilike_exact THEN email_addresses.email END),
+          MAX(CASE WHEN email_addresses.email ILIKE :prefix      THEN email_addresses.email END),
+          MAX(CASE WHEN email_addresses.email ILIKE :contains    THEN email_addresses.email END)
         )
+      SQL
+
+      left_joins(:email_addresses)
+        .select(Arel.sql(
+          "users.*, " \
+          "(#{rank_sql}) AS rank_score, " \
+          "(#{matched_email_sql}) AS matched_email"
+        ))
+        .where("users.id IN (#{candidates_sql})")
         .group("users.id")
         .order(Arel.sql("rank_score DESC, users.username ASC"))
         .limit(limit)

--- a/app/models/concerns/user_fuzzy_search.rb
+++ b/app/models/concerns/user_fuzzy_search.rb
@@ -2,26 +2,6 @@ module UserFuzzySearch
   extend ActiveSupport::Concern
 
   class_methods do
-    # Ranked fuzzy search across id/slack_uid/username/github_username/slack_username/email.
-    # Returns a Relation with two virtual attributes per record:
-    #
-    #   * `rank_score`    — weighted match score: id/slack_uid exact = 1000,
-    #                       field exact = 100, prefix = 50, contains = 10
-    #   * `matched_email` — the email_addresses row that best matches the query
-    #                       (exact > prefix > contains; NULL if the user matched
-    #                       on a non-email field).
-    #
-    # Pass the raw user-supplied term. The method uses ILIKE for case-insensitive
-    # matching but compares `users.slack_uid` and the numeric `users.id` lookup
-    # case-sensitively, so callers must NOT pre-downcase or mixed-case Slack UIDs
-    # miss the 1000-point exact path.
-    #
-    # Implementation note: the candidate-ID lookup uses UNION over per-column
-    # index-using subqueries rather than a flat OR across joined tables, because
-    # PG can't `BitmapOr` across tables joined with OR. Each subquery hits its
-    # column's gin_trgm_ops index (users.{username,slack_username,github_username},
-    # email_addresses.email) or B-tree index (users.slack_uid, users.id) — added
-    # in 20260526120000_add_trgm_indexes_for_admin_user_search.rb.
     def fuzzy_ranked_search(term, limit: 20)
       term = term.to_s.strip
       return none if term.blank?

--- a/app/models/concerns/user_fuzzy_search.rb
+++ b/app/models/concerns/user_fuzzy_search.rb
@@ -62,7 +62,8 @@ module UserFuzzySearch
         .select(Arel.sql(
           "users.*, " \
           "(#{rank_sql}) AS rank_score, " \
-          "(#{matched_email_sql}) AS matched_email"
+          "(#{matched_email_sql}) AS matched_email, " \
+          "(MAX(email_addresses.id) IS NOT NULL) AS has_any_email"
         ))
         .where("users.id IN (#{candidates_sql})")
         .group("users.id")

--- a/app/models/concerns/user_fuzzy_search.rb
+++ b/app/models/concerns/user_fuzzy_search.rb
@@ -1,0 +1,60 @@
+module UserFuzzySearch
+  extend ActiveSupport::Concern
+
+  class_methods do
+    # Ranked fuzzy search across id/slack_uid/username/github_username/slack_username/email.
+    # Returns a Relation with a virtual `rank_score` attribute on each record. Pass the
+    # raw user-supplied term — the method downcases internally for case-insensitive LIKE
+    # matching but uses the term verbatim for case-sensitive exact comparisons against
+    # `users.slack_uid` and `users.id::text`.
+    def fuzzy_ranked_search(term, limit: 20)
+      term = term.to_s.strip
+      return none if term.blank?
+
+      sanitized = sanitize_sql_like(term.downcase)
+      binds = {
+        exact: term,
+        lower: term.downcase,
+        prefix: "#{sanitized}%",
+        contains: "%#{sanitized}%"
+      }
+
+      rank_sql = sanitize_sql_for_conditions([ <<~SQL.squish, binds ])
+        CASE WHEN users.id::text = :exact THEN 1000 ELSE 0 END +
+        CASE WHEN users.slack_uid = :exact THEN 1000 ELSE 0 END +
+        CASE WHEN LOWER(users.username) = :lower THEN 100
+             WHEN LOWER(users.username) LIKE :prefix THEN 50
+             WHEN LOWER(users.username) LIKE :contains THEN 10
+             ELSE 0 END +
+        CASE WHEN LOWER(users.github_username) = :lower THEN 100
+             WHEN LOWER(users.github_username) LIKE :prefix THEN 50
+             WHEN LOWER(users.github_username) LIKE :contains THEN 10
+             ELSE 0 END +
+        CASE WHEN LOWER(users.slack_username) = :lower THEN 100
+             WHEN LOWER(users.slack_username) LIKE :prefix THEN 50
+             WHEN LOWER(users.slack_username) LIKE :contains THEN 10
+             ELSE 0 END +
+        COALESCE(MAX(
+          CASE WHEN LOWER(email_addresses.email) = :lower THEN 100
+               WHEN LOWER(email_addresses.email) LIKE :prefix THEN 50
+               WHEN LOWER(email_addresses.email) LIKE :contains THEN 10
+               ELSE 0 END
+        ), 0)
+      SQL
+
+      left_joins(:email_addresses)
+        .select(Arel.sql("users.*, (#{rank_sql}) AS rank_score"))
+        .where(
+          "users.id::text = :exact OR users.slack_uid = :exact OR " \
+          "LOWER(users.username) LIKE :contains OR " \
+          "LOWER(users.github_username) LIKE :contains OR " \
+          "LOWER(users.slack_username) LIKE :contains OR " \
+          "LOWER(email_addresses.email) LIKE :contains",
+          binds
+        )
+        .group("users.id")
+        .order(Arel.sql("rank_score DESC, users.username ASC"))
+        .limit(limit)
+    end
+  end
+end

--- a/app/models/concerns/user_fuzzy_search.rb
+++ b/app/models/concerns/user_fuzzy_search.rb
@@ -53,7 +53,8 @@ module UserFuzzySearch
         COALESCE(
           MAX(CASE WHEN email_addresses.email ILIKE :ilike_exact THEN email_addresses.email END),
           MAX(CASE WHEN email_addresses.email ILIKE :prefix      THEN email_addresses.email END),
-          MAX(CASE WHEN email_addresses.email ILIKE :contains    THEN email_addresses.email END)
+          MAX(CASE WHEN email_addresses.email ILIKE :contains    THEN email_addresses.email END),
+          MAX(email_addresses.email)
         )
       SQL
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -166,22 +166,31 @@ class User < ApplicationRecord
 
   has_many :heartbeat_import_runs, dependent: :destroy
 
+  # Unranked, unlimited fuzzy lookup for cross-table filtering (admin endpoints
+  # that pluck the IDs to filter a different table). Use `fuzzy_ranked_search`
+  # instead when you need ranked top-N results with rank_score / matched_email.
+  #
+  # Matches: username, slack_username, github_username, email (substring), plus
+  # exact user id when the term is purely numeric. Per-column subqueries are
+  # UNION'd so each hits its own gin_trgm_ops index — a flat OR across joined
+  # tables defeats BitmapOr and forces a seq scan.
   scope :search_identity, ->(term) {
-    term = term.to_s.strip.downcase
+    term = term.to_s.strip
     return none if term.blank?
 
-    pattern = "%#{sanitize_sql_like(term)}%"
+    contains = "%#{sanitize_sql_like(term)}%"
+    numeric_id = (term.match?(/\A\d+\z/) ? term.to_i : nil)
 
-    left_joins(:email_addresses)
-      .where(
-        "LOWER(users.username) LIKE :p OR " \
-        "LOWER(users.slack_username) LIKE :p OR " \
-        "LOWER(users.github_username) LIKE :p OR " \
-        "LOWER(email_addresses.email) LIKE :p OR " \
-        "CAST(users.id AS TEXT) LIKE :p",
-        p: pattern
-      )
-      .distinct
+    parts = [
+      "SELECT id FROM users WHERE username ILIKE :contains",
+      "SELECT id FROM users WHERE slack_username ILIKE :contains",
+      "SELECT id FROM users WHERE github_username ILIKE :contains",
+      "SELECT user_id AS id FROM email_addresses WHERE email ILIKE :contains"
+    ]
+    parts << "SELECT id FROM users WHERE id = #{numeric_id}" if numeric_id
+
+    candidates_sql = sanitize_sql_for_conditions([ parts.join(" UNION "), { contains: contains } ])
+    where("users.id IN (#{candidates_sql})")
   }
 
   has_many :trust_level_audit_logs, dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -166,14 +166,6 @@ class User < ApplicationRecord
 
   has_many :heartbeat_import_runs, dependent: :destroy
 
-  # Unranked, unlimited fuzzy lookup for cross-table filtering (admin endpoints
-  # that pluck the IDs to filter a different table). Use `fuzzy_ranked_search`
-  # instead when you need ranked top-N results with rank_score / matched_email.
-  #
-  # Matches: username, slack_username, github_username, email (substring), plus
-  # exact user id when the term is purely numeric. Per-column subqueries are
-  # UNION'd so each hits its own gin_trgm_ops index — a flat OR across joined
-  # tables defeats BitmapOr and forces a seq scan.
   scope :search_identity, ->(term) {
     term = term.to_s.strip
     return none if term.blank?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ class User < ApplicationRecord
 
   include TimezoneRegions
   include UserThemeConfiguration
+  include UserFuzzySearch
   include ::OauthAuthentication
   include ::SlackIntegration
   include ::GithubIntegration

--- a/db/migrate/20260526120000_add_trgm_indexes_for_admin_user_search.rb
+++ b/db/migrate/20260526120000_add_trgm_indexes_for_admin_user_search.rb
@@ -1,0 +1,32 @@
+class AddTrgmIndexesForAdminUserSearch < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  # GIN trigram indexes let the admin user-search ILIKE '%term%' predicates run
+  # against an index instead of seq-scanning users / email_addresses.
+  INDEXES = {
+    users: %i[username slack_username github_username],
+    email_addresses: %i[email]
+  }.freeze
+
+  def up
+    enable_extension :pg_trgm unless extension_enabled?(:pg_trgm)
+
+    INDEXES.each do |table, columns|
+      columns.each do |column|
+        execute <<~SQL
+          CREATE INDEX CONCURRENTLY IF NOT EXISTS index_#{table}_on_#{column}_trgm
+            ON #{table}
+            USING gin (#{column} gin_trgm_ops)
+        SQL
+      end
+    end
+  end
+
+  def down
+    INDEXES.each do |table, columns|
+      columns.each do |column|
+        execute "DROP INDEX CONCURRENTLY IF EXISTS index_#{table}_on_#{column}_trgm"
+      end
+    end
+  end
+end

--- a/db/migrate/20260526120000_add_trgm_indexes_for_admin_user_search.rb
+++ b/db/migrate/20260526120000_add_trgm_indexes_for_admin_user_search.rb
@@ -13,11 +13,12 @@ class AddTrgmIndexesForAdminUserSearch < ActiveRecord::Migration[8.1]
 
     INDEXES.each do |table, columns|
       columns.each do |column|
-        execute <<~SQL
-          CREATE INDEX CONCURRENTLY IF NOT EXISTS index_#{table}_on_#{column}_trgm
-            ON #{table}
-            USING gin (#{column} gin_trgm_ops)
-        SQL
+        add_index table, column,
+                  name: "index_#{table}_on_#{column}_trgm",
+                  using: :gin,
+                  opclass: :gin_trgm_ops,
+                  algorithm: :concurrently,
+                  if_not_exists: true
       end
     end
   end
@@ -25,7 +26,10 @@ class AddTrgmIndexesForAdminUserSearch < ActiveRecord::Migration[8.1]
   def down
     INDEXES.each do |table, columns|
       columns.each do |column|
-        execute "DROP INDEX CONCURRENTLY IF EXISTS index_#{table}_on_#{column}_trgm"
+        remove_index table, column,
+                     name: "index_#{table}_on_#{column}_trgm",
+                     algorithm: :concurrently,
+                     if_exists: true
       end
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_26_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_18_170142) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -121,7 +121,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_26_120000) do
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.index ["email"], name: "index_email_addresses_on_email", unique: true
-    t.index ["email"], name: "index_email_addresses_on_email_trgm", opclass: :gin_trgm_ops, using: :gin
     t.index ["user_id"], name: "index_email_addresses_on_user_id"
   end
 
@@ -151,36 +150,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_26_120000) do
     t.datetime "updated_at", null: false
     t.text "value"
     t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true
-  end
-
-  create_table "github_app_installations", force: :cascade do |t|
-    t.bigint "account_github_id"
-    t.string "account_login", null: false
-    t.string "account_type", null: false
-    t.datetime "created_at", null: false
-    t.bigint "installation_id", null: false
-    t.datetime "suspended_at"
-    t.datetime "updated_at", null: false
-    t.bigint "user_id"
-    t.index ["account_github_id"], name: "index_github_app_installations_on_account_github_id"
-    t.index ["installation_id"], name: "index_github_app_installations_on_installation_id", unique: true
-    t.index ["user_id"], name: "index_github_app_installations_on_user_id"
-  end
-
-  create_table "github_app_repositories", force: :cascade do |t|
-    t.boolean "archived", default: false, null: false
-    t.datetime "created_at", null: false
-    t.string "full_name", null: false
-    t.bigint "github_app_installation_id", null: false
-    t.bigint "github_repo_id", null: false
-    t.string "html_url", null: false
-    t.boolean "private", default: false, null: false
-    t.bigint "repository_id"
-    t.datetime "updated_at", null: false
-    t.index ["full_name"], name: "index_github_app_repositories_on_full_name"
-    t.index ["github_app_installation_id"], name: "index_github_app_repositories_on_github_app_installation_id"
-    t.index ["github_repo_id"], name: "index_github_app_repositories_on_github_repo_id", unique: true
-    t.index ["repository_id"], name: "index_github_app_repositories_on_repository_id"
   end
 
   create_table "goals", force: :cascade do |t|
@@ -329,13 +298,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_26_120000) do
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.index ["user_id"], name: "index_heartbeat_import_sources_on_user_id", unique: true
-  end
-
-  create_table "heartbeat_user_agents", primary_key: "user_agent", id: :text, force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.float "first_seen_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["user_agent"], name: "index_heartbeat_user_agents_trgm", opclass: :gin_trgm_ops, using: :gin
   end
 
   create_table "heartbeats", force: :cascade do |t|
@@ -684,8 +646,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_26_120000) do
     t.string "hca_access_token"
     t.string "hca_id"
     t.string "hca_scopes", default: [], array: true
-    t.text "leaderboard_shadowban_reason"
-    t.boolean "leaderboard_shadowbanned", default: false, null: false
     t.text "profile_bio"
     t.string "profile_bluesky_url"
     t.string "profile_discord_url"
@@ -709,14 +669,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_26_120000) do
     t.boolean "weekly_summary_email_enabled", default: true, null: false
     t.index ["github_uid", "github_access_token"], name: "index_users_on_github_uid_and_access_token"
     t.index ["github_uid"], name: "index_users_on_github_uid"
-    t.index ["github_username"], name: "index_users_on_github_username_trgm", opclass: :gin_trgm_ops, using: :gin
-    t.index ["leaderboard_shadowbanned"], name: "index_users_on_leaderboard_shadowbanned", where: "(leaderboard_shadowbanned = true)"
     t.index ["slack_uid"], name: "index_users_on_slack_uid", unique: true
-    t.index ["slack_username"], name: "index_users_on_slack_username_trgm", opclass: :gin_trgm_ops, using: :gin
     t.index ["timezone", "trust_level"], name: "index_users_on_timezone_trust_level"
     t.index ["timezone"], name: "index_users_on_timezone"
     t.index ["username"], name: "index_users_on_username"
-    t.index ["username"], name: "index_users_on_username_trgm", opclass: :gin_trgm_ops, using: :gin
   end
 
   create_table "versions", force: :cascade do |t|
@@ -757,7 +713,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_26_120000) do
   add_foreign_key "deletion_requests", "users", column: "admin_approved_by_id"
   add_foreign_key "email_addresses", "users"
   add_foreign_key "email_verification_requests", "users"
-  add_foreign_key "github_app_repositories", "github_app_installations"
   add_foreign_key "goals", "users"
   add_foreign_key "heartbeat_import_runs", "users"
   add_foreign_key "heartbeat_import_sources", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_18_170142) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_26_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -121,6 +121,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_18_170142) do
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.index ["email"], name: "index_email_addresses_on_email", unique: true
+    t.index ["email"], name: "index_email_addresses_on_email_trgm", opclass: :gin_trgm_ops, using: :gin
     t.index ["user_id"], name: "index_email_addresses_on_user_id"
   end
 
@@ -150,6 +151,36 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_18_170142) do
     t.datetime "updated_at", null: false
     t.text "value"
     t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true
+  end
+
+  create_table "github_app_installations", force: :cascade do |t|
+    t.bigint "account_github_id"
+    t.string "account_login", null: false
+    t.string "account_type", null: false
+    t.datetime "created_at", null: false
+    t.bigint "installation_id", null: false
+    t.datetime "suspended_at"
+    t.datetime "updated_at", null: false
+    t.bigint "user_id"
+    t.index ["account_github_id"], name: "index_github_app_installations_on_account_github_id"
+    t.index ["installation_id"], name: "index_github_app_installations_on_installation_id", unique: true
+    t.index ["user_id"], name: "index_github_app_installations_on_user_id"
+  end
+
+  create_table "github_app_repositories", force: :cascade do |t|
+    t.boolean "archived", default: false, null: false
+    t.datetime "created_at", null: false
+    t.string "full_name", null: false
+    t.bigint "github_app_installation_id", null: false
+    t.bigint "github_repo_id", null: false
+    t.string "html_url", null: false
+    t.boolean "private", default: false, null: false
+    t.bigint "repository_id"
+    t.datetime "updated_at", null: false
+    t.index ["full_name"], name: "index_github_app_repositories_on_full_name"
+    t.index ["github_app_installation_id"], name: "index_github_app_repositories_on_github_app_installation_id"
+    t.index ["github_repo_id"], name: "index_github_app_repositories_on_github_repo_id", unique: true
+    t.index ["repository_id"], name: "index_github_app_repositories_on_repository_id"
   end
 
   create_table "goals", force: :cascade do |t|
@@ -298,6 +329,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_18_170142) do
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.index ["user_id"], name: "index_heartbeat_import_sources_on_user_id", unique: true
+  end
+
+  create_table "heartbeat_user_agents", primary_key: "user_agent", id: :text, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.float "first_seen_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_agent"], name: "index_heartbeat_user_agents_trgm", opclass: :gin_trgm_ops, using: :gin
   end
 
   create_table "heartbeats", force: :cascade do |t|
@@ -646,6 +684,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_18_170142) do
     t.string "hca_access_token"
     t.string "hca_id"
     t.string "hca_scopes", default: [], array: true
+    t.text "leaderboard_shadowban_reason"
+    t.boolean "leaderboard_shadowbanned", default: false, null: false
     t.text "profile_bio"
     t.string "profile_bluesky_url"
     t.string "profile_discord_url"
@@ -669,10 +709,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_18_170142) do
     t.boolean "weekly_summary_email_enabled", default: true, null: false
     t.index ["github_uid", "github_access_token"], name: "index_users_on_github_uid_and_access_token"
     t.index ["github_uid"], name: "index_users_on_github_uid"
+    t.index ["github_username"], name: "index_users_on_github_username_trgm", opclass: :gin_trgm_ops, using: :gin
+    t.index ["leaderboard_shadowbanned"], name: "index_users_on_leaderboard_shadowbanned", where: "(leaderboard_shadowbanned = true)"
     t.index ["slack_uid"], name: "index_users_on_slack_uid", unique: true
+    t.index ["slack_username"], name: "index_users_on_slack_username_trgm", opclass: :gin_trgm_ops, using: :gin
     t.index ["timezone", "trust_level"], name: "index_users_on_timezone_trust_level"
     t.index ["timezone"], name: "index_users_on_timezone"
     t.index ["username"], name: "index_users_on_username"
+    t.index ["username"], name: "index_users_on_username_trgm", opclass: :gin_trgm_ops, using: :gin
   end
 
   create_table "versions", force: :cascade do |t|
@@ -713,6 +757,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_18_170142) do
   add_foreign_key "deletion_requests", "users", column: "admin_approved_by_id"
   add_foreign_key "email_addresses", "users"
   add_foreign_key "email_verification_requests", "users"
+  add_foreign_key "github_app_repositories", "github_app_installations"
   add_foreign_key "goals", "users"
   add_foreign_key "heartbeat_import_runs", "users"
   add_foreign_key "heartbeat_import_sources", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_18_170142) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_26_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -121,6 +121,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_18_170142) do
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.index ["email"], name: "index_email_addresses_on_email", unique: true
+    t.index ["email"], name: "index_email_addresses_on_email_trgm", opclass: :gin_trgm_ops, using: :gin
     t.index ["user_id"], name: "index_email_addresses_on_user_id"
   end
 
@@ -669,10 +670,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_18_170142) do
     t.boolean "weekly_summary_email_enabled", default: true, null: false
     t.index ["github_uid", "github_access_token"], name: "index_users_on_github_uid_and_access_token"
     t.index ["github_uid"], name: "index_users_on_github_uid"
+    t.index ["github_username"], name: "index_users_on_github_username_trgm", opclass: :gin_trgm_ops, using: :gin
     t.index ["slack_uid"], name: "index_users_on_slack_uid", unique: true
+    t.index ["slack_username"], name: "index_users_on_slack_username_trgm", opclass: :gin_trgm_ops, using: :gin
     t.index ["timezone", "trust_level"], name: "index_users_on_timezone_trust_level"
     t.index ["timezone"], name: "index_users_on_timezone"
     t.index ["username"], name: "index_users_on_username"
+    t.index ["username"], name: "index_users_on_username_trgm", opclass: :gin_trgm_ops, using: :gin
   end
 
   create_table "versions", force: :cascade do |t|

--- a/spec/requests/api/admin/v1/admin_user_utils_spec.rb
+++ b/spec/requests/api/admin/v1/admin_user_utils_spec.rb
@@ -765,7 +765,7 @@ RSpec.describe 'Api::Admin::V1::UserUtils', type: :request do
                 type: :object,
                 properties: {
                   id: { type: :integer },
-                  username: { type: :string },
+                  username: { type: :string, nullable: true },
                   slack_username: { type: :string, nullable: true },
                   github_username: { type: :string, nullable: true },
                   slack_avatar_url: { type: :string, nullable: true },

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -1500,6 +1500,7 @@ paths:
                           type: integer
                         username:
                           type: string
+                          nullable: true
                         slack_username:
                           type: string
                           nullable: true

--- a/test/models/concerns/user_fuzzy_search_test.rb
+++ b/test/models/concerns/user_fuzzy_search_test.rb
@@ -1,0 +1,298 @@
+require "test_helper"
+
+# Tests for User.fuzzy_ranked_search (UserFuzzySearch concern).
+#
+# Production scenarios mirror the queries the admin search UI fires:
+#   "mahad", "miggy", "58", "mahadkalam1234@gmail.com", "mahadkalam1234", "json"
+# — each of those is asserted against equivalent fixture users below.
+#
+# Invariants covered:
+#   - blank/whitespace input -> none
+#   - limit kwarg respected
+#   - ordering: rank_score DESC, username ASC
+#   - rank scoring tiers (id/slack_uid exact = 1000; field exact = 100;
+#     prefix = 50; contains = 10; tiers compound additively)
+#   - case-insensitive ILIKE on username/email fields
+#   - case-sensitive equality on slack_uid
+#   - matched_email picks best email (exact > prefix > contains > any)
+#   - matched_email is nil only when the user has zero emails
+#   - has_any_email correctly reflects email-row presence
+#   - SQL-LIKE wildcards (%/_) in the term are escaped, not interpreted
+class UserFuzzySearchTest < ActiveSupport::TestCase
+  def create_user(attrs = {})
+    User.create!({ timezone: "UTC" }.merge(attrs))
+  end
+
+  def with_email(user, email)
+    user.email_addresses.create!(email: email)
+    user
+  end
+
+  # ----- blank input -----
+
+  test "returns none for blank term" do
+    assert_equal [], User.fuzzy_ranked_search("").to_a
+    assert_equal [], User.fuzzy_ranked_search(nil).to_a
+    assert_equal [], User.fuzzy_ranked_search("   ").to_a
+  end
+
+  test "strips leading and trailing whitespace from term" do
+    u = create_user(username: "spacecadet")
+    with_email(u, "spacecadet@example.com")
+    ids = User.fuzzy_ranked_search("  spacecadet  ").to_a.map(&:id)
+    assert_includes ids, u.id
+  end
+
+  # ----- limit -----
+
+  test "respects limit keyword arg" do
+    5.times { |i| create_user(username: "limittest#{i}") }
+    rows = User.fuzzy_ranked_search("limittest", limit: 3).to_a
+    assert_equal 3, rows.size
+  end
+
+  test "default limit is 20" do
+    25.times { |i| create_user(username: "manyusers#{i}") }
+    rows = User.fuzzy_ranked_search("manyusers").to_a
+    assert_equal 20, rows.size
+  end
+
+  # ----- ranking tiers -----
+
+  test "exact id match scores 1000" do
+    u = create_user(username: "exactiduser")
+    row = User.fuzzy_ranked_search(u.id.to_s).first
+    assert_equal u.id, row.id
+    assert_operator row.rank_score, :>=, 1000
+  end
+
+  test "exact slack_uid match scores 1000" do
+    u = create_user(slack_uid: "U#{SecureRandom.hex(8).upcase}", username: "slackuiduser")
+    row = User.fuzzy_ranked_search(u.slack_uid).first
+    assert_equal u.id, row.id
+    assert_operator row.rank_score, :>=, 1000
+  end
+
+  test "slack_uid match is case-sensitive" do
+    u = create_user(slack_uid: "U#{SecureRandom.hex(8).upcase}", username: "casesensitive_slack")
+    downcased = u.slack_uid.downcase
+    refute_equal u.slack_uid, downcased, "test fixture should contain uppercase letters"
+
+    # downcased term should NOT hit the 1000-point slack_uid exact path
+    rows = User.fuzzy_ranked_search(downcased).where(id: u.id)
+    assert rows.empty? || rows.first.rank_score < 1000,
+      "downcased slack_uid should not score 1000 (case-sensitive equality)"
+  end
+
+  test "exact username match scores 100" do
+    u = create_user(username: "exactname")
+    with_email(u, "exactname-#{SecureRandom.hex(4)}@example.com")
+    row = User.fuzzy_ranked_search("exactname").find { |r| r.id == u.id }
+    # exact (100) + email contains "exactname" (10) = 110, plus any other tiers
+    assert_operator row.rank_score, :>=, 100
+    assert_operator row.rank_score, :<, 1000
+  end
+
+  test "username prefix match scores 50" do
+    u = create_user(username: "prefixmatch123")
+    row = User.fuzzy_ranked_search("prefixmatch").find { |r| r.id == u.id }
+    # prefix (50). May also have substring (10) trigger separately so >=50.
+    assert_operator row.rank_score, :>=, 50
+    assert_operator row.rank_score, :<, 100
+  end
+
+  test "username substring match scores 10" do
+    u = create_user(username: "abcsubstringxyz")
+    row = User.fuzzy_ranked_search("substring").find { |r| r.id == u.id }
+    assert_operator row.rank_score, :>=, 10
+    assert_operator row.rank_score, :<, 50
+  end
+
+  test "username matching is case-insensitive" do
+    u = create_user(username: "MixedCaseUser")
+    assert User.fuzzy_ranked_search("mixedcaseuser").any? { |r| r.id == u.id }
+    assert User.fuzzy_ranked_search("MIXEDCASEUSER").any? { |r| r.id == u.id }
+  end
+
+  # ----- multi-field tiers -----
+
+  test "github_username, slack_username, and email tiers contribute" do
+    u = create_user(github_username: "githubmatch", slack_username: "slackmatch")
+    with_email(u, "emailmatch@example.com")
+
+    gh = User.fuzzy_ranked_search("githubmatch").find { |r| r.id == u.id }
+    sl = User.fuzzy_ranked_search("slackmatch").find { |r| r.id == u.id }
+    em = User.fuzzy_ranked_search("emailmatch@example.com").find { |r| r.id == u.id }
+    assert_operator gh.rank_score, :>=, 100
+    assert_operator sl.rank_score, :>=, 100
+    assert_operator em.rank_score, :>=, 100
+  end
+
+  test "scores from multiple matching fields compound additively" do
+    # Same term hits username exact + github_username prefix + email contains
+    u = create_user(username: "compound", github_username: "compound_gh")
+    with_email(u, "user@compound.example.com")
+    row = User.fuzzy_ranked_search("compound").find { |r| r.id == u.id }
+    # username exact (100) + github_username prefix (50) + email contains (10) >= 160
+    assert_operator row.rank_score, :>=, 160
+  end
+
+  # ----- email matching tiers -----
+
+  test "email exact match scores 100" do
+    u = create_user(username: "emailexact_#{SecureRandom.hex(4)}")
+    with_email(u, "exact@example.test")
+    row = User.fuzzy_ranked_search("exact@example.test").find { |r| r.id == u.id }
+    assert_operator row.rank_score, :>=, 100
+    assert_equal "exact@example.test", row.matched_email
+  end
+
+  test "email prefix match scores 50" do
+    u = create_user
+    with_email(u, "prefixsearch@example.test")
+    row = User.fuzzy_ranked_search("prefixsearch").find { |r| r.id == u.id }
+    # Score must be >= 50 (prefix tier). May add up if other fields coincidentally match.
+    assert_operator row.rank_score, :>=, 50
+    assert_equal "prefixsearch@example.test", row.matched_email
+  end
+
+  test "email substring match scores 10" do
+    u = create_user
+    with_email(u, "foo-deepsubstring-bar@example.test")
+    row = User.fuzzy_ranked_search("deepsubstring").find { |r| r.id == u.id }
+    assert_operator row.rank_score, :>=, 10
+    assert_equal "foo-deepsubstring-bar@example.test", row.matched_email
+  end
+
+  test "matched_email picks the best matching email when user has multiple" do
+    u = create_user
+    with_email(u, "nope@other.example.test")
+    with_email(u, "exactmatch@best.example.test")
+    with_email(u, "exactmatchprefixed@best.example.test") # prefix match
+    row = User.fuzzy_ranked_search("exactmatch@best.example.test").find { |r| r.id == u.id }
+    assert_equal "exactmatch@best.example.test", row.matched_email
+  end
+
+  test "matched_email falls back to any email when no email matches the term" do
+    u = create_user(slack_uid: "U#{SecureRandom.hex(8).upcase}", username: "nonemailmatch")
+    with_email(u, "completely-unrelated@example.test")
+    row = User.fuzzy_ranked_search("nonemailmatch").find { |r| r.id == u.id }
+    assert_equal "completely-unrelated@example.test", row.matched_email,
+      "matched_email should fall back to any email so the controller's has_any_email gate works"
+  end
+
+  test "matched_email is nil when user has no emails" do
+    u = create_user(slack_uid: "U#{SecureRandom.hex(8).upcase}", username: "noemailuser")
+    row = User.fuzzy_ranked_search("noemailuser").find { |r| r.id == u.id }
+    assert_nil row.matched_email
+  end
+
+  # ----- has_any_email -----
+
+  test "has_any_email is true when user has at least one email" do
+    u = create_user(username: "hasemail_#{SecureRandom.hex(4)}")
+    with_email(u, "anything@example.test")
+    row = User.fuzzy_ranked_search(u.username).find { |r| r.id == u.id }
+    assert_equal true, ActiveModel::Type::Boolean.new.cast(row.has_any_email)
+  end
+
+  test "has_any_email is false when user has no emails" do
+    u = create_user(slack_uid: "U#{SecureRandom.hex(8).upcase}", username: "noemails_#{SecureRandom.hex(4)}")
+    row = User.fuzzy_ranked_search(u.username).find { |r| r.id == u.id }
+    assert_equal false, ActiveModel::Type::Boolean.new.cast(row.has_any_email)
+  end
+
+  # ----- ordering -----
+
+  test "results are ordered by rank_score DESC then username ASC" do
+    # Highest rank: exact username match
+    high = create_user(username: "orderingtest")
+    # Mid rank: prefix match
+    mid = create_user(username: "orderingtest_extra_a")
+    # Same prefix-match score, alphabetically later username
+    mid_b = create_user(username: "orderingtest_extra_b")
+    rows = User.fuzzy_ranked_search("orderingtest").to_a
+    ranks = rows.map(&:rank_score)
+    assert_equal ranks.sort.reverse, ranks, "rank_score must be DESC"
+
+    same_rank = rows.select { |r| r.id.in?([ mid.id, mid_b.id ]) }
+    assert_equal [ mid.id, mid_b.id ], same_rank.map(&:id),
+      "tie-breaking should fall back to username ASC"
+    _ = high # silence unused warning; presence already implied by ordering
+  end
+
+  # ----- SQL safety -----
+
+  test "term containing LIKE wildcards is escaped, not interpreted" do
+    u = create_user(username: "literal_underscore")
+    # `_` in LIKE normally matches any single character. Sanitized term should
+    # only match the literal underscore, not e.g. "literalXunderscore".
+    decoy = create_user(username: "literalXunderscore")
+    rows = User.fuzzy_ranked_search("literal_underscore").to_a
+    ids = rows.map(&:id)
+    assert_includes ids, u.id
+    refute_includes ids, decoy.id, "literal `_` must not be treated as LIKE wildcard"
+  end
+
+  test "term containing percent sign is escaped" do
+    u = create_user(username: "literalpercent")
+    create_user(username: "decoy_no_percent")
+    rows = User.fuzzy_ranked_search("%").to_a
+    ids = rows.map(&:id)
+    refute_includes ids, u.id, "literal `%` must not match arbitrary substrings"
+  end
+
+  # ----- production-query parity -----
+
+  test "production query 'mahad' returns the user with username mahad ranked highest" do
+    mahad = create_user(username: "mahad", slack_uid: "U059VC0UDEU")
+    with_email(mahad, "mahadkalam1234@gmail.com")
+    create_user(username: "mahadmammu5") # secondary contains match
+    row = User.fuzzy_ranked_search("mahad").first
+    assert_equal mahad.id, row.id
+    assert_operator row.rank_score, :>=, 100
+  end
+
+  test "production query 'miggy' returns the user whose slack_username is miggy" do
+    miggy = create_user(username: "shy", slack_username: "miggy", github_username: "ImShyMike")
+    with_email(miggy, "imshymike@proton.me")
+    row = User.fuzzy_ranked_search("miggy").find { |r| r.id == miggy.id }
+    assert row, "user matched by slack_username should appear"
+    assert_operator row.rank_score, :>=, 100
+  end
+
+  test "production query '58' (numeric) hits the exact-id path" do
+    u = create_user(username: "byid_#{SecureRandom.hex(4)}")
+    row = User.fuzzy_ranked_search(u.id.to_s).find { |r| r.id == u.id }
+    assert row, "numeric term should find user by id"
+    assert_operator row.rank_score, :>=, 1000
+  end
+
+  test "production query 'mahadkalam1234@gmail.com' (full email) is an exact email match" do
+    u = create_user(username: "mahad", slack_uid: "U#{SecureRandom.hex(8).upcase}")
+    with_email(u, "mahadkalam1234@gmail.com")
+    row = User.fuzzy_ranked_search("mahadkalam1234@gmail.com").find { |r| r.id == u.id }
+    assert_equal "mahadkalam1234@gmail.com", row.matched_email
+    # exact (100) + maybe other tiers for "mahad" inside the email containing username
+    assert_operator row.rank_score, :>=, 100
+  end
+
+  test "production query 'mahadkalam1234' (email prefix) returns email prefix match" do
+    u = create_user(slack_uid: "U#{SecureRandom.hex(8).upcase}")
+    with_email(u, "mahadkalam1234@gmail.com")
+    row = User.fuzzy_ranked_search("mahadkalam1234").find { |r| r.id == u.id }
+    assert_equal "mahadkalam1234@gmail.com", row.matched_email
+    # email prefix tier (50) at minimum
+    assert_operator row.rank_score, :>=, 50
+  end
+
+  test "production query 'json' returns users with json in their username" do
+    json_lk = create_user(username: "JSON_LK")
+    with_email(json_lk, "sojyta@gmail.com")
+    json_cam = create_user(username: "jsoncameron")
+    with_email(json_cam, "jasoncameron.all@gmail.com")
+    ids = User.fuzzy_ranked_search("json").to_a.map(&:id)
+    assert_includes ids, json_lk.id
+    assert_includes ids, json_cam.id
+  end
+end


### PR DESCRIPTION
## Summary of the problem
We had multiple search implementations, even though the fuzzy search endpoint had the best one.

## Describe your changes
Uses the fuzzy search API's code for other search stuff (e.g. admin timeline). We also now have `pg_trgm` indexes on emails/Slack usernames/display names so that search is faster (~10ms).

## Screenshots / Media
N/A