### PR TITLE
Match settings description styling

### DIFF
--- a/app/javascript/pages/Users/Settings/Shell.svelte
+++ b/app/javascript/pages/Users/Settings/Shell.svelte
@@ -65,7 +65,7 @@
     >
       {heading}
     </h1>
-    <p class="mt-1 max-w-3xl text-pretty text-sm leading-6 text-muted sm:mt-2">
+    <p class="mt-1 max-w-3xl text-sm text-muted sm:mt-2 sm:text-base">
       {subheading}
     </p>
   </header>

--- a/app/javascript/pages/Users/Settings/Shell.svelte
+++ b/app/javascript/pages/Users/Settings/Shell.svelte
@@ -65,7 +65,7 @@
     >
       {heading}
     </h1>
-    <p class="mt-1 max-w-3xl text-sm text-muted sm:mt-2 sm:text-base">
+    <p class="mt-1 max-w-3xl text-pretty text-sm text-muted sm:mt-2 sm:text-base">
       {subheading}
     </p>
   </header>


### PR DESCRIPTION
## Summary of the problem

The Settings page header description used smaller typography than comparable top-level pages like Extensions, making the page feel visually inconsistent.

## Describe your changes

- Updated the Settings shell subheading classes to use the same responsive `text-sm` to `sm:text-base` pattern as the Extensions page.
- Kept the change scoped to the shared Settings shell so all settings sections use the corrected description styling.

Validation:
- `docker compose exec web bun run check:svelte` (passes with two existing warnings in `Home/signedIn/IntervalSelectBody.svelte`)
- `docker compose exec web bun prettier --check app/javascript/pages/Users/Settings/Shell.svelte`
- `docker compose exec web env RAILS_ENV=test bin/vite build`

## Screenshots / Media

Not included; this is a one-class typography alignment.
