### PR TITLE
Add missing fields to admin heartbeat endpoint

### DIFF
--- a/app/controllers/concerns/api/admin/v1/user_utilities.rb
+++ b/app/controllers/concerns/api/admin/v1/user_utilities.rb
@@ -308,25 +308,32 @@ module Api
           source_types = Heartbeat.source_types.invert
           rows = query.order(time: :asc).limit(limit).offset(offset).pluck(*HEARTBEAT_RESPONSE_COLUMNS)
           ja4s_by_id = Ja4.where(id: rows.filter_map(&:last).uniq).index_by(&:id)
-          heartbeats = rows.map do |id, time, lineno, cursorpos, is_write, project, language, entity, branch, category, editor, machine, user_agent, ip_address, lines, source_type, ja4_id|
+          heartbeats = rows.map do |id, time, created_at, lineno, cursorpos, is_write, project, language, entity, branch, category, dependencies, editor, machine, operating_system, type, project_root_count, user_agent, line_additions, line_deletions, ip_address, lines, source_type, ja4_id|
             {
               id: id,
               time: time,
-              lineno: lineno || 0,
-              cursorpos: cursorpos || 0,
-              is_write: is_write,
+              created_at: created_at,
               project: project,
-              language: language,
-              entity: entity,
               branch: branch,
               category: category,
+              dependencies: dependencies,
               editor: editor,
+              entity: entity,
+              language: language,
               machine: machine,
+              operating_system: operating_system,
+              type: type,
               user_agent: user_agent,
-              ip_address: ip_address,
-              ja4: ja4s_by_id[ja4_id]&.then { |ja4| { fingerprint: ja4.fingerprint, name: ja4.name } },
+              line_additions: line_additions,
+              line_deletions: line_deletions,
+              lineno: lineno,
               lines: lines,
-              source_type: source_types[source_type] || source_type
+              cursorpos: cursorpos,
+              project_root_count: project_root_count,
+              is_write: is_write,
+              source_type: source_types[source_type] || source_type,
+              ip_address: ip_address,
+              ja4: ja4s_by_id[ja4_id]&.then { |ja4| { fingerprint: ja4.fingerprint, name: ja4.name } }
             }
           end
 

--- a/app/controllers/concerns/api/admin/v1/user_utilities.rb
+++ b/app/controllers/concerns/api/admin/v1/user_utilities.rb
@@ -6,7 +6,7 @@ module Api
         include DateParsing
 
         HEARTBEAT_RESPONSE_COLUMNS = [
-          *%i[id time lineno cursorpos is_write project language entity branch category editor machine user_agent ip_address lines source_type],
+          *%i[id time created_at lineno cursorpos is_write project language entity branch category dependencies editor machine operating_system type project_root_count user_agent line_additions line_deletions ip_address lines source_type],
           :ja4_id
         ].freeze
 

--- a/spec/requests/api/admin/v1/admin_user_utils_spec.rb
+++ b/spec/requests/api/admin/v1/admin_user_utils_spec.rb
@@ -165,17 +165,26 @@ RSpec.describe 'Api::Admin::V1::UserUtils', type: :request, openapi_spec: 'admin
                 properties: {
                   id: { type: :integer, example: 987654 },
                   time: { type: :number, example: 1710946200.0 },
-                  lineno: { type: :integer, example: 42, description: 'Coalesced to 0 when null' },
-                  cursorpos: { type: :integer, example: 12, description: 'Coalesced to 0 when null' },
-                  is_write: { type: :boolean, nullable: true, example: true },
+                  created_at: { type: :string, format: :date_time, example: '2024-03-20T15:30:00Z' },
                   project: { type: :string, nullable: true, example: 'hackatime' },
-                  language: { type: :string, nullable: true, example: 'Ruby' },
-                  entity: { type: :string, nullable: true, example: 'app/models/user.rb' },
                   branch: { type: :string, nullable: true, example: 'main' },
                   category: { type: :string, nullable: true, example: 'coding' },
+                  dependencies: { type: :array, nullable: true, items: { type: :string }, example: [ 'rails', 'sidekiq' ] },
                   editor: { type: :string, nullable: true, example: 'VS Code' },
+                  entity: { type: :string, nullable: true, example: 'app/models/user.rb' },
+                  language: { type: :string, nullable: true, example: 'Ruby' },
                   machine: { type: :string, nullable: true, example: 'Orpheus-MacBook-Pro' },
+                  operating_system: { type: :string, nullable: true, example: 'Mac' },
+                  type: { type: :string, nullable: true, example: 'file' },
                   user_agent: { type: :string, nullable: true, example: 'wakatime/v1.115.2 (darwin-24.6.0) go1.23 vscode/1.96.0' },
+                  line_additions: { type: :integer, nullable: true, example: 8 },
+                  line_deletions: { type: :integer, nullable: true, example: 3 },
+                  lineno: { type: :integer, nullable: true, example: 42 },
+                  lines: { type: :integer, nullable: true, example: 350 },
+                  cursorpos: { type: :integer, nullable: true, example: 12 },
+                  project_root_count: { type: :integer, nullable: true, example: 4 },
+                  is_write: { type: :boolean, nullable: true, example: true },
+                  source_type: { type: :string, example: 'direct_entry' },
                   ip_address: { type: :string, nullable: true, example: '203.0.113.7' },
                   ja4: {
                     type: :object,
@@ -184,9 +193,7 @@ RSpec.describe 'Api::Admin::V1::UserUtils', type: :request, openapi_spec: 'admin
                       fingerprint: { type: :string, example: 't13d1516h2_8daaf6152771_02713d6af862' },
                       name: { type: :string, nullable: true, example: 'Go net/http' }
                     }
-                  },
-                  lines: { type: :integer, nullable: true, example: 350 },
-                  source_type: { type: :string, example: 'direct_entry' }
+                  }
                 }
               }
             },
@@ -201,6 +208,12 @@ RSpec.describe 'Api::Admin::V1::UserUtils', type: :request, openapi_spec: 'admin
           u.heartbeats.create!(
             entity: 'app/models/user.rb',
             time: Time.current.to_f,
+            dependencies: [ 'rails', 'sidekiq' ],
+            operating_system: 'Mac',
+            type: 'file',
+            project_root_count: 4,
+            line_additions: 8,
+            line_deletions: 3,
             source_type: :direct_entry,
             ja4: Ja4.create!(fingerprint: 't13d1516h2_8daaf6152771_02713d6af862', name: 'Go net/http')
           )
@@ -217,7 +230,19 @@ RSpec.describe 'Api::Admin::V1::UserUtils', type: :request, openapi_spec: 'admin
         let(:limit) { 10 }
         let(:offset) { 0 }
         run_test! do |response|
-          expect(JSON.parse(response.body).dig('heartbeats', 0, 'ja4')).to eq(
+          heartbeat = JSON.parse(response.body).dig('heartbeats', 0)
+          expect(heartbeat).to include(
+            'created_at' => be_present,
+            'dependencies' => [ 'rails', 'sidekiq' ],
+            'operating_system' => 'Mac',
+            'type' => 'file',
+            'project_root_count' => 4,
+            'line_additions' => 8,
+            'line_deletions' => 3,
+            'lineno' => nil,
+            'cursorpos' => nil
+          )
+          expect(heartbeat.fetch('ja4')).to eq(
             'fingerprint' => 't13d1516h2_8daaf6152771_02713d6af862',
             'name' => 'Go net/http'
           )

--- a/swagger/admin/swagger.yaml
+++ b/swagger/admin/swagger.yaml
@@ -1802,30 +1802,14 @@ paths:
                         time:
                           type: number
                           example: 1710946200.0
-                        lineno:
-                          type: integer
-                          example: 42
-                          description: Coalesced to 0 when null
-                        cursorpos:
-                          type: integer
-                          example: 12
-                          description: Coalesced to 0 when null
-                        is_write:
-                          type: boolean
-                          nullable: true
-                          example: true
+                        created_at:
+                          type: string
+                          format: date_time
+                          example: '2024-03-20T15:30:00Z'
                         project:
                           type: string
                           nullable: true
                           example: hackatime
-                        language:
-                          type: string
-                          nullable: true
-                          example: Ruby
-                        entity:
-                          type: string
-                          nullable: true
-                          example: app/models/user.rb
                         branch:
                           type: string
                           nullable: true
@@ -1834,18 +1818,73 @@ paths:
                           type: string
                           nullable: true
                           example: coding
+                        dependencies:
+                          type: array
+                          nullable: true
+                          items:
+                            type: string
+                          example:
+                          - rails
+                          - sidekiq
                         editor:
                           type: string
                           nullable: true
                           example: VS Code
+                        entity:
+                          type: string
+                          nullable: true
+                          example: app/models/user.rb
+                        language:
+                          type: string
+                          nullable: true
+                          example: Ruby
                         machine:
                           type: string
                           nullable: true
                           example: Orpheus-MacBook-Pro
+                        operating_system:
+                          type: string
+                          nullable: true
+                          example: Mac
+                        type:
+                          type: string
+                          nullable: true
+                          example: file
                         user_agent:
                           type: string
                           nullable: true
                           example: wakatime/v1.115.2 (darwin-24.6.0) go1.23 vscode/1.96.0
+                        line_additions:
+                          type: integer
+                          nullable: true
+                          example: 8
+                        line_deletions:
+                          type: integer
+                          nullable: true
+                          example: 3
+                        lineno:
+                          type: integer
+                          nullable: true
+                          example: 42
+                        lines:
+                          type: integer
+                          nullable: true
+                          example: 350
+                        cursorpos:
+                          type: integer
+                          nullable: true
+                          example: 12
+                        project_root_count:
+                          type: integer
+                          nullable: true
+                          example: 4
+                        is_write:
+                          type: boolean
+                          nullable: true
+                          example: true
+                        source_type:
+                          type: string
+                          example: direct_entry
                         ip_address:
                           type: string
                           nullable: true
@@ -1861,13 +1900,6 @@ paths:
                               type: string
                               nullable: true
                               example: Go net/http
-                        lines:
-                          type: integer
-                          nullable: true
-                          example: 350
-                        source_type:
-                          type: string
-                          example: direct_entry
                   total_count:
                     type: integer
                     example: 15234


### PR DESCRIPTION
## Summary of the problem
`user_heartbeats` is missing fields that are currently returned by `user_stats`


## Describe your changes
Adds back the missing fields and make fields not get coalesced to 0
