### PR TITLE
Speed up StatsController#user_stats

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -120,6 +120,10 @@ group :development, :test do
 
   # Random data generation — only used in seed rake tasks
   gem "faker", require: false
+
+  # technically not used for any of the scripts in the repo, but I like
+  # to use it for scratch benchmarks
+  gem "benchmark"
 end
 
 gem "rswag-api"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,7 @@ GEM
     aws-sigv4 (1.12.1)
       aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.3.0)
+    benchmark (0.5.0)
     better_html (2.2.0)
       actionview (>= 7.0)
       activesupport (>= 7.0)
@@ -625,6 +626,7 @@ DEPENDENCIES
   activerecord-import
   autotuner (~> 1.0)
   aws-sdk-s3
+  benchmark
   bootsnap
   brakeman
   bullet

--- a/app/controllers/api/v1/stats_controller.rb
+++ b/app/controllers/api/v1/stats_controller.rb
@@ -40,7 +40,9 @@ class Api::V1::StatsController < ApplicationController
     return if performed?
 
     # /api/v1/users/current/stats?filter_by_project=harbor,high-seas
-    scope = params[:filter_by_project].present? ? @user.heartbeats.where(project: params[:filter_by_project].split(",")) : nil
+    filter_by_projects = params[:filter_by_project].presence&.split(",")
+    filter_by_categories = params[:filter_by_category].presence&.split(",")
+    scope = filter_by_projects ? @user.heartbeats.where(project: filter_by_projects) : nil
 
     enabled_features = params[:features]&.split(",")&.map(&:to_sym) || %i[languages]
 
@@ -52,7 +54,7 @@ class Api::V1::StatsController < ApplicationController
       start_date: start_date,
       end_date: end_date
     }
-    service_params[:scope] = scope if scope.present?
+    service_params[:scope] = scope if scope
 
     if params[:test_param] == "true"
       service_params[:boundary_aware] = true # always and i mean always use boundary aware in test mode
@@ -67,8 +69,8 @@ class Api::V1::StatsController < ApplicationController
     else
       if params[:total_seconds] == "true"
         query = Heartbeat.where(user_id: @user.id).where("time >= ? AND time < ?", start_date.to_f, end_date.to_f)
-        query = query.where(project: params[:filter_by_project].split(",")) if params[:filter_by_project].present?
-        query = query.where(category: params[:filter_by_category].split(",")) if params[:filter_by_category].present?
+        query = query.where(project: filter_by_projects) if filter_by_projects
+        query = query.where(category: filter_by_categories) if filter_by_categories
 
         total_seconds = if params[:boundary_aware] == "true"
           Heartbeat.duration_seconds_boundary_aware(
@@ -88,9 +90,8 @@ class Api::V1::StatsController < ApplicationController
     end
 
     if params[:features]&.include?("projects") && params[:filter_by_project].present?
-      filter_by_project = params[:filter_by_project].split(",")
       heartbeats = @user.heartbeats.coding_only.with_valid_timestamps
-                                   .where(time: start_date..end_date, project: filter_by_project)
+                                   .where(time: start_date..end_date, project: filter_by_projects)
       summary[:unique_total_seconds] = unique_heartbeat_seconds(heartbeats)
     end
 

--- a/test/controllers/api/v1/stats_controller_test.rb
+++ b/test/controllers/api/v1/stats_controller_test.rb
@@ -34,9 +34,9 @@ class Api::V1::StatsControllerTest < ActionDispatch::IntegrationTest
     create_heartbeat(user:, time: Time.utc(2025, 12, 15, 10, 0, 0).to_f, project: "Galactic_war", category: "coding")
     create_heartbeat(user:, time: Time.utc(2025, 12, 15, 10, 1, 0).to_f, project: "Galactic_war", category: "coding")
 
-    sql_queries = []
-    subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
-      sql_queries << payload[:sql]
+    instantiated_heartbeats = 0
+    subscriber = ActiveSupport::Notifications.subscribe("instantiation.active_record") do |*, payload|
+      instantiated_heartbeats += payload[:record_count] if payload[:class_name] == "Heartbeat"
     end
 
     get "/api/v1/users/#{user.username}/stats", params: {
@@ -47,7 +47,7 @@ class Api::V1::StatsControllerTest < ActionDispatch::IntegrationTest
     }
 
     assert_response :success
-    assert sql_queries.none? { |sql| sql.match?(/SELECT "heartbeats"\."id", "heartbeats"\."user_id"/) }
+    assert_equal 0, instantiated_heartbeats
   ensure
     ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
   end

--- a/test/controllers/api/v1/stats_controller_test.rb
+++ b/test/controllers/api/v1/stats_controller_test.rb
@@ -29,6 +29,29 @@ class Api::V1::StatsControllerTest < ActionDispatch::IntegrationTest
     assert_equal summary_total, total_only
   end
 
+  test "user_stats with project filter does not load heartbeat records" do
+    user = User.create!(username: "stats_user_#{SecureRandom.hex(3)}", timezone: "UTC")
+    create_heartbeat(user:, time: Time.utc(2025, 12, 15, 10, 0, 0).to_f, project: "Galactic_war", category: "coding")
+    create_heartbeat(user:, time: Time.utc(2025, 12, 15, 10, 1, 0).to_f, project: "Galactic_war", category: "coding")
+
+    sql_queries = []
+    subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+      sql_queries << payload[:sql]
+    end
+
+    get "/api/v1/users/#{user.username}/stats", params: {
+      features: "projects",
+      filter_by_project: "Galactic_war",
+      start_date: "2025-12-15",
+      end_date: "2025-12-16"
+    }
+
+    assert_response :success
+    assert sql_queries.none? { |sql| sql.match?(/SELECT "heartbeats"\."id", "heartbeats"\."user_id"/) }
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+  end
+
   private
 
   def create_heartbeat(user:, time:, project:, category:)


### PR DESCRIPTION
## Summary of the problem
Some high-traffic API endpoints were spending most of their tail latency in heartbeat aggregation queries. `user_stats` also allocated millions of objects on project-filtered requests because `present?` loaded the entire heartbeat relation.

## Describe your changes
Fixed the user_stats relation materialization bug and reused parsed filters. Also added a ✨ regression test ✨  for the allocation fix.

## Screenshots / Media
N/A