### PR TITLE
Make JA4s have names + drop unused index

### DIFF
--- a/app/controllers/concerns/api/admin/v1/user_utilities.rb
+++ b/app/controllers/concerns/api/admin/v1/user_utilities.rb
@@ -307,7 +307,7 @@ module Api
           total_count = query.count
           source_types = Heartbeat.source_types.invert
           rows = query.order(time: :asc).limit(limit).offset(offset).pluck(*HEARTBEAT_RESPONSE_COLUMNS)
-          ja4s_by_id = Ja4.where(id: rows.filter_map(&:last).uniq).pluck(:id, :fingerprint).to_h
+          ja4s_by_id = Ja4.where(id: rows.filter_map(&:last).uniq).index_by(&:id)
           heartbeats = rows.map do |id, time, lineno, cursorpos, is_write, project, language, entity, branch, category, editor, machine, user_agent, ip_address, lines, source_type, ja4_id|
             {
               id: id,
@@ -324,7 +324,7 @@ module Api
               machine: machine,
               user_agent: user_agent,
               ip_address: ip_address,
-              ja4: ja4s_by_id[ja4_id],
+              ja4: ja4s_by_id[ja4_id]&.then { |ja4| { fingerprint: ja4.fingerprint, name: ja4.name } },
               lines: lines,
               source_type: source_types[source_type] || source_type
             }

--- a/db/migrate/20260619131952_add_name_to_ja4s.rb
+++ b/db/migrate/20260619131952_add_name_to_ja4s.rb
@@ -1,0 +1,5 @@
+class AddNameToJa4s < ActiveRecord::Migration[8.1]
+  def change
+    add_column :ja4s, :name, :text, if_not_exists: true
+  end
+end

--- a/db/migrate/20260620232900_drop_unused_heartbeat_indexes.rb
+++ b/db/migrate/20260620232900_drop_unused_heartbeat_indexes.rb
@@ -1,0 +1,29 @@
+class DropUnusedHeartbeatIndexes < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def up
+    remove_index :heartbeats,
+      name: :index_heartbeats_on_time_imported,
+      algorithm: :concurrently,
+      if_exists: true
+
+    remove_index :heartbeats,
+      name: :index_heartbeats_on_last_language_user_id,
+      algorithm: :concurrently,
+      if_exists: true
+  end
+
+  def down
+    add_index :heartbeats, :time,
+      name: :index_heartbeats_on_time_imported,
+      where: "source_type != 0",
+      algorithm: :concurrently,
+      if_not_exists: true
+
+    add_index :heartbeats, :user_id,
+      name: :index_heartbeats_on_last_language_user_id,
+      where: "language = '<<LAST_LANGUAGE>>'",
+      algorithm: :concurrently,
+      if_not_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_13_154503) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_20_232900) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -344,7 +344,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_13_154503) do
     t.index ["time", "source_type"], name: "index_heartbeats_on_time_and_source_type"
     t.index ["time", "user_id"], name: "idx_heartbeats_time_user_active", where: "(deleted_at IS NULL)"
     t.index ["time"], name: "index_heartbeats_on_time_active_covering", where: "(deleted_at IS NULL)", include: ["source_type"]
-    t.index ["time"], name: "index_heartbeats_on_time_imported", where: "(source_type <> 0)"
     t.index ["user_agent"], name: "index_heartbeats_on_user_agent"
     t.index ["user_agent"], name: "index_heartbeats_on_user_agent_trgm", opclass: :gin_trgm_ops, using: :gin
     t.index ["user_id", "category", "time"], name: "idx_heartbeats_user_category_time_incl_editor", where: "(deleted_at IS NULL)", include: ["editor"]
@@ -380,6 +379,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_13_154503) do
   create_table "ja4s", id: :serial, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.text "fingerprint", null: false
+    t.text "name"
     t.datetime "updated_at", null: false
     t.index ["fingerprint"], name: "index_ja4s_on_fingerprint", unique: true
   end

--- a/spec/requests/api/admin/v1/admin_user_utils_spec.rb
+++ b/spec/requests/api/admin/v1/admin_user_utils_spec.rb
@@ -177,7 +177,14 @@ RSpec.describe 'Api::Admin::V1::UserUtils', type: :request, openapi_spec: 'admin
                   machine: { type: :string, nullable: true, example: 'Orpheus-MacBook-Pro' },
                   user_agent: { type: :string, nullable: true, example: 'wakatime/v1.115.2 (darwin-24.6.0) go1.23 vscode/1.96.0' },
                   ip_address: { type: :string, nullable: true, example: '203.0.113.7' },
-                  ja4: { type: :string, nullable: true, example: 't13d1516h2_8daaf6152771_02713d6af862' },
+                  ja4: {
+                    type: :object,
+                    nullable: true,
+                    properties: {
+                      fingerprint: { type: :string, example: 't13d1516h2_8daaf6152771_02713d6af862' },
+                      name: { type: :string, nullable: true, example: 'Go net/http' }
+                    }
+                  },
                   lines: { type: :integer, nullable: true, example: 350 },
                   source_type: { type: :string, example: 'direct_entry' }
                 }
@@ -195,7 +202,7 @@ RSpec.describe 'Api::Admin::V1::UserUtils', type: :request, openapi_spec: 'admin
             entity: 'app/models/user.rb',
             time: Time.current.to_f,
             source_type: :direct_entry,
-            ja4: Ja4.create!(fingerprint: 't13d1516h2_8daaf6152771_02713d6af862')
+            ja4: Ja4.create!(fingerprint: 't13d1516h2_8daaf6152771_02713d6af862', name: 'Go net/http')
           )
           u
         end
@@ -210,7 +217,10 @@ RSpec.describe 'Api::Admin::V1::UserUtils', type: :request, openapi_spec: 'admin
         let(:limit) { 10 }
         let(:offset) { 0 }
         run_test! do |response|
-          expect(JSON.parse(response.body).dig('heartbeats', 0, 'ja4')).to eq('t13d1516h2_8daaf6152771_02713d6af862')
+          expect(JSON.parse(response.body).dig('heartbeats', 0, 'ja4')).to eq(
+            'fingerprint' => 't13d1516h2_8daaf6152771_02713d6af862',
+            'name' => 'Go net/http'
+          )
         end
       end
 

--- a/swagger/admin/swagger.yaml
+++ b/swagger/admin/swagger.yaml
@@ -1850,9 +1850,16 @@ paths:
                           nullable: true
                           example: 203.0.113.7
                         ja4:
-                          type: string
+                          type: object
                           nullable: true
-                          example: t13d1516h2_8daaf6152771_02713d6af862
+                          properties:
+                            fingerprint:
+                              type: string
+                              example: t13d1516h2_8daaf6152771_02713d6af862
+                            name:
+                              type: string
+                              nullable: true
+                              example: Go net/http
                         lines:
                           type: integer
                           nullable: true

--- a/test/controllers/api/admin/v1/admin_controller_test.rb
+++ b/test/controllers/api/admin/v1/admin_controller_test.rb
@@ -1,0 +1,31 @@
+require "test_helper"
+
+class Api::Admin::V1::AdminControllerTest < ActionDispatch::IntegrationTest
+  test "user heartbeats returns ja4 fingerprint and name" do
+    admin = User.create!(timezone: "UTC", admin_level: :superadmin)
+    key = admin.admin_api_keys.create!(name: "test")
+    user = User.create!(timezone: "UTC", username: "admin_heartbeats_ja4")
+    ja4 = Ja4.create!(fingerprint: "t13d1312h2_f57a46bbacb6_ab7e3b40a677", name: "Go net/http")
+
+    user.heartbeats.create!(
+      time: Time.current.to_i,
+      project: "test-project",
+      entity: "test.rb",
+      source_type: :direct_entry,
+      ja4: ja4
+    )
+
+    get "/api/admin/v1/user/heartbeats", params: { user_id: user.id }, headers: auth_headers(key)
+
+    assert_response :success
+    response_ja4 = response.parsed_body.fetch("heartbeats").first.fetch("ja4")
+    assert_equal "t13d1312h2_f57a46bbacb6_ab7e3b40a677", response_ja4.fetch("fingerprint")
+    assert_equal "Go net/http", response_ja4.fetch("name")
+  end
+
+  private
+
+  def auth_headers(key)
+    { "Authorization" => ActionController::HttpAuthentication::Token.encode_credentials(key.token) }
+  end
+end


### PR DESCRIPTION
## Summary of the problem
JA4s don't have names :(

## Describe your changes
Make the admin heartbeats endpoint return JA4 fingerprints _and_ names.

## Screenshots / Media
N/A