### PR TITLE
Fix privacy key rotation message

### DIFF
--- a/app/javascript/pages/Users/Settings/Privacy.svelte
+++ b/app/javascript/pages/Users/Settings/Privacy.svelte
@@ -29,7 +29,6 @@
   ];
 
   let rotatingApiKey = $state(false);
-  let rotatedApiKeyError = $state("");
   let apiKeyCopied = $state(false);
   let rotateApiKeyModalOpen = $state(false);
   let deletionRequestModalOpen = $state(false);
@@ -42,16 +41,12 @@
   const rotateApiKey = () => {
     if (rotatingApiKey) return;
     rotatingApiKey = true;
-    rotatedApiKeyError = "";
     apiKeyCopied = false;
     router.post(
       settingsPrivacy.rotateApiKey.path(),
       {},
       {
         preserveScroll: true,
-        onError: () => {
-          rotatedApiKeyError = "Unable to rotate API key.";
-        },
         onFinish: () => {
           rotatingApiKey = false;
         },
@@ -101,16 +96,8 @@
     id="user_api_key"
     title="API Key"
     description="Rotate your API key if you think it has been exposed."
-    hasBody={Boolean(rotatedApiKeyError || rotated_api_key)}
+    hasBody={Boolean(rotated_api_key)}
   >
-    {#if rotatedApiKeyError}
-      <p
-        class="rounded-md border border-danger/40 bg-danger/10 px-3 py-2 text-sm text-red"
-      >
-        {rotatedApiKeyError}
-      </p>
-    {/if}
-
     {#if rotated_api_key}
       <div class="rounded-md border border-surface-200 bg-darker p-3">
         <p class="text-xs font-semibold uppercase tracking-wide text-muted">

--- a/test/system/settings/privacy_settings_test.rb
+++ b/test/system/settings/privacy_settings_test.rb
@@ -71,6 +71,7 @@ class PrivacySettingsTest < ApplicationSystemTestCase
     end
 
     assert_text(/New API key/i)
+    assert_no_text "Unable to rotate API key"
 
     new_token = @user.reload.api_keys.order(:id).last.token
     refute_equal old_token, new_token


### PR DESCRIPTION
## Summary of the problem

The Privacy & Security page could show "Unable to rotate API key" after a successful key rotation, even while rendering the newly rotated key.

## Describe your changes

- Removed the local Inertia `onError` state that displayed a duplicate inline rotation error.
- Kept real failures covered by the existing Rails flash alert from `Settings::PrivacyController#rotate_api_key`.
- Added a system assertion that successful rotation does not render the false error message.

Validation:
- `docker compose exec web rails test test/system/settings/privacy_settings_test.rb`
- `docker compose exec web bun run check:svelte` (passes with two existing warnings in `Home/signedIn/IntervalSelectBody.svelte`)

## Screenshots / Media

Not included; behavior is covered by the focused system test.
