### PR TITLE
Added Hackabile (Android hackatime client) to extensions.

### DIFF
--- a/app/javascript/pages/Extensions/Index.svelte
+++ b/app/javascript/pages/Extensions/Index.svelte
@@ -29,6 +29,12 @@
       install: "https://hackclub.enterprise.slack.com/archives/C0AJLGZ73NE",
       buttonLabel: "Try it out!",
     },
+    {
+      name: "Hackabile",
+      source: "https://github.com/nilanshsharma23/hackabile",
+      description: "Android app for Hackatime.",
+      install: "https://github.com/nilanshsharma23/hackabile/releases/tag/v1.0",
+    },
   ];
 </script>
 


### PR DESCRIPTION
## Summary of the problem
There wasn't a mobile client for hackatime before. So I decided to make one.


## Describe your changes
I added the link and the source of this mobile client to the extensions page.


## Screenshots / Media
<img width="1302" height="467" alt="image" src="https://github.com/user-attachments/assets/b1c584c5-f403-47b3-8227-2bfc0be7a676" />
