### PR TITLE
Heartbeat ingest: supply time_epoch partition column (hypertable cutover prep)

### DIFF
--- a/app/models/heartbeat.rb
+++ b/app/models/heartbeat.rb
@@ -1,5 +1,6 @@
 class Heartbeat < ApplicationRecord
   before_save :set_fields_hash!
+  before_save :set_time_epoch!
   after_commit :schedule_dashboard_rollup_refresh, on: %i[create update destroy]
 
   include Heartbeatable
@@ -59,6 +60,13 @@ class Heartbeat < ApplicationRecord
   def set_fields_hash!
     # only if the field exists in activerecord
     self.fields_hash = self.class.generate_fields_hash(self.attributes) if self.class.column_names.include?("fields_hash")
+  end
+
+  # Populate the hypertable partition column on AR-object saves. Bulk ingest
+  # (insert/insert_all) sets it directly; this covers create/save/update paths.
+  # No-op until the column exists (post-cutover; plain table in dev/test).
+  def set_time_epoch!
+    self.time_epoch = time&.floor if self.class.column_names.include?("time_epoch") && time.present?
   end
 
   def schedule_dashboard_rollup_refresh = DashboardRollupRefreshJob.schedule_for(user_id)

--- a/app/services/heartbeat_ingest.rb
+++ b/app/services/heartbeat_ingest.rb
@@ -104,7 +104,7 @@ class HeartbeatIngest
     now = Time.current
     result = with_heartbeat_unique_by do |unique_by|
       Heartbeat.insert(
-        attrs.merge(fields_hash:, created_at: now, updated_at: now),
+        attrs.merge(fields_hash:, created_at: now, updated_at: now, **partition_attrs(attrs[:time])),
         unique_by:, returning: Heartbeat.column_names
       )
     end
@@ -177,14 +177,29 @@ class HeartbeatIngest
   def flush_import_batch(seen_hashes)
     return 0 if seen_hashes.empty?
     timestamp = Time.current
-    records = seen_hashes.values.map { |r| r.merge(created_at: timestamp, updated_at: timestamp) }
     ActiveRecord::Base.logger.silence do
-      with_heartbeat_unique_by { |unique_by| Heartbeat.insert_all(records, unique_by:).length }
+      # Build records inside the retry block so a cutover-time schema refresh
+      # recomputes both the conflict target and the time_epoch partition column.
+      with_heartbeat_unique_by do |unique_by|
+        records = seen_hashes.values.map { |r| r.merge(created_at: timestamp, updated_at: timestamp, **partition_attrs(r[:time])) }
+        Heartbeat.insert_all(records, unique_by:).length
+      end
     end
   end
 
   def heartbeat_unique_by
-    Heartbeat.column_names.include?("time_epoch") ? UNIQUE_BY_COMPOSITE : UNIQUE_BY_LEGACY
+    time_epoch_column? ? UNIQUE_BY_COMPOSITE : UNIQUE_BY_LEGACY
+  end
+
+  def time_epoch_column? = Heartbeat.column_names.include?("time_epoch")
+
+  # The hypertable partition column must arrive populated (TimescaleDB routes to
+  # a chunk before row triggers fire). Bulk insert/insert_all bypass model
+  # callbacks, so ingest supplies time_epoch explicitly once the column exists.
+  # No-op on the pre-cutover / dev-and-test plain table.
+  def partition_attrs(time)
+    return {} unless time_epoch_column? && time.present?
+    { time_epoch: time.to_f.floor }
   end
 
   # Rails resolves `unique_by:` against its schema cache, which goes stale the

--- a/test/services/heartbeat_ingest_test.rb
+++ b/test/services/heartbeat_ingest_test.rb
@@ -200,6 +200,40 @@ class HeartbeatIngestTest < ActiveSupport::TestCase
     end
   end
 
+  test "partition_attrs supplies floor(time) as time_epoch only once the column exists" do
+    ingest = HeartbeatIngest.new(user: User.new, mode: :direct, heartbeats: [])
+
+    # pre-cutover / dev-and-test plain table: no-op
+    assert_equal({}, ingest.send(:partition_attrs, 1_783_000_000.9))
+
+    with_time_epoch_column = Heartbeat.column_names + [ "time_epoch" ]
+    Heartbeat.define_singleton_method(:column_names) { with_time_epoch_column }
+    begin
+      assert_equal({ time_epoch: 1_783_000_000 }, ingest.send(:partition_attrs, 1_783_000_000.9))
+      assert_equal({}, ingest.send(:partition_attrs, nil))
+    ensure
+      Heartbeat.singleton_class.remove_method(:column_names)
+    end
+  end
+
+  test "set_time_epoch! populates the partition column when it exists" do
+    hb = Heartbeat.new(time: 1_783_000_000.9)
+
+    # column absent today: hook is a no-op and does not raise
+    assert_nothing_raised { hb.send(:set_time_epoch!) }
+
+    captured = []
+    hb.define_singleton_method(:time_epoch=) { |v| captured << v }
+    with_time_epoch = Heartbeat.column_names + [ "time_epoch" ]
+    Heartbeat.define_singleton_method(:column_names) { with_time_epoch }
+    begin
+      hb.send(:set_time_epoch!)
+      assert_equal [ 1_783_000_000 ], captured
+    ensure
+      Heartbeat.singleton_class.remove_method(:column_names)
+    end
+  end
+
   test "with_heartbeat_unique_by re-raises inside an open transaction after refreshing the schema cache" do
     ingest = HeartbeatIngest.new(user: User.new, mode: :direct, heartbeats: [])
 


### PR DESCRIPTION
# Disclaimer - this PR was AI-generated by Claude Fable 5, but was manually reviewed by a human in development.

---

## What & why

Stage 2 of the heartbeats → TimescaleDB hypertable migration. The new hypertable partitions on **`time_epoch`** (`bigint = floor(time)`).

Key constraint discovered during the live Stage 2 build: **TimescaleDB routes an insert to its chunk (and NULL-checks the partition column) *before* row triggers fire**, so a `BEFORE` trigger cannot populate `time_epoch` on the hypertable. Bulk `insert`/`insert_all` also bypass model callbacks. Therefore ingest must supply `time_epoch` explicitly.

## Changes

- **`HeartbeatIngest#partition_attrs`** merges `{ time_epoch: floor(time) }` into both the direct (`insert`) and import (`insert_all`) paths. Computed *inside* the existing `with_heartbeat_unique_by` retry block, so a cutover-time schema-cache refresh recomputes it alongside the `ON CONFLICT` target.
- **`Heartbeat#set_time_epoch!`** `before_save` hook covers non-bulk AR writes (`create`/`save`/`update`), mirroring `set_fields_hash!`.
- Both are **no-ops until the `time_epoch` column exists** — dev/test (plain table) and the pre-cutover prod table are unaffected; behaviour flips automatically once the column is present.

## Safe to deploy anytime before cutover
This is inert in production until the Stage 3 rename-swap makes `heartbeats` the hypertable. Deploying it early is the point: in-flight app processes already know how to write `time_epoch` the moment the schema flips.

## Verification
- Full suite green (390 runs, 0 failures); rubocop clean.
- New unit tests for `partition_attrs` and `set_time_epoch!` (schema-gated on/off).
- **End-to-end dev simulation of the post-cutover schema** (add `time_epoch` + composite unique index, drop old unique index, **no trigger**): direct ingest sets `time_epoch`, import normalizes ms-scaled epochs and dedups via `ON CONFLICT (fields_hash, time_epoch)`, re-sends dedup, zero NULL epochs.

Follows #1468. See `scratch/heartbeats-hypertable-migration.md` (§ execution corrections) for the full context.