### PR TITLE
Allow using OAuth2 access tokens w/ `/api/v1/users/<userid>/stats`

### DIFF
--- a/app/controllers/api/v1/authenticated/application_controller.rb
+++ b/app/controllers/api/v1/authenticated/application_controller.rb
@@ -4,7 +4,7 @@ module Api
       class ApplicationController < ActionController::API
         include Doorkeeper::Rails::Helpers
         before_action :doorkeeper_authorize!
-        before_action :ensure_no_ban
+        before_action :ensure_api_access_allowed
 
         private
 
@@ -12,8 +12,8 @@ module Api
           @current_user ||= User.find(doorkeeper_token.resource_owner_id) if doorkeeper_token
         end
 
-        def ensure_no_ban
-          render json: { error: "Unauthorized" }, status: :unauthorized if current_user&.trust_level == "red"
+        def ensure_api_access_allowed
+          render json: { error: "Unauthorized" }, status: :unauthorized if current_user&.api_access_restricted?
         end
       end
     end

--- a/app/controllers/api/v1/authenticated/application_controller.rb
+++ b/app/controllers/api/v1/authenticated/application_controller.rb
@@ -15,6 +15,10 @@ module Api
         def ensure_api_access_allowed
           render json: { error: "Unauthorized" }, status: :unauthorized if current_user&.api_access_restricted?
         end
+
+        def ensure_no_pending_deletion
+          render json: { error: "Unauthorized" }, status: :unauthorized if current_user&.pending_deletion?
+        end
       end
     end
   end

--- a/app/controllers/api/v1/authenticated/me_controller.rb
+++ b/app/controllers/api/v1/authenticated/me_controller.rb
@@ -3,6 +3,7 @@ module Api
     module Authenticated
       class MeController < ApplicationController
         skip_before_action :ensure_api_access_allowed, only: :index
+        before_action :ensure_no_pending_deletion, only: :index
 
         def index
           app = doorkeeper_token&.application

--- a/app/controllers/api/v1/authenticated/me_controller.rb
+++ b/app/controllers/api/v1/authenticated/me_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V1
     module Authenticated
       class MeController < ApplicationController
-        skip_before_action :ensure_no_ban, only: :index
+        skip_before_action :ensure_api_access_allowed, only: :index
 
         def index
           app = doorkeeper_token&.application

--- a/app/controllers/api/v1/stats_controller.rb
+++ b/app/controllers/api/v1/stats_controller.rb
@@ -170,7 +170,7 @@ class Api::V1::StatsController < ApplicationController
     if identifier == "my"
       token = request.headers["Authorization"]&.split(" ")&.last
       @api_caller_user = ApiKey.find_by(token: token)&.user if token.present?
-      @user = @api_caller_user
+      @user = @api_caller_user || oauth_bearer_user
     else
       @user = User.lookup_by_identifier(identifier)
     end
@@ -179,7 +179,7 @@ class Api::V1::StatsController < ApplicationController
   def ensure_public_stats_allowed!
     return render_not_found_json("User not found") unless @user
     return if @user.allow_public_stats_lookup
-    return if current_user == @user || @api_caller_user == @user
+    return if current_user == @user || @api_caller_user == @user || oauth_bearer_user == @user
     render_forbidden("user has disabled public stats")
   end
 

--- a/app/controllers/api/v1/stats_controller.rb
+++ b/app/controllers/api/v1/stats_controller.rb
@@ -167,10 +167,12 @@ class Api::V1::StatsController < ApplicationController
 
   def set_user
     identifier = params[:username] || params[:username_or_id] || params[:user_id]
+    token = request.headers["Authorization"]&.split(" ")&.last
+    @api_caller_user = ApiKey.find_by(token: token)&.user if token.present?
+    @api_caller_user ||= oauth_read_bearer_user
+
     if identifier == "my"
-      token = request.headers["Authorization"]&.split(" ")&.last
-      @api_caller_user = ApiKey.find_by(token: token)&.user if token.present?
-      @user = @api_caller_user || oauth_bearer_user
+      @user = @api_caller_user
     else
       @user = User.lookup_by_identifier(identifier)
     end
@@ -179,9 +181,11 @@ class Api::V1::StatsController < ApplicationController
   def ensure_public_stats_allowed!
     return render_not_found_json("User not found") unless @user
     return if @user.allow_public_stats_lookup
-    return if current_user == @user || @api_caller_user == @user || oauth_bearer_user == @user
+    return if current_user == @user || @api_caller_user == @user
     render_forbidden("user has disabled public stats")
   end
+
+  def oauth_read_bearer_user = oauth_bearer_user([ "read" ])
 
   def find_by_email(email)
     cache_key = "user_id_by_email/#{email}"

--- a/app/controllers/api/v1/stats_controller.rb
+++ b/app/controllers/api/v1/stats_controller.rb
@@ -169,6 +169,7 @@ class Api::V1::StatsController < ApplicationController
     identifier = params[:username] || params[:username_or_id] || params[:user_id]
     token = request.headers["Authorization"]&.split(" ")&.last
     @api_caller_user = ApiKey.find_by(token: token)&.user if token.present?
+    @api_caller_user = nil if @api_caller_user&.api_access_restricted?
     @api_caller_user ||= oauth_read_bearer_user
 
     if identifier == "my"

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -70,12 +70,13 @@ class ApplicationController < ActionController::Base
     render_unauthorized(message) unless token.present? && ActiveSupport::SecurityUtils.secure_compare(token, expected)
   end
 
-  def oauth_bearer_user
-    @oauth_bearer_user ||= begin
+  def oauth_bearer_user(required_scopes = [])
+    @oauth_bearer_users ||= {}
+    @oauth_bearer_users[required_scopes] ||= begin
       scheme, raw_token = request.headers["Authorization"].to_s.split(/\s+/, 2)
       if scheme == "Bearer" && raw_token.present?
         token = Doorkeeper::AccessToken.by_token(raw_token)
-        User.find_by(id: token.resource_owner_id) if token&.acceptable?([])
+        User.find_by(id: token.resource_owner_id) if token&.acceptable?(required_scopes)
       end
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -74,9 +74,12 @@ class ApplicationController < ActionController::Base
     @oauth_bearer_users ||= {}
     @oauth_bearer_users[required_scopes] ||= begin
       scheme, raw_token = request.headers["Authorization"].to_s.split(/\s+/, 2)
-      if scheme == "Bearer" && raw_token.present?
+      if scheme&.casecmp?("Bearer") && raw_token.present?
         token = Doorkeeper::AccessToken.by_token(raw_token)
-        User.find_by(id: token.resource_owner_id) if token&.acceptable?(required_scopes)
+        if token&.acceptable?(required_scopes)
+          user = User.find_by(id: token.resource_owner_id)
+          user unless user&.api_access_restricted?
+        end
       end
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -70,6 +70,16 @@ class ApplicationController < ActionController::Base
     render_unauthorized(message) unless token.present? && ActiveSupport::SecurityUtils.secure_compare(token, expected)
   end
 
+  def oauth_bearer_user
+    @oauth_bearer_user ||= begin
+      scheme, raw_token = request.headers["Authorization"].to_s.split(/\s+/, 2)
+      if scheme == "Bearer" && raw_token.present?
+        token = Doorkeeper::AccessToken.by_token(raw_token)
+        User.find_by(id: token.resource_owner_id) if token&.acceptable?([])
+      end
+    end
+  end
+
   def enforce_lockout
     return unless current_user&.pending_deletion?
     return if %w[deletion_requests sessions].include?(controller_name)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -257,6 +257,7 @@ class User < ApplicationRecord
   def streak_days = @streak_days ||= heartbeats.daily_streaks_for_users([ id ]).values.first
   def active_deletion_request = deletion_requests.active.order(created_at: :desc).first
   def pending_deletion? = active_deletion_request.present?
+  def api_access_restricted? = red? || pending_deletion?
 
   def can_request_deletion?
     return false if pending_deletion?

--- a/test/controllers/api/v1/authenticated/me_controller_test.rb
+++ b/test/controllers/api/v1/authenticated/me_controller_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+
+class Api::V1::Authenticated::MeControllerTest < ActionDispatch::IntegrationTest
+  test "index allows red users" do
+    user = User.create!(timezone: "UTC", trust_level: :red)
+    access_token = create_oauth_access_token(user)
+
+    get "/api/v1/authenticated/me", headers: { "Authorization" => "Bearer #{access_token.token}" }
+
+    assert_response :success
+  end
+
+  test "index rejects pending deletion users" do
+    user = User.create!(timezone: "UTC")
+    DeletionRequest.create_for_user!(user)
+    access_token = create_oauth_access_token(user)
+
+    get "/api/v1/authenticated/me", headers: { "Authorization" => "Bearer #{access_token.token}" }
+
+    assert_response :unauthorized
+  end
+
+  private
+
+  def create_oauth_access_token(user, scopes: "profile")
+    application = user.oauth_applications.create!(
+      name: "Test App",
+      redirect_uri: "https://example.com/callback",
+      scopes: scopes,
+      confidential: true
+    )
+
+    Doorkeeper::AccessToken.create!(
+      application: application,
+      resource_owner_id: user.id,
+      scopes: scopes,
+      expires_in: 16.years
+    )
+  end
+end

--- a/test/controllers/api/v1/stats_controller_test.rb
+++ b/test/controllers/api/v1/stats_controller_test.rb
@@ -81,7 +81,7 @@ class Api::V1::StatsControllerTest < ActionDispatch::IntegrationTest
 
   test "user_stats allows owner via OAuth token even when public stats disabled" do
     user = User.create!(username: "private_#{SecureRandom.hex(3)}", timezone: "UTC", allow_public_stats_lookup: false)
-    access_token = create_oauth_access_token(user)
+    access_token = create_oauth_access_token(user, scopes: "profile read")
 
     get "/api/v1/users/#{user.username}/stats", headers: { "Authorization" => "Bearer #{access_token.token}" }
 
@@ -90,7 +90,7 @@ class Api::V1::StatsControllerTest < ActionDispatch::IntegrationTest
 
   test "user_projects allows owner via OAuth token even when public stats disabled" do
     user = User.create!(username: "private_#{SecureRandom.hex(3)}", timezone: "UTC", allow_public_stats_lookup: false)
-    access_token = create_oauth_access_token(user)
+    access_token = create_oauth_access_token(user, scopes: "profile read")
 
     get "/api/v1/users/#{user.username}/projects", headers: { "Authorization" => "Bearer #{access_token.token}" }
 
@@ -100,9 +100,18 @@ class Api::V1::StatsControllerTest < ActionDispatch::IntegrationTest
   test "user_stats rejects a different user's OAuth token against a private user's stats" do
     private_user = User.create!(username: "private_#{SecureRandom.hex(3)}", timezone: "UTC", allow_public_stats_lookup: false)
     other_user = User.create!(username: "other_#{SecureRandom.hex(3)}", timezone: "UTC")
-    access_token = create_oauth_access_token(other_user)
+    access_token = create_oauth_access_token(other_user, scopes: "profile read")
 
     get "/api/v1/users/#{private_user.username}/stats", headers: { "Authorization" => "Bearer #{access_token.token}" }
+
+    assert_response :forbidden
+  end
+
+  test "user_stats rejects owner OAuth token without read scope when public stats disabled" do
+    user = User.create!(username: "private_#{SecureRandom.hex(3)}", timezone: "UTC", allow_public_stats_lookup: false)
+    access_token = create_oauth_access_token(user, scopes: "profile")
+
+    get "/api/v1/users/#{user.username}/stats", headers: { "Authorization" => "Bearer #{access_token.token}" }
 
     assert_response :forbidden
   end
@@ -129,18 +138,18 @@ class Api::V1::StatsControllerTest < ActionDispatch::IntegrationTest
     )
   end
 
-  def create_oauth_access_token(user)
+  def create_oauth_access_token(user, scopes: "profile")
     application = user.oauth_applications.create!(
       name: "Test App",
       redirect_uri: "https://example.com/callback",
-      scopes: "profile",
+      scopes: scopes,
       confidential: true
     )
 
     Doorkeeper::AccessToken.create!(
       application: application,
       resource_owner_id: user.id,
-      scopes: "profile",
+      scopes: scopes,
       expires_in: 16.years
     )
   end

--- a/test/controllers/api/v1/stats_controller_test.rb
+++ b/test/controllers/api/v1/stats_controller_test.rb
@@ -79,6 +79,34 @@ class Api::V1::StatsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "user_stats allows owner via OAuth token even when public stats disabled" do
+    user = User.create!(username: "private_#{SecureRandom.hex(3)}", timezone: "UTC", allow_public_stats_lookup: false)
+    access_token = create_oauth_access_token(user)
+
+    get "/api/v1/users/#{user.username}/stats", headers: { "Authorization" => "Bearer #{access_token.token}" }
+
+    assert_response :success
+  end
+
+  test "user_projects allows owner via OAuth token even when public stats disabled" do
+    user = User.create!(username: "private_#{SecureRandom.hex(3)}", timezone: "UTC", allow_public_stats_lookup: false)
+    access_token = create_oauth_access_token(user)
+
+    get "/api/v1/users/#{user.username}/projects", headers: { "Authorization" => "Bearer #{access_token.token}" }
+
+    assert_response :success
+  end
+
+  test "user_stats rejects a different user's OAuth token against a private user's stats" do
+    private_user = User.create!(username: "private_#{SecureRandom.hex(3)}", timezone: "UTC", allow_public_stats_lookup: false)
+    other_user = User.create!(username: "other_#{SecureRandom.hex(3)}", timezone: "UTC")
+    access_token = create_oauth_access_token(other_user)
+
+    get "/api/v1/users/#{private_user.username}/stats", headers: { "Authorization" => "Bearer #{access_token.token}" }
+
+    assert_response :forbidden
+  end
+
   test "user_stats rejects a different user's API token against a private user's stats" do
     private_user = User.create!(username: "private_#{SecureRandom.hex(3)}", timezone: "UTC", allow_public_stats_lookup: false)
     other_user = User.create!(username: "other_#{SecureRandom.hex(3)}", timezone: "UTC")
@@ -98,6 +126,22 @@ class Api::V1::StatsControllerTest < ActionDispatch::IntegrationTest
       time: time,
       project: project,
       category: category
+    )
+  end
+
+  def create_oauth_access_token(user)
+    application = user.oauth_applications.create!(
+      name: "Test App",
+      redirect_uri: "https://example.com/callback",
+      scopes: "profile",
+      confidential: true
+    )
+
+    Doorkeeper::AccessToken.create!(
+      application: application,
+      resource_owner_id: user.id,
+      scopes: "profile",
+      expires_in: 16.years
     )
   end
 end

--- a/test/controllers/api/v1/stats_controller_test.rb
+++ b/test/controllers/api/v1/stats_controller_test.rb
@@ -88,6 +88,15 @@ class Api::V1::StatsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "user_stats allows owner via lowercase OAuth bearer scheme" do
+    user = User.create!(username: "private_#{SecureRandom.hex(3)}", timezone: "UTC", allow_public_stats_lookup: false)
+    access_token = create_oauth_access_token(user, scopes: "profile read")
+
+    get "/api/v1/users/#{user.username}/stats", headers: { "Authorization" => "bearer #{access_token.token}" }
+
+    assert_response :success
+  end
+
   test "user_projects allows owner via OAuth token even when public stats disabled" do
     user = User.create!(username: "private_#{SecureRandom.hex(3)}", timezone: "UTC", allow_public_stats_lookup: false)
     access_token = create_oauth_access_token(user, scopes: "profile read")
@@ -97,12 +106,47 @@ class Api::V1::StatsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "private read endpoints allow owner via OAuth token" do
+    user = User.create!(username: "private_#{SecureRandom.hex(3)}", timezone: "UTC", allow_public_stats_lookup: false)
+    create_heartbeat(user:, time: Time.current.to_f, project: "Galactic_war", category: "coding")
+    access_token = create_oauth_access_token(user, scopes: "profile read")
+    headers = { "Authorization" => "Bearer #{access_token.token}" }
+
+    get "/api/v1/users/#{user.username}/heartbeats/spans", headers: headers
+    assert_response :success
+
+    get "/api/v1/users/#{user.username}/project/Galactic_war", headers: headers
+    assert_response :success
+
+    get "/api/v1/users/#{user.username}/projects/details", params: { projects: "Galactic_war" }, headers: headers
+    assert_response :success
+  end
+
   test "user_stats rejects a different user's OAuth token against a private user's stats" do
     private_user = User.create!(username: "private_#{SecureRandom.hex(3)}", timezone: "UTC", allow_public_stats_lookup: false)
     other_user = User.create!(username: "other_#{SecureRandom.hex(3)}", timezone: "UTC")
     access_token = create_oauth_access_token(other_user, scopes: "profile read")
 
     get "/api/v1/users/#{private_user.username}/stats", headers: { "Authorization" => "Bearer #{access_token.token}" }
+
+    assert_response :forbidden
+  end
+
+  test "user_stats rejects red owner OAuth token when public stats disabled" do
+    user = User.create!(username: "private_#{SecureRandom.hex(3)}", timezone: "UTC", allow_public_stats_lookup: false, trust_level: :red)
+    access_token = create_oauth_access_token(user, scopes: "profile read")
+
+    get "/api/v1/users/#{user.username}/stats", headers: { "Authorization" => "Bearer #{access_token.token}" }
+
+    assert_response :forbidden
+  end
+
+  test "user_stats rejects pending deletion owner OAuth token when public stats disabled" do
+    user = User.create!(username: "private_#{SecureRandom.hex(3)}", timezone: "UTC", allow_public_stats_lookup: false)
+    DeletionRequest.create_for_user!(user)
+    access_token = create_oauth_access_token(user, scopes: "profile read")
+
+    get "/api/v1/users/#{user.username}/stats", headers: { "Authorization" => "Bearer #{access_token.token}" }
 
     assert_response :forbidden
   end

--- a/test/controllers/api/v1/stats_controller_test.rb
+++ b/test/controllers/api/v1/stats_controller_test.rb
@@ -170,6 +170,15 @@ class Api::V1::StatsControllerTest < ActionDispatch::IntegrationTest
     assert_response :forbidden
   end
 
+  test "user_stats rejects restricted owner API token when public stats disabled" do
+    user = User.create!(username: "private_#{SecureRandom.hex(3)}", timezone: "UTC", allow_public_stats_lookup: false, trust_level: :red)
+    api_key = user.api_keys.create!(name: "test")
+
+    get "/api/v1/users/#{user.username}/stats", headers: { "Authorization" => "Bearer #{api_key.token}" }
+
+    assert_response :forbidden
+  end
+
   private
 
   def create_heartbeat(user:, time:, project:, category:)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -69,6 +69,20 @@ class UserTest < ActiveSupport::TestCase
     assert_equal "User;#{user.id}", user.flipper_id
   end
 
+  test "api_access_restricted? is true for red users and users pending deletion" do
+    user = User.create!(timezone: "UTC")
+    assert_not user.api_access_restricted?
+
+    user.update!(trust_level: :red)
+    assert user.api_access_restricted?
+
+    user.update!(trust_level: :blue)
+    assert_not user.api_access_restricted?
+
+    DeletionRequest.create_for_user!(user)
+    assert user.api_access_restricted?
+  end
+
   test "display name override takes precedence over synced provider names" do
     user = User.create!(
       timezone: "UTC",


### PR DESCRIPTION
## Summary of the problem
The OAuth API is... terrible. This helps make things easier for YSWS authors whilst we revamp the API :)

## Describe your changes
Allows using OAuth2 access tokens in the `Bearer` header to bypass the public stats gate.

## Screenshots / Media
N/A