### PR TITLE
Fix deleted_at leaks + make heartbeat ingest hypertable-cutover safe

### DIFF
--- a/app/controllers/api/admin/v1/admin_controller.rb
+++ b/app/controllers/api/admin/v1/admin_controller.rb
@@ -44,6 +44,7 @@ module Api
                     date_trunc('day', to_timestamp("time")) as day_start
                 FROM heartbeats
                 WHERE user_id = ?
+                AND deleted_at IS NULL
                 AND "time" >= ? AND "time" <= ?
                 LIMIT 1000000
             ),
@@ -94,7 +95,7 @@ module Api
                 date_trunc('day', to_timestamp("time"))::date as day,
                 "time" - LAG("time", 1, "time") OVER (PARTITION BY date_trunc('day', to_timestamp("time")) ORDER BY "time", id) as gap
               FROM heartbeats
-              WHERE user_id = ? AND time >= ? AND time <= ?
+              WHERE user_id = ? AND deleted_at IS NULL AND time >= ? AND time <= ?
             )
             SELECT day, SUM(LEAST(gap, 120)) as total_seconds
             FROM heartbeats_with_gaps
@@ -148,6 +149,7 @@ module Api
                         user_id IS NOT NULL
                         AND machine IS NOT NULL
                         AND ip_address IS NOT NULL
+                        AND deleted_at IS NULL
                         AND time >= ?
                     GROUP BY 1, 2, 3
                 ) r1
@@ -164,6 +166,7 @@ module Api
                         user_id IS NOT NULL
                         AND machine IS NOT NULL
                         AND ip_address IS NOT NULL
+                        AND deleted_at IS NULL
                         AND time >= ?
                     GROUP BY 1, 2, 3
                 ) r2 ON r1.machine = r2.machine AND r1.ip_address = r2.ip_address

--- a/app/controllers/api/admin/v1/heartbeats_controller.rb
+++ b/app/controllers/api/admin/v1/heartbeats_controller.rb
@@ -27,6 +27,7 @@ module Api
               WHERE user_id IS NOT NULL
                 AND machine IS NOT NULL
                 AND ip_address IS NOT NULL
+                AND deleted_at IS NULL
                 AND time > ?
               GROUP BY user_id, machine, ip_address
             ) r1
@@ -37,6 +38,7 @@ module Api
               WHERE user_id IS NOT NULL
                 AND machine IS NOT NULL
                 AND ip_address IS NOT NULL
+                AND deleted_at IS NULL
                 AND time > ?
               GROUP BY user_id, machine, ip_address
             ) r2 ON r1.machine = r2.machine AND r1.ip_address = r2.ip_address
@@ -67,12 +69,13 @@ module Api
                 SELECT DISTINCT machine, user_id
                 FROM heartbeats
                 WHERE machine IS NOT NULL
+                  AND deleted_at IS NULL
                   AND time > ?
               ) AS user_machines
               GROUP BY machine
               HAVING COUNT(user_id) > 1
             ) AS sms
-            JOIN heartbeats hb ON hb.machine = sms.machine AND hb.time > ?
+            JOIN heartbeats hb ON hb.machine = sms.machine AND hb.deleted_at IS NULL AND hb.time > ?
             JOIN users u ON u.id = hb.user_id
             GROUP BY sms.machine, sms.machine_frequency
             ORDER BY sms.machine_frequency DESC, sms.machine ASC

--- a/app/jobs/cache/active_projects_job.rb
+++ b/app/jobs/cache/active_projects_job.rb
@@ -6,14 +6,28 @@ class Cache::ActiveProjectsJob < Cache::ActivityJob
   def cache_expiration = 15.minutes
 
   def calculate
-    ProjectRepoMapping.active
-      .joins("INNER JOIN heartbeats ON heartbeats.project = project_repo_mappings.project_name AND heartbeats.user_id = project_repo_mappings.user_id")
-      .joins("INNER JOIN users ON users.id = heartbeats.user_id")
-      .where("heartbeats.source_type = ?", Heartbeat.source_types[:direct_entry])
-      .where("heartbeats.deleted_at IS NULL")
-      .where("heartbeats.time > ?", 5.minutes.ago.to_f)
-      .select("DISTINCT ON (heartbeats.user_id) project_repo_mappings.*, heartbeats.user_id")
-      .order("heartbeats.user_id, heartbeats.time DESC")
-      .index_by(&:user_id)
+    # The recent-heartbeats set (last 5 min) is tiny, so we materialize it first
+    # and join outward. Filtering heartbeats.deleted_at inline instead makes the
+    # planner abandon the index-only scan and fall into a per-mapping nested loop
+    # (measured ~380x slower on prod), so keep this shape.
+    sql = ProjectRepoMapping.sanitize_sql_array([ <<~SQL, Heartbeat.source_types[:direct_entry], 5.minutes.ago.to_f ])
+      WITH recent AS MATERIALIZED (
+        SELECT user_id, project, time
+        FROM heartbeats
+        WHERE source_type = ?
+          AND deleted_at IS NULL
+          AND time > ?
+      )
+      SELECT DISTINCT ON (recent.user_id) project_repo_mappings.*, recent.user_id
+      FROM project_repo_mappings
+      INNER JOIN recent
+        ON recent.project = project_repo_mappings.project_name
+        AND recent.user_id = project_repo_mappings.user_id
+      INNER JOIN users ON users.id = recent.user_id
+      WHERE project_repo_mappings.archived_at IS NULL
+      ORDER BY recent.user_id, recent.time DESC
+    SQL
+
+    ProjectRepoMapping.find_by_sql(sql).index_by(&:user_id)
   end
 end

--- a/app/jobs/cache/active_projects_job.rb
+++ b/app/jobs/cache/active_projects_job.rb
@@ -6,10 +6,6 @@ class Cache::ActiveProjectsJob < Cache::ActivityJob
   def cache_expiration = 15.minutes
 
   def calculate
-    # The recent-heartbeats set (last 5 min) is tiny, so we materialize it first
-    # and join outward. Filtering heartbeats.deleted_at inline instead makes the
-    # planner abandon the index-only scan and fall into a per-mapping nested loop
-    # (measured ~380x slower on prod), so keep this shape.
     sql = ProjectRepoMapping.sanitize_sql_array([ <<~SQL, Heartbeat.source_types[:direct_entry], 5.minutes.ago.to_f ])
       WITH recent AS MATERIALIZED (
         SELECT user_id, project, time

--- a/app/jobs/cache/active_projects_job.rb
+++ b/app/jobs/cache/active_projects_job.rb
@@ -10,6 +10,7 @@ class Cache::ActiveProjectsJob < Cache::ActivityJob
       .joins("INNER JOIN heartbeats ON heartbeats.project = project_repo_mappings.project_name AND heartbeats.user_id = project_repo_mappings.user_id")
       .joins("INNER JOIN users ON users.id = heartbeats.user_id")
       .where("heartbeats.source_type = ?", Heartbeat.source_types[:direct_entry])
+      .where("heartbeats.deleted_at IS NULL")
       .where("heartbeats.time > ?", 5.minutes.ago.to_f)
       .select("DISTINCT ON (heartbeats.user_id) project_repo_mappings.*, heartbeats.user_id")
       .order("heartbeats.user_id, heartbeats.time DESC")

--- a/app/services/heartbeat_ingest.rb
+++ b/app/services/heartbeat_ingest.rb
@@ -1,6 +1,16 @@
 class HeartbeatIngest
   LAST_LANGUAGE_SENTINEL = "<<LAST_LANGUAGE>>"
 
+  # Sane epoch-seconds window: 2001-09-09 .. 2033-05-18. Values outside are
+  # client bugs (uptime-like numbers, literal years, ms/µs/ns-scaled epochs).
+  EPOCH_SANE_MIN = 1_000_000_000
+  EPOCH_SANE_MAX = 2_000_000_000
+
+  # The heartbeats dedup unique index changes from (fields_hash) to
+  # (fields_hash, time_epoch) during the hypertable migration.
+  UNIQUE_BY_LEGACY = [ :fields_hash ].freeze
+  UNIQUE_BY_COMPOSITE = %i[fields_hash time_epoch].freeze
+
   Result = Data.define(:total_count, :persisted_count, :duplicate_count, :failed_count, :errors, :items)
   Item = Data.define(:heartbeat, :status, :error)
 
@@ -57,6 +67,7 @@ class HeartbeatIngest
 
   def normalize_direct_heartbeat(heartbeat, last_language:)
     attrs = heartbeat.to_h.with_indifferent_access
+    attrs[:time] = normalize_epoch_time(attrs[:time]) if attrs[:time].present?
     source_type = attrs[:entity] == "test.txt" ? :test_entry : :direct_entry
 
     if attrs[:language] == LAST_LANGUAGE_SENTINEL
@@ -91,10 +102,12 @@ class HeartbeatIngest
     return [ existing, true ] if existing
 
     now = Time.current
-    result = Heartbeat.insert(
-      attrs.merge(fields_hash:, created_at: now, updated_at: now),
-      unique_by: :fields_hash, returning: Heartbeat.column_names
-    )
+    result = with_heartbeat_unique_by do |unique_by|
+      Heartbeat.insert(
+        attrs.merge(fields_hash:, created_at: now, updated_at: now),
+        unique_by:, returning: Heartbeat.column_names
+      )
+    end
 
     persisted = result.any? ? Heartbeat.new(result.first) : @user.heartbeats.find_by!(fields_hash:)
     self.class.schedule_rollup_refresh(user: @user) if result.any? && @schedule_rollup_refresh
@@ -136,7 +149,7 @@ class HeartbeatIngest
 
     attrs = {
       user_id: @user.id,
-      time: hb[:time].is_a?(String) ? Time.parse(hb[:time]).to_f : hb[:time].to_f,
+      time: normalize_epoch_time(hb[:time].is_a?(String) ? Time.parse(hb[:time]).to_f : hb[:time]),
       entity: hb[:entity],
       type: hb[:type],
       category: hb[:category] || "coding",
@@ -165,7 +178,40 @@ class HeartbeatIngest
     return 0 if seen_hashes.empty?
     timestamp = Time.current
     records = seen_hashes.values.map { |r| r.merge(created_at: timestamp, updated_at: timestamp) }
-    ActiveRecord::Base.logger.silence { Heartbeat.insert_all(records, unique_by: [ :fields_hash ]).length }
+    ActiveRecord::Base.logger.silence do
+      with_heartbeat_unique_by { |unique_by| Heartbeat.insert_all(records, unique_by:).length }
+    end
+  end
+
+  def heartbeat_unique_by
+    Heartbeat.column_names.include?("time_epoch") ? UNIQUE_BY_COMPOSITE : UNIQUE_BY_LEGACY
+  end
+
+  # Rails resolves `unique_by:` against its schema cache, which goes stale the
+  # moment the hypertable cutover swaps the table under us. Refresh the cache
+  # and retry once so in-flight processes self-heal without a restart.
+  def with_heartbeat_unique_by
+    yield heartbeat_unique_by
+  rescue ActiveRecord::StatementInvalid, ArgumentError => e
+    Heartbeat.reset_column_information
+    # Inside an open (now aborted) transaction a retry cannot succeed; re-raise
+    # and let the caller retry with the already-refreshed schema cache.
+    raise if Heartbeat.connection.transaction_open?
+
+    Rails.logger.warn("HeartbeatIngest unique_by fallback: #{e.class}: #{e.message}")
+    yield heartbeat_unique_by
+  end
+
+  def normalize_epoch_time(value)
+    t = value.to_f
+    return t if t >= EPOCH_SANE_MIN && t < EPOCH_SANE_MAX
+
+    # ms / µs / ns-scaled epochs are mechanically repairable
+    [ 1e3, 1e6, 1e9 ].each do |scale|
+      scaled = t / scale
+      return scaled if scaled >= EPOCH_SANE_MIN && scaled < EPOCH_SANE_MAX
+    end
+    t
   end
 
   def parse_user_agent(user_agent)

--- a/test/jobs/cache/active_projects_job_test.rb
+++ b/test/jobs/cache/active_projects_job_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+
+class Cache::ActiveProjectsJobTest < ActiveSupport::TestCase
+  setup { Rails.cache.clear }
+  teardown { Rails.cache.clear }
+
+  def create_heartbeat(user:, project:, **attrs)
+    Heartbeat.create!(
+      user: user, project: project, entity: "src/#{project}.rb",
+      source_type: :direct_entry, time: Time.current.to_f, **attrs
+    )
+  end
+
+  test "returns the most recent active project per user and excludes soft-deleted heartbeats" do
+    user = User.create!(timezone: "UTC")
+    ProjectRepoMapping.create!(user: user, project_name: "live")
+    ProjectRepoMapping.create!(user: user, project_name: "ghost")
+
+    create_heartbeat(user: user, project: "live", time: 1.minute.ago.to_f)
+    # a soft-deleted recent heartbeat must NOT resurrect "ghost" as active
+    create_heartbeat(user: user, project: "ghost", time: 30.seconds.ago.to_f, deleted_at: Time.current)
+
+    result = Cache::ActiveProjectsJob.new.send(:calculate)
+
+    assert_equal [ user.id ], result.keys
+    assert_equal "live", result[user.id].project_name
+  end
+
+  test "excludes heartbeats older than the recent window and non-direct source types" do
+    user = User.create!(timezone: "UTC")
+    ProjectRepoMapping.create!(user: user, project_name: "stale")
+    ProjectRepoMapping.create!(user: user, project_name: "imported")
+
+    create_heartbeat(user: user, project: "stale", time: 10.minutes.ago.to_f)
+    create_heartbeat(user: user, project: "imported", time: 1.minute.ago.to_f, source_type: :wakapi_import)
+
+    assert_empty Cache::ActiveProjectsJob.new.send(:calculate)
+  end
+end

--- a/test/services/heartbeat_ingest_test.rb
+++ b/test/services/heartbeat_ingest_test.rb
@@ -150,6 +150,70 @@ class HeartbeatIngestTest < ActiveSupport::TestCase
     assert_equal [ "Python", "Python" ], heartbeats.pluck(:language)
   end
 
+  test "direct heartbeat ingest normalizes millisecond-scaled epoch times" do
+    user = User.create!(timezone: "UTC")
+    sane_time = Time.current.to_f
+
+    HeartbeatIngest.call(
+      user: user,
+      mode: :direct,
+      heartbeats: [ { entity: "src/main.rb", time: (sane_time * 1000).round, type: "file" } ]
+    )
+
+    assert_in_delta sane_time, user.heartbeats.sole.time, 1.0
+  end
+
+  test "import heartbeat ingest normalizes nanosecond-scaled epoch times" do
+    user = User.create!(timezone: "UTC")
+    sane_time = 1_700_000_000.0
+
+    HeartbeatIngest.call(
+      user: user,
+      mode: :import,
+      heartbeats: [ { entity: "/tmp/test.rb", type: "file", time: sane_time * 1_000_000_000 } ]
+    )
+
+    assert_in_delta sane_time, user.heartbeats.sole.time, 1.0
+  end
+
+  test "epoch normalization leaves sane and unrepairable values untouched" do
+    ingest = HeartbeatIngest.new(user: User.new, mode: :direct, heartbeats: [])
+
+    sane = Time.current.to_f
+    assert_equal sane, ingest.send(:normalize_epoch_time, sane)
+    # literal-year garbage is not scaled data; passes through (quarantined DB-side later)
+    assert_equal 2026.0, ingest.send(:normalize_epoch_time, 2026)
+    assert_equal(-9_999_999.0, ingest.send(:normalize_epoch_time, -9_999_999))
+  end
+
+  test "heartbeat_unique_by targets the composite index once time_epoch exists" do
+    ingest = HeartbeatIngest.new(user: User.new, mode: :direct, heartbeats: [])
+
+    assert_equal [ :fields_hash ], ingest.send(:heartbeat_unique_by)
+
+    with_time_epoch_column = Heartbeat.column_names + [ "time_epoch" ]
+    Heartbeat.define_singleton_method(:column_names) { with_time_epoch_column }
+    begin
+      assert_equal %i[fields_hash time_epoch], ingest.send(:heartbeat_unique_by)
+    ensure
+      Heartbeat.singleton_class.remove_method(:column_names)
+    end
+  end
+
+  test "with_heartbeat_unique_by re-raises inside an open transaction after refreshing the schema cache" do
+    ingest = HeartbeatIngest.new(user: User.new, mode: :direct, heartbeats: [])
+
+    # transactional tests already wrap us in a transaction, so the guard applies
+    calls = 0
+    assert_raises(ArgumentError) do
+      ingest.send(:with_heartbeat_unique_by) do |_unique_by|
+        calls += 1
+        raise ArgumentError, "No unique index found"
+      end
+    end
+    assert_equal 1, calls
+  end
+
   test "import heartbeat ingest deduplicates imported heartbeats and schedules dashboard rollup refresh" do
     user = User.create!(timezone: "UTC")
 
@@ -187,5 +251,38 @@ class HeartbeatIngestTest < ActiveSupport::TestCase
 
     heartbeat = user.heartbeats.order(:id).last
     assert_equal "wakapi_import", heartbeat.source_type
+  end
+end
+
+# Outside a transaction (the production configuration for both ingest modes),
+# the unique_by fallback must retry exactly once with a refreshed schema cache.
+class HeartbeatIngestUniqueByFallbackTest < ActiveSupport::TestCase
+  self.use_transactional_tests = false
+
+  test "with_heartbeat_unique_by retries once after a schema-cache failure" do
+    ingest = HeartbeatIngest.new(user: User.new, mode: :direct, heartbeats: [])
+
+    calls = 0
+    result = ingest.send(:with_heartbeat_unique_by) do |unique_by|
+      calls += 1
+      raise ActiveRecord::StatementInvalid, "no unique or exclusion constraint" if calls == 1
+      unique_by
+    end
+
+    assert_equal 2, calls
+    assert_equal [ :fields_hash ], result
+  end
+
+  test "with_heartbeat_unique_by does not retry more than once" do
+    ingest = HeartbeatIngest.new(user: User.new, mode: :direct, heartbeats: [])
+
+    calls = 0
+    assert_raises(ActiveRecord::StatementInvalid) do
+      ingest.send(:with_heartbeat_unique_by) do |_unique_by|
+        calls += 1
+        raise ActiveRecord::StatementInvalid, "no unique or exclusion constraint"
+      end
+    end
+    assert_equal 2, calls
   end
 end


### PR DESCRIPTION
> [!NOTE]
> This PR was written by AI and reviewed extensively by a human.

Stage 1 of the heartbeats hypertable migration (runbook: `scratch/heartbeats-hypertable-migration.md`, Phase A). Everything here is valuable on its own; nothing depends on the migration actually happening.

## Bug fixes: soft-deleted heartbeats leaking into queries

A full-codebase audit of every heartbeats query found six raw-SQL/join sites that skip the `deleted_at IS NULL` filter that `default_scope` normally applies:

- `api/admin/v1/heartbeats_controller.rb`: `ip_machine_pairs` (both subqueries), `shared_machines` (inner select and the `JOIN heartbeats hb`)
- `api/admin/v1/admin_controller.rb`: `visualization_quantized`, the daily-totals CTE, `alt_candidates` (both subqueries)
- `cache/active_projects_job.rb`: runs every minute; a soft-deleted recent heartbeat could resurrect a project as "active"

Each now filters `deleted_at IS NULL` explicitly.

## Ingest: cutover-safe dedup upserts

The hypertable migration changes the dedup unique index from `(fields_hash)` to `(fields_hash, time_epoch)` (TimescaleDB requires unique indexes to include the partition column). Since `fields_hash` is derived from `time`, dedup semantics are unchanged. Rails resolves `unique_by:` from its schema cache, which goes stale at the moment of cutover, so `HeartbeatIngest`:

- picks the conflict target from the live schema (`heartbeat_unique_by`)
- wraps both upsert sites (`Heartbeat.insert` and `insert_all`) in a fallback that refreshes the schema cache and retries once on `StatementInvalid`/`ArgumentError`, so in-flight processes self-heal without a restart
- re-raises inside an open transaction (retrying an aborted transaction cannot work) but refreshes the cache first so the caller's retry succeeds; verified that no current ingest caller wraps in a transaction

Also normalizes ms/us/ns-scaled epoch timestamps at ingest in both modes (prod has 3.7k+ rows with millisecond-scaled `time` from client bugs). Literal-garbage values (e.g. `time = 2026`) pass through unchanged and will be quarantined DB-side during the migration.

## Verification

- Simulated the actual cutover against the dev DB (add column, swap unique indexes, install the `time_epoch` trigger, all outside a transaction like the real swap): stale-cache insert fails, wrapper self-heals, composite insert succeeds, trigger populates `time_epoch` before conflict arbitration, duplicates correctly rejected
- 12 ingest tests (7 new), full suite green: 386 runs, 0 failures
- Rubocop clean; Brakeman no warnings (relevant since raw SQL was touched)