### PR TITLE
Allow OAuth2 apps to instantly go through HCA

### DIFF
--- a/app/controllers/admin/oauth_applications_controller.rb
+++ b/app/controllers/admin/oauth_applications_controller.rb
@@ -42,6 +42,6 @@ class Admin::OauthApplicationsController < Admin::BaseController
   end
 
   def application_params
-    params.require(:oauth_application).permit(:name, :redirect_uri, :scopes, :confidential)
+    params.require(:oauth_application).permit(:name, :redirect_uri, :scopes, :confidential, :redirect_to_hca_login)
   end
 end

--- a/app/controllers/doorkeeper/applications_controller.rb
+++ b/app/controllers/doorkeeper/applications_controller.rb
@@ -118,7 +118,10 @@ module Doorkeeper
     end
 
     def application_params
-      params.require(:doorkeeper_application).permit(:name, :redirect_uri, :scopes, :confidential, :redirect_to_hca_login)
+      permitted = params.require(:doorkeeper_application)
+        .permit(:name, :redirect_uri, :confidential, :redirect_to_hca_login, scopes: [])
+      permitted[:scopes] = permitted[:scopes].compact_blank.join(" ")
+      permitted
     end
 
     def i18n_scope(action) = %i[doorkeeper flash applications] << action

--- a/app/controllers/doorkeeper/applications_controller.rb
+++ b/app/controllers/doorkeeper/applications_controller.rb
@@ -118,7 +118,7 @@ module Doorkeeper
     end
 
     def application_params
-      params.require(:doorkeeper_application).permit(:name, :redirect_uri, :scopes, :confidential)
+      params.require(:doorkeeper_application).permit(:name, :redirect_uri, :scopes, :confidential, :redirect_to_hca_login)
     end
 
     def i18n_scope(action) = %i[doorkeeper flash applications] << action
@@ -149,6 +149,7 @@ module Doorkeeper
           uid: @application.uid,
           verified: @application.verified?,
           confidential: @application.confidential?,
+          redirect_to_hca_login: @application.redirect_to_hca_login?,
           scopes: @application.scopes.to_a.map(&:to_s),
           redirect_uris: redirect_uris_for(@application),
           can_toggle_verified: current_user&.admin_level_superadmin? || current_user&.admin_level_ultraadmin? || false
@@ -189,6 +190,7 @@ module Doorkeeper
           name: @application.name.to_s,
           redirect_uri: @application.redirect_uri.to_s,
           confidential: @application.confidential?,
+          redirect_to_hca_login: @application.redirect_to_hca_login?,
           verified: @application.verified?,
           selected_scopes: selected_scopes_for(@application)
         },

--- a/app/javascript/pages/OAuthApplications/Form.svelte
+++ b/app/javascript/pages/OAuthApplications/Form.svelte
@@ -17,11 +17,13 @@
 
   let selectedScopes = $state<string[]>([]);
   let confidential = $state(false);
+  let redirectToHcaLogin = $state(false);
   let redirectUri = $state("");
 
   $effect(() => {
     selectedScopes = [...(application.selected_scopes || [])];
     confidential = Boolean(application.confidential);
+    redirectToHcaLogin = Boolean(application.redirect_to_hca_login);
     redirectUri = application.redirect_uri;
   });
 
@@ -184,6 +186,31 @@
           >
           <span class="mt-1 block text-xs text-muted"
             >{help_text.confidential}</span
+          >
+        </span>
+      </label>
+
+      <label class={row} for="doorkeeper_application_redirect_to_hca_login">
+        <input
+          type="hidden"
+          name="doorkeeper_application[redirect_to_hca_login]"
+          value="0"
+        />
+        <input
+          id="doorkeeper_application_redirect_to_hca_login"
+          type="checkbox"
+          name="doorkeeper_application[redirect_to_hca_login]"
+          value="1"
+          bind:checked={redirectToHcaLogin}
+          class="mt-1 h-4 w-4 rounded border-surface-300 bg-darker text-primary"
+        />
+        <span>
+          <span class="text-sm font-medium text-surface-content"
+            >Use Hack Club Auth for login</span
+          >
+          <span class="mt-1 block text-xs text-muted"
+            >Send unauthenticated users directly to Hack Club Auth before this
+            app's OAuth consent screen.</span
           >
         </span>
       </label>

--- a/app/javascript/pages/OAuthApplications/Form.svelte
+++ b/app/javascript/pages/OAuthApplications/Form.svelte
@@ -15,19 +15,8 @@
     errors,
   }: OAuthApplicationFormProps = $props();
 
-  let selectedScopes = $state<string[]>([]);
-  let confidential = $state(false);
-  let redirectToHcaLogin = $state(false);
-  let redirectUri = $state("");
-
-  $effect(() => {
-    selectedScopes = [...(application.selected_scopes || [])];
-    confidential = Boolean(application.confidential);
-    redirectToHcaLogin = Boolean(application.redirect_to_hca_login);
-    redirectUri = application.redirect_uri;
-  });
-
   const nameLocked = $derived(application.persisted && application.verified);
+  const selectedScopes = $derived(application.selected_scopes || []);
 
   const submitPath = $derived(
     form_mode === "edit" && application.id != null
@@ -112,7 +101,7 @@
           id="doorkeeper_application_redirect_uri"
           name="doorkeeper_application[redirect_uri]"
           rows="4"
-          bind:value={redirectUri}
+          value={application.redirect_uri}
           placeholder="https://example.com/auth/callback"
           class="{input} font-mono"
         ></textarea>
@@ -130,11 +119,7 @@
         <p class="mb-2 block text-sm font-medium text-surface-content">
           Scopes
         </p>
-        <input
-          type="hidden"
-          name="doorkeeper_application[scopes]"
-          value={selectedScopes.join(" ")}
-        />
+        <input type="hidden" name="doorkeeper_application[scopes][]" value="" />
 
         <div class="space-y-2">
           {#each scope_options as scope}
@@ -142,8 +127,9 @@
               <input
                 id={`scope_${scope.value}`}
                 type="checkbox"
+                name="doorkeeper_application[scopes][]"
                 value={scope.value}
-                bind:group={selectedScopes}
+                checked={selectedScopes.includes(scope.value)}
                 class="mt-1 h-4 w-4 rounded border-surface-300 bg-darker text-primary"
               />
               <span>
@@ -177,7 +163,7 @@
           type="checkbox"
           name="doorkeeper_application[confidential]"
           value="1"
-          bind:checked={confidential}
+          checked={application.confidential}
           class="mt-1 h-4 w-4 rounded border-surface-300 bg-darker text-primary"
         />
         <span>
@@ -201,7 +187,7 @@
           type="checkbox"
           name="doorkeeper_application[redirect_to_hca_login]"
           value="1"
-          bind:checked={redirectToHcaLogin}
+          checked={application.redirect_to_hca_login}
           class="mt-1 h-4 w-4 rounded border-surface-300 bg-darker text-primary"
         />
         <span>

--- a/app/javascript/pages/OAuthApplications/Show.svelte
+++ b/app/javascript/pages/OAuthApplications/Show.svelte
@@ -135,7 +135,9 @@
           </Field>
 
           <Field label="Login redirect">
-            <Badge tone={application.redirect_to_hca_login ? "green" : "yellow"}>
+            <Badge
+              tone={application.redirect_to_hca_login ? "green" : "yellow"}
+            >
               {application.redirect_to_hca_login
                 ? "Hack Club Auth"
                 : "Hackatime sign in"}

--- a/app/javascript/pages/OAuthApplications/Show.svelte
+++ b/app/javascript/pages/OAuthApplications/Show.svelte
@@ -134,6 +134,14 @@
             </Badge>
           </Field>
 
+          <Field label="Login redirect">
+            <Badge tone={application.redirect_to_hca_login ? "green" : "yellow"}>
+              {application.redirect_to_hca_login
+                ? "Hack Club Auth"
+                : "Hackatime sign in"}
+            </Badge>
+          </Field>
+
           <Field label="Verified">
             <Badge tone={application.verified ? "green" : "yellow"}>
               {application.verified ? "Verified" : "Unverified"}

--- a/app/javascript/pages/OAuthApplications/types.ts
+++ b/app/javascript/pages/OAuthApplications/types.ts
@@ -24,6 +24,7 @@ type OAuthApplicationFormApplication = {
   name: string;
   redirect_uri: string;
   confidential: boolean;
+  redirect_to_hca_login: boolean;
   verified: boolean;
   selected_scopes: string[];
 };
@@ -63,6 +64,7 @@ type OAuthApplicationShowApplication = {
   uid: string;
   verified: boolean;
   confidential: boolean;
+  redirect_to_hca_login: boolean;
   scopes: string[];
   redirect_uris: string[];
   can_toggle_verified: boolean;

--- a/app/javascript/pages/OAuthApplications/types.ts
+++ b/app/javascript/pages/OAuthApplications/types.ts
@@ -35,6 +35,7 @@ type OAuthApplicationFormErrors = {
   redirect_uri: string[];
   scopes: string[];
   confidential: string[];
+  redirect_to_hca_login: boolean;
 };
 
 export type OAuthApplicationFormProps = {

--- a/app/views/admin/oauth_applications/edit.html.erb
+++ b/app/views/admin/oauth_applications/edit.html.erb
@@ -89,6 +89,14 @@
             <p class="mt-1 text-xs text-secondary">Confidential clients can keep secrets. Native apps and SPAs are not confidential.</p>
           </div>
         </div>
+
+        <div class="flex items-start gap-3 p-4 bg-darkless border border-darkless rounded">
+          <%= f.check_box :redirect_to_hca_login, class: 'mt-0.5 w-4 h-4 text-primary border-darkless rounded focus:ring-primary bg-darker' %>
+          <div>
+            <%= f.label :redirect_to_hca_login, 'Use Hack Club Auth for Login', class: 'text-sm font-medium text-surface-content' %>
+            <p class="mt-1 text-xs text-secondary">Unauthenticated users authorizing this app will be sent directly to Hack Club Auth instead of the generic Hackatime sign-in page.</p>
+          </div>
+        </div>
       </div>
     </div>
 

--- a/app/views/admin/oauth_applications/show.html.erb
+++ b/app/views/admin/oauth_applications/show.html.erb
@@ -115,6 +115,15 @@
           </div>
 
           <div>
+            <label class="block text-sm font-medium text-secondary mb-2">Login Redirect</label>
+            <% if @application.redirect_to_hca_login? %>
+              <span class="inline-flex items-center gap-1.5 px-2 py-1 bg-green/20 text-green border border-green/30 rounded text-sm">Hack Club Auth</span>
+            <% else %>
+              <span class="inline-flex items-center gap-1.5 px-2 py-1 bg-yellow/20 text-yellow border border-yellow/30 rounded text-sm">Hackatime sign in</span>
+            <% end %>
+          </div>
+
+          <div>
             <label class="block text-sm font-medium text-secondary mb-2">Created</label>
             <span class="text-surface-content"><%= @application.created_at.strftime("%B %d, %Y at %I:%M %p") %></span>
           </div>

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -10,7 +10,15 @@ Doorkeeper.configure do
 
   resource_owner_authenticator do
     if respond_to?(:current_user, true)
-      send(:current_user) || redirect_to(signin_path(continue: request.fullpath))
+      user = send(:current_user)
+
+      if user
+        user
+      elsif OauthApplication.find_by(uid: request.params[:client_id])&.redirect_to_hca_login?
+        redirect_to(hca_auth_path(continue: request.fullpath))
+      else
+        redirect_to(signin_path(continue: request.fullpath))
+      end
     end
   end
 

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -11,10 +11,11 @@ Doorkeeper.configure do
   resource_owner_authenticator do
     if respond_to?(:current_user, true)
       user = send(:current_user)
+      client_id = request.params[:client_id]
 
       if user
         user
-      elsif OauthApplication.find_by(uid: request.params[:client_id])&.redirect_to_hca_login?
+      elsif client_id.present? && OauthApplication.find_by(uid: client_id)&.redirect_to_hca_login?
         redirect_to(hca_auth_path(continue: request.fullpath))
       else
         redirect_to(signin_path(continue: request.fullpath))

--- a/db/migrate/20260602122953_add_redirect_to_hca_login_to_oauth_applications.rb
+++ b/db/migrate/20260602122953_add_redirect_to_hca_login_to_oauth_applications.rb
@@ -1,0 +1,5 @@
+class AddRedirectToHCALoginToOauthApplications < ActiveRecord::Migration[8.1]
+  def change
+    add_column :oauth_applications, :redirect_to_hca_login, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_28_142103) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_02_122953) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -473,6 +473,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_28_142103) do
     t.string "name", null: false
     t.bigint "owner_id"
     t.string "owner_type"
+    t.boolean "redirect_to_hca_login", default: false, null: false
     t.text "redirect_uri", null: false
     t.string "scopes", default: "", null: false
     t.string "secret", null: false

--- a/test/controllers/custom_doorkeeper/authorizations_controller_test.rb
+++ b/test/controllers/custom_doorkeeper/authorizations_controller_test.rb
@@ -17,7 +17,21 @@ class CustomDoorkeeperAuthorizationsControllerTest < ActionDispatch::Integration
   test "new redirects unauthenticated user to sign in" do
     get "/oauth/authorize", params: authorization_params
     assert_response :redirect
-    assert_match %r{signin}, response.location
+
+    redirect_uri = URI.parse(response.location)
+    assert_equal "/signin", redirect_uri.path
+    assert_equal request.fullpath, Rack::Utils.parse_query(redirect_uri.query)["continue"]
+  end
+
+  test "new redirects unauthenticated user to HCA sign in when application requires it" do
+    @oauth_app.update!(redirect_to_hca_login: true)
+
+    get "/oauth/authorize", params: authorization_params
+    assert_response :redirect
+
+    redirect_uri = URI.parse(response.location)
+    assert_equal "/auth/hca", redirect_uri.path
+    assert_equal request.fullpath, Rack::Utils.parse_query(redirect_uri.query)["continue"]
   end
 
   test "new renders OAuthAuthorize/New for authorizable request" do

--- a/test/controllers/doorkeeper/applications_controller_test.rb
+++ b/test/controllers/doorkeeper/applications_controller_test.rb
@@ -69,6 +69,18 @@ class Doorkeeper::ApplicationsControllerTest < ActionDispatch::IntegrationTest
     assert flash[:application_secret].present?
   end
 
+  test "create can persist HCA login redirect preference" do
+    user = User.create!(timezone: "UTC")
+
+    sign_in_as(user)
+    post oauth_applications_path, params: {
+      doorkeeper_application: valid_application_params(name: "HCA Login App").merge(redirect_to_hca_login: "1")
+    }
+
+    created_application = OauthApplication.order(:created_at).last
+    assert created_application.redirect_to_hca_login?
+  end
+
   test "create invalid re-renders inertia new with validation errors" do
     user = User.create!(timezone: "UTC")
 
@@ -108,6 +120,19 @@ class Doorkeeper::ApplicationsControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to oauth_application_url(application)
     assert_equal "After", application.reload.name
+  end
+
+  test "update can persist HCA login redirect preference" do
+    user = User.create!(timezone: "UTC")
+    application = create_application_for(user, name: "Before")
+
+    sign_in_as(user)
+    patch oauth_application_path(application), params: {
+      doorkeeper_application: { redirect_to_hca_login: "1" }
+    }
+
+    assert_redirected_to oauth_application_url(application)
+    assert application.reload.redirect_to_hca_login?
   end
 
   test "update invalid re-renders inertia edit with validation errors" do

--- a/test/controllers/doorkeeper/applications_controller_test.rb
+++ b/test/controllers/doorkeeper/applications_controller_test.rb
@@ -59,7 +59,7 @@ class Doorkeeper::ApplicationsControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(user)
     assert_difference -> { OauthApplication.count }, 1 do
       post oauth_applications_path, params: {
-        doorkeeper_application: valid_application_params(name: "Created App")
+        doorkeeper_application: valid_application_form_params(name: "Created App")
       }
     end
 
@@ -74,7 +74,7 @@ class Doorkeeper::ApplicationsControllerTest < ActionDispatch::IntegrationTest
 
     sign_in_as(user)
     post oauth_applications_path, params: {
-      doorkeeper_application: valid_application_params(name: "HCA Login App").merge(redirect_to_hca_login: "1")
+      doorkeeper_application: valid_application_form_params(name: "HCA Login App").merge(redirect_to_hca_login: "1")
     }
 
     created_application = OauthApplication.order(:created_at).last
@@ -86,7 +86,7 @@ class Doorkeeper::ApplicationsControllerTest < ActionDispatch::IntegrationTest
 
     sign_in_as(user)
     post oauth_applications_path, params: {
-      doorkeeper_application: valid_application_params(name: "")
+      doorkeeper_application: valid_application_form_params(name: "")
     }
 
     assert_response :unprocessable_entity
@@ -101,7 +101,7 @@ class Doorkeeper::ApplicationsControllerTest < ActionDispatch::IntegrationTest
 
     sign_in_as(user)
     post oauth_applications_path(format: :json), params: {
-      doorkeeper_application: valid_application_params(name: "")
+      doorkeeper_application: valid_application_form_params(name: "")
     }
 
     assert_response :unprocessable_entity
@@ -115,7 +115,7 @@ class Doorkeeper::ApplicationsControllerTest < ActionDispatch::IntegrationTest
 
     sign_in_as(user)
     patch oauth_application_path(application), params: {
-      doorkeeper_application: { name: "After" }
+      doorkeeper_application: valid_application_form_params(name: "After")
     }
 
     assert_redirected_to oauth_application_url(application)
@@ -128,7 +128,7 @@ class Doorkeeper::ApplicationsControllerTest < ActionDispatch::IntegrationTest
 
     sign_in_as(user)
     patch oauth_application_path(application), params: {
-      doorkeeper_application: { redirect_to_hca_login: "1" }
+      doorkeeper_application: valid_application_form_params(name: application.name).merge(redirect_to_hca_login: "1")
     }
 
     assert_redirected_to oauth_application_url(application)
@@ -141,7 +141,7 @@ class Doorkeeper::ApplicationsControllerTest < ActionDispatch::IntegrationTest
 
     sign_in_as(user)
     patch oauth_application_path(application), params: {
-      doorkeeper_application: { name: "" }
+      doorkeeper_application: valid_application_form_params(name: "")
     }
 
     assert_response :unprocessable_entity
@@ -200,6 +200,10 @@ class Doorkeeper::ApplicationsControllerTest < ActionDispatch::IntegrationTest
       scopes: configured_scopes,
       confidential: "1"
     }
+  end
+
+  def valid_application_form_params(name:)
+    valid_application_params(name: name).merge(scopes: configured_scopes.split)
   end
 
   def create_application_for(user, name:)


### PR DESCRIPTION
## Summary of the problem
If you aren't authenticated with Hackatime already and you go through the OAuth2 authorize flow, you then get redirected to the Hackatime sign-in page. This is rather awkward because chances are you use HCA to login!

## Describe your changes
Allows setting your app to always go through HCA auth for unauthenticated users.

## Screenshots / Media
<img width="742" height="100" alt="image" src="https://github.com/user-attachments/assets/bc48a53c-277f-4291-9524-bb46bb30cb97" />