### PR TITLE
Allow admins to LB shadowban people

### DIFF
--- a/app/controllers/inertia_controller.rb
+++ b/app/controllers/inertia_controller.rb
@@ -91,7 +91,10 @@ class InertiaController < ApplicationController
 
   def inertia_admin_links
     return [] unless current_user&.admin_level.in?(%w[admin superadmin ultraadmin])
-    build_nav_from(ADMIN_NAV_LINKS)
+    build_nav_from(ADMIN_NAV_LINKS) + [
+      # viewers can't access these!
+      inertia_link("Leaderboard Shadowbans", admin_leaderboard_shadowbans_path, active: helpers.current_page?(admin_leaderboard_shadowbans_path) || request.path.start_with?("/admin/leaderboard_shadowbans"), inertia: true)
+    ]
   end
 
   def inertia_viewer_links
@@ -106,8 +109,7 @@ class InertiaController < ApplicationController
     [
       inertia_link("Admin Management", admin_admin_users_path, active: helpers.current_page?(admin_admin_users_path)),
       inertia_link("Account Deletions", admin_deletion_requests_path, active: helpers.current_page?(admin_deletion_requests_path), badge: pending_count.positive? ? pending_count : nil),
-      inertia_link("All OAuth Apps", admin_oauth_applications_path, active: helpers.current_page?(admin_oauth_applications_path) || request.path.start_with?("/admin/oauth_applications")),
-      inertia_link("Leaderboard Shadowbans", admin_leaderboard_shadowbans_path, active: helpers.current_page?(admin_leaderboard_shadowbans_path) || request.path.start_with?("/admin/leaderboard_shadowbans"), inertia: true)
+      inertia_link("All OAuth Apps", admin_oauth_applications_path, active: helpers.current_page?(admin_oauth_applications_path) || request.path.start_with?("/admin/oauth_applications"))
     ]
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -106,7 +106,7 @@ class User < ApplicationRecord
   end
 
   def can_convict_users? = admin_level_superadmin? || admin_level_ultraadmin?
-  def can_leaderboard_shadowban_users? = admin_level_superadmin? || admin_level_ultraadmin?
+  def can_leaderboard_shadowban_users? = admin_level.in?(%w[admin superadmin ultraadmin])
   def can_view_query_stats? = admin_level.in?(%w[viewer admin superadmin ultraadmin])
   def admin_level_rank = ADMIN_LEVEL_RANK[admin_level.to_s] || 0
 

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -118,7 +118,7 @@
             <%= link_to 'All OAuth Apps', admin_oauth_applications_path, class: nav_link_class.call(current_page?(admin_oauth_applications_path) || request.path.start_with?('/admin/oauth_applications')), data: { action: "click->nav#clickLink" } %>
           <% end %>
 
-          <% superadmin_tool(nil, "div") do %>
+          <% admin_tool(nil, "div") do %>
             <%= link_to 'Leaderboard Shadowbans', admin_leaderboard_shadowbans_path, class: nav_link_class.call(current_page?(admin_leaderboard_shadowbans_path) || request.path.start_with?('/admin/leaderboard_shadowbans')), data: { action: "click->nav#clickLink" } %>
           <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,9 +44,6 @@ Rails.application.routes.draw do
           post :rotate_secret
         end
       end
-      resources :leaderboard_shadowbans, only: [ :index, :create, :destroy ], param: :user_id do
-        get :search_users, on: :collection
-      end
     end
   end
 
@@ -82,6 +79,9 @@ Rails.application.routes.draw do
           post :approve
           post :reject
         end
+      end
+      resources :leaderboard_shadowbans, only: [ :index, :create, :destroy ], param: :user_id do
+        get :search_users, on: :collection
       end
     end
     get "/impersonate/:id", to: "sessions#impersonate", as: :impersonate_user

--- a/spec/requests/api/admin/v1/leaderboard_shadowbans_spec.rb
+++ b/spec/requests/api/admin/v1/leaderboard_shadowbans_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Api::Admin::V1::LeaderboardShadowbans', type: :request do
   path '/api/admin/v1/leaderboard_shadowbans' do
     get('List Leaderboard Shadowbans') do
       tags 'Admin Resources'
-      description 'List users hidden from public leaderboards. Requires superadmin privileges.'
+      description 'List users hidden from public leaderboards. Requires admin privileges.'
       security [ AdminToken: [] ]
       produces 'application/json'
 
@@ -31,7 +31,7 @@ RSpec.describe 'Api::Admin::V1::LeaderboardShadowbans', type: :request do
 
     post('Create Leaderboard Shadowban') do
       tags 'Admin Resources'
-      description 'Hide a user from public leaderboards. Requires superadmin privileges and a reason.'
+      description 'Hide a user from public leaderboards. Requires admin privileges and a reason.'
       security [ AdminToken: [] ]
       consumes 'application/json'
       produces 'application/json'
@@ -74,7 +74,7 @@ RSpec.describe 'Api::Admin::V1::LeaderboardShadowbans', type: :request do
   path '/api/admin/v1/leaderboard_shadowbans/search_users' do
     get('Search Users for Leaderboard Shadowbans') do
       tags 'Admin Resources'
-      description 'Search users and include their current leaderboard shadowban metadata. Requires superadmin privileges.'
+      description 'Search users and include their current leaderboard shadowban metadata. Requires admin privileges.'
       security [ AdminToken: [] ]
       produces 'application/json'
 
@@ -104,7 +104,7 @@ RSpec.describe 'Api::Admin::V1::LeaderboardShadowbans', type: :request do
   path '/api/admin/v1/leaderboard_shadowbans/{user_id}' do
     delete('Delete Leaderboard Shadowban') do
       tags 'Admin Resources'
-      description 'Remove a user from the leaderboard shadowban list. Requires superadmin privileges.'
+      description 'Remove a user from the leaderboard shadowban list. Requires admin privileges.'
       security [ AdminToken: [] ]
       produces 'application/json'
 

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -1734,8 +1734,7 @@ paths:
       summary: List Leaderboard Shadowbans
       tags:
       - Admin Resources
-      description: List users hidden from public leaderboards. Requires superadmin
-        privileges.
+      description: List users hidden from public leaderboards. Requires admin privileges.
       security:
       - AdminToken: []
       responses:
@@ -1754,7 +1753,7 @@ paths:
       summary: Create Leaderboard Shadowban
       tags:
       - Admin Resources
-      description: Hide a user from public leaderboards. Requires superadmin privileges
+      description: Hide a user from public leaderboards. Requires admin privileges
         and a reason.
       security:
       - AdminToken: []
@@ -1798,7 +1797,7 @@ paths:
       tags:
       - Admin Resources
       description: Search users and include their current leaderboard shadowban metadata.
-        Requires superadmin privileges.
+        Requires admin privileges.
       security:
       - AdminToken: []
       parameters:
@@ -1824,7 +1823,7 @@ paths:
       summary: Delete Leaderboard Shadowban
       tags:
       - Admin Resources
-      description: Remove a user from the leaderboard shadowban list. Requires superadmin
+      description: Remove a user from the leaderboard shadowban list. Requires admin
         privileges.
       security:
       - AdminToken: []

--- a/test/controllers/admin/leaderboard_shadowbans_controller_test.rb
+++ b/test/controllers/admin/leaderboard_shadowbans_controller_test.rb
@@ -1,13 +1,23 @@
 require "test_helper"
 
 class Admin::LeaderboardShadowbansControllerTest < ActionDispatch::IntegrationTest
-  test "index is not routed for regular admins" do
+  test "index is not routed for viewers" do
+    viewer = User.create!(timezone: "UTC", admin_level: :viewer)
+    sign_in_as(viewer)
+
+    get admin_leaderboard_shadowbans_path
+
+    assert_response :not_found
+  end
+
+  test "index renders for regular admins" do
     admin = User.create!(timezone: "UTC", admin_level: :admin)
     sign_in_as(admin)
 
     get admin_leaderboard_shadowbans_path
 
-    assert_response :not_found
+    assert_response :success
+    assert_inertia_component "Admin/LeaderboardShadowbans"
   end
 
   test "index renders current shadowbanned users" do

--- a/test/controllers/api/admin/v1/leaderboard_shadowbans_controller_test.rb
+++ b/test/controllers/api/admin/v1/leaderboard_shadowbans_controller_test.rb
@@ -2,8 +2,8 @@ require "test_helper"
 
 class Api::Admin::V1::LeaderboardShadowbansControllerTest < ActionDispatch::IntegrationTest
   test "index requires a shadowban-capable admin API key" do
-    admin = User.create!(timezone: "UTC", admin_level: :admin)
-    key = admin.admin_api_keys.create!(name: "test")
+    viewer = User.create!(timezone: "UTC", admin_level: :viewer)
+    key = viewer.admin_api_keys.create!(name: "test")
 
     get "/api/admin/v1/leaderboard_shadowbans", headers: auth_headers(key)
 
@@ -11,8 +11,8 @@ class Api::Admin::V1::LeaderboardShadowbansControllerTest < ActionDispatch::Inte
   end
 
   test "create requires a shadowban-capable admin API key" do
-    admin = User.create!(timezone: "UTC", admin_level: :admin)
-    key = admin.admin_api_keys.create!(name: "test")
+    viewer = User.create!(timezone: "UTC", admin_level: :viewer)
+    key = viewer.admin_api_keys.create!(name: "test")
     user = User.create!(timezone: "UTC", username: "shadowban_create_403")
 
     post "/api/admin/v1/leaderboard_shadowbans", params: { user_id: user.id, reason: "fake leaderboard activity" }, headers: auth_headers(key), as: :json
@@ -23,14 +23,25 @@ class Api::Admin::V1::LeaderboardShadowbansControllerTest < ActionDispatch::Inte
 
   test "destroy requires a shadowban-capable admin API key" do
     superadmin = User.create!(timezone: "UTC", admin_level: :superadmin)
-    admin = User.create!(timezone: "UTC", admin_level: :admin)
-    key = admin.admin_api_keys.create!(name: "test")
+    viewer = User.create!(timezone: "UTC", admin_level: :viewer)
+    key = viewer.admin_api_keys.create!(name: "test")
     user = User.create!(timezone: "UTC", username: "shadowban_destroy403")
     user.set_leaderboard_shadowban(banned: true, changed_by_user: superadmin, reason: "fake leaderboard activity")
 
     delete "/api/admin/v1/leaderboard_shadowbans/#{user.id}", headers: auth_headers(key)
 
     assert_response :forbidden
+    assert user.reload.leaderboard_shadowbanned?
+  end
+
+  test "regular admins can create leaderboard shadowbans" do
+    admin = User.create!(timezone: "UTC", admin_level: :admin)
+    key = admin.admin_api_keys.create!(name: "test")
+    user = User.create!(timezone: "UTC", username: "sb_admin_create")
+
+    post "/api/admin/v1/leaderboard_shadowbans", params: { user_id: user.id, reason: "fake leaderboard activity" }, headers: auth_headers(key), as: :json
+
+    assert_response :created
     assert user.reload.leaderboard_shadowbanned?
   end
 


### PR DESCRIPTION
## Summary of the problem
Admins often find fraud, but they can't shadowban people because they don't have perms!

## Describe your changes
Allows admins and above to shadowban users.

## Screenshots / Media
N/A