### PR TITLE
Prevent layout shift while Spline Sans loads

### DIFF
--- a/app/assets/tailwind/main.css
+++ b/app/assets/tailwind/main.css
@@ -18,11 +18,18 @@
   }
 }
 
+@font-face {
+  font-family: "Spline Sans Fallback";
+  src: local("Arial"), local("Liberation Sans"), local("DejaVu Sans");
+  size-adjust: 89.6%;
+}
+
 body,
 html {
   font-family:
     "Spline Sans Variable",
     "Spline Sans",
+    "Spline Sans Fallback",
     -apple-system,
     BlinkMacSystemFont,
     "Inter",

--- a/app/javascript/entrypoints/application.css
+++ b/app/javascript/entrypoints/application.css
@@ -1,4 +1,5 @@
-@import '../../assets/tailwind/application.css';
+@import "@fontsource-variable/spline-sans";
+@import "../../assets/tailwind/application.css";
 
 @plugin '@tailwindcss/typography';
 @plugin '@tailwindcss/forms';

--- a/app/javascript/entrypoints/inertia.ts
+++ b/app/javascript/entrypoints/inertia.ts
@@ -1,4 +1,3 @@
-import "@fontsource-variable/spline-sans";
 import { createInertiaApp, type ResolvedComponent } from "@inertiajs/svelte";
 
 const pages = import.meta.glob<ResolvedComponent>("../pages/**/*.svelte");

--- a/app/javascript/ssr/ssr.ts
+++ b/app/javascript/ssr/ssr.ts
@@ -1,4 +1,3 @@
-import "@fontsource-variable/spline-sans";
 import { createInertiaApp, type ResolvedComponent } from "@inertiajs/svelte";
 
 const pages = import.meta.glob<ResolvedComponent>("../pages/**/*.svelte");


### PR DESCRIPTION
## Summary of the problem

After restoring the signed-in dashboard's eager SSR path, a smaller layout shift remained during hydration. Spline Sans was imported by the Inertia JavaScript entrypoint, so the browser initially laid out the SSR HTML with its substantially wider system fallback. When Spline Sans loaded, the GitHub banner changed from three lines to two and moved the already-rendered dashboard upward by 24px.

Cold Playwright runs measured CLS of 0.0335 from this font swap. Blocking the Spline Sans request eliminated the shift, confirming the cause was font metrics rather than deferred dashboard data or hydration markup.

## Describe your changes

- Load Spline Sans through the render-blocking application stylesheet instead of the Inertia client and SSR JavaScript entries.
- Add a metric-adjusted local fallback for Arial, Liberation Sans, and DejaVu Sans so cold text layout closely matches Spline Sans before the webfont arrives.
- Keep the final Spline Sans rendering unchanged.

On three cache-isolated Playwright runs through the Amp Portal, measured CLS fell from 0.0335 to 0.00098 (about a 97% reduction). The eager dashboard remained present in raw SSR with zero skeletons and no `dashboard_stats` partial request.

Validated with:

- `docker compose exec -T web bun run check`
- targeted Prettier checks for all changed CSS and TypeScript files
- `docker compose exec -T web bin/vite build --force`
- `docker compose exec -T web bin/vite build --ssr --force`
- Playwright with JavaScript disabled and enabled for both eager rollup and genuinely deferred dashboard URLs

## Screenshots / Media

N/A — the final rendering is unchanged; this prevents movement while the existing font loads.
