### PR TITLE
Deploy prebuilt production images through Coolify

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,14 +115,13 @@ jobs:
         run: bin/rails zeitwerk:check
 
   docker_build:
-    if: github.event_name == 'pull_request'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
     strategy:
       fail-fast: false
       matrix:
-        dockerfile: [Dockerfile, Dockerfile.dev]
+        dockerfile: ${{ fromJSON(github.event_name == 'pull_request' && '["Dockerfile", "Dockerfile.dev"]' || '["Dockerfile.dev"]') }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,7 +300,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           COOLIFY_URL: ${{ secrets.COOLIFY_URL }}
           COOLIFY_API_TOKEN: ${{ secrets.COOLIFY_API_TOKEN }}
-          COOLIFY_APPLICATION_UUID: ${{ secrets.COOLIFY_APPLICATION_UUID }}
+          COOLIFY_WEB_APPLICATION_UUID: ${{ secrets.COOLIFY_WEB_APPLICATION_UUID }}
+          COOLIFY_WORKER_APPLICATION_UUID: ${{ secrets.COOLIFY_WORKER_APPLICATION_UUID }}
           IMAGE_NAME: ghcr.io/${{ github.repository }}
           IMAGE_TAG: ${{ github.sha }}
         run: |
@@ -308,51 +309,70 @@ jobs:
 
           : "${COOLIFY_URL:?Set the COOLIFY_URL production environment secret}"
           : "${COOLIFY_API_TOKEN:?Set the COOLIFY_API_TOKEN production environment secret}"
-          : "${COOLIFY_APPLICATION_UUID:?Set the COOLIFY_APPLICATION_UUID production environment secret}"
+          : "${COOLIFY_WEB_APPLICATION_UUID:?Set the COOLIFY_WEB_APPLICATION_UUID production environment secret}"
+          : "${COOLIFY_WORKER_APPLICATION_UUID:?Set the COOLIFY_WORKER_APPLICATION_UUID production environment secret}"
+
+          if [ "$COOLIFY_WEB_APPLICATION_UUID" = "$COOLIFY_WORKER_APPLICATION_UUID" ]; then
+            echo "::error::Web and worker must be separate Coolify applications."
+            exit 1
+          fi
 
           coolify_url="${COOLIFY_URL%/}"
           api_url="${coolify_url}/api/v1"
           authorization="Authorization: Bearer ${COOLIFY_API_TOKEN}"
 
-          latest_main_sha="$(curl --fail-with-body --silent --show-error \
-            --connect-timeout 10 --max-time 60 \
-            --retry 3 --retry-all-errors \
-            --header "Authorization: Bearer ${GH_TOKEN}" \
-            --header 'Accept: application/vnd.github+json' \
-            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/commits/main" | jq -er '.sha')"
+          ensure_current_main() {
+            latest_main_sha="$(curl --fail-with-body --silent --show-error \
+              --connect-timeout 10 --max-time 60 \
+              --retry 3 --retry-all-errors \
+              --header "Authorization: Bearer ${GH_TOKEN}" \
+              --header 'Accept: application/vnd.github+json' \
+              "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/commits/main" | jq -er '.sha')"
 
-          if [ "$latest_main_sha" != "$IMAGE_TAG" ]; then
-            echo "::notice::Skipping stale deployment of ${IMAGE_TAG}; main is ${latest_main_sha}."
-            exit 0
-          fi
+            if [ "$latest_main_sha" != "$IMAGE_TAG" ]; then
+              echo "::notice::Skipping stale deployment of ${IMAGE_TAG}; main is ${latest_main_sha}."
+              exit 0
+            fi
+          }
 
-          application="$(curl --fail-with-body --silent --show-error \
-            --connect-timeout 10 --max-time 60 \
-            --retry 3 --retry-all-errors \
-            --header "$authorization" \
-            "${api_url}/applications/${COOLIFY_APPLICATION_UUID}")"
+          ensure_current_main
 
-          if [ "$(jq -r '.build_pack' <<<"$application")" != "dockerimage" ]; then
-            echo "::error::COOLIFY_APPLICATION_UUID must identify a Docker Image application."
-            exit 1
-          fi
+          for application_uuid in "$COOLIFY_WEB_APPLICATION_UUID" "$COOLIFY_WORKER_APPLICATION_UUID"; do
+            application="$(curl --fail-with-body --silent --show-error \
+              --connect-timeout 10 --max-time 60 \
+              --retry 3 --retry-all-errors \
+              --header "$authorization" \
+              "${api_url}/applications/${application_uuid}")"
+
+            if [ "$(jq -r '.build_pack' <<<"$application")" != "dockerimage" ]; then
+              echo "::error::${application_uuid} must identify a Docker Image application."
+              exit 1
+            fi
+          done
+
+          ensure_current_main
 
           update_payload="$(jq -cn \
             --arg image "$IMAGE_NAME" \
             --arg tag "$IMAGE_TAG" \
             '{docker_registry_image_name: $image, docker_registry_image_tag: $tag}')"
 
-          curl --fail-with-body --silent --show-error \
-            --connect-timeout 10 --max-time 60 \
-            --retry 3 --retry-all-errors \
-            --request PATCH \
-            --header "$authorization" \
-            --header 'Content-Type: application/json' \
-            --data "$update_payload" \
-            --output /dev/null \
-            "${api_url}/applications/${COOLIFY_APPLICATION_UUID}"
+          for application_uuid in "$COOLIFY_WEB_APPLICATION_UUID" "$COOLIFY_WORKER_APPLICATION_UUID"; do
+            curl --fail-with-body --silent --show-error \
+              --connect-timeout 10 --max-time 60 \
+              --retry 3 --retry-all-errors \
+              --request PATCH \
+              --header "$authorization" \
+              --header 'Content-Type: application/json' \
+              --data "$update_payload" \
+              --output /dev/null \
+              "${api_url}/applications/${application_uuid}"
+          done
 
-          deploy_payload="$(jq -cn --arg uuid "$COOLIFY_APPLICATION_UUID" '{uuid: $uuid}')"
+          ensure_current_main
+
+          application_uuids="${COOLIFY_WEB_APPLICATION_UUID},${COOLIFY_WORKER_APPLICATION_UUID}"
+          deploy_payload="$(jq -cn --arg uuid "$application_uuids" '{uuid: $uuid}')"
           deploy_response="$(curl --fail-with-body --silent --show-error \
             --connect-timeout 10 --max-time 60 \
             --request POST \
@@ -360,38 +380,53 @@ jobs:
             --header 'Content-Type: application/json' \
             --data "$deploy_payload" \
             "${api_url}/deploy")"
-          deployment_uuid="$(jq -er '.deployments[0].deployment_uuid' <<<"$deploy_response")"
+          deployment_rows="$(jq -er \
+            --arg web "$COOLIFY_WEB_APPLICATION_UUID" \
+            --arg worker "$COOLIFY_WORKER_APPLICATION_UUID" '
+              [.deployments[] |
+                select(.resource_uuid == $web or .resource_uuid == $worker) |
+                select(.deployment_uuid | type == "string" and length > 0)] as $deployments |
+              if ($deployments | map(select(.resource_uuid == $web)) | length) == 1 and
+                 ($deployments | map(select(.resource_uuid == $worker)) | length) == 1
+              then $deployments[] | [.resource_uuid, .deployment_uuid] | @tsv
+              else error("Coolify did not queue exactly one web and one worker deployment")
+              end
+            ' <<<"$deploy_response")"
 
-          echo "Coolify deployment queued: ${deployment_uuid}"
           deadline=$((SECONDS + 900))
 
-          while (( SECONDS < deadline )); do
-            deployment="$(curl --fail-with-body --silent --show-error \
-              --connect-timeout 10 --max-time 60 \
-              --retry 3 --retry-all-errors \
-              --header "$authorization" \
-              "${api_url}/deployments/${deployment_uuid}")"
-            status="$(jq -er '.status' <<<"$deployment")"
-            echo "Coolify deployment status: ${status}"
+          while IFS=$'\t' read -r application_uuid deployment_uuid; do
+            echo "Coolify deployment queued for ${application_uuid}: ${deployment_uuid}"
+            status=""
 
-            case "$status" in
-              queued|in_progress)
-                ;;
-              finished)
-                exit 0
-                ;;
-              failed|cancelled-by-user)
-                echo "::error::Coolify deployment ${deployment_uuid} ended with status ${status}."
-                exit 1
-                ;;
-              *)
-                echo "::error::Unknown Coolify deployment status: ${status}"
-                exit 1
-                ;;
-            esac
+            while :; do
+              deployment="$(curl --fail-with-body --silent --show-error \
+                --connect-timeout 10 --max-time 60 \
+                --retry 3 --retry-all-errors \
+                --header "$authorization" \
+                "${api_url}/deployments/${deployment_uuid}")"
+              status="$(jq -er '.status' <<<"$deployment")"
+              echo "Coolify deployment ${deployment_uuid} status: ${status}"
 
-            sleep 5
-          done
-
-          echo "::error::Coolify deployment ${deployment_uuid} did not finish within 15 minutes."
-          exit 1
+              case "$status" in
+                queued|in_progress)
+                  if (( SECONDS >= deadline )); then
+                    echo "::error::Coolify deployment ${deployment_uuid} did not finish within 15 minutes."
+                    exit 1
+                  fi
+                  sleep 5
+                  ;;
+                finished)
+                  break
+                  ;;
+                failed|cancelled-by-user)
+                  echo "::error::Coolify deployment ${deployment_uuid} ended with status ${status}."
+                  exit 1
+                  ;;
+                *)
+                  echo "::error::Unknown Coolify deployment status: ${status}"
+                  exit 1
+                  ;;
+              esac
+            done
+          done <<<"$deployment_rows"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,10 @@ jobs:
         run: bin/rails zeitwerk:check
 
   docker_build:
+    if: github.event_name == 'pull_request'
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -133,8 +136,39 @@ jobs:
         with:
           context: .
           file: ${{ matrix.dockerfile }}
-          push: false
           load: false
+          push: false
+
+  publish_image:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Blacksmith Builder
+        uses: useblacksmith/setup-docker-builder@v1
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and publish production image
+        uses: useblacksmith/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile
+          labels: org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+          load: false
+          push: true
+          tags: ghcr.io/${{ github.repository }}:${{ github.sha }}
 
   test:
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -250,3 +284,115 @@ jobs:
           name: screenshots
           path: ${{ github.workspace }}/tmp/screenshots
           if-no-files-found: ignore
+
+  deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [scan_ruby, scan_js, lint, frontend, zeitwerk, publish_image, test, test_system]
+    runs-on: ubuntu-latest
+    concurrency:
+      group: production-deploy
+      cancel-in-progress: false
+    environment: production
+    timeout-minutes: 20
+
+    steps:
+      - name: Deploy immutable image through Coolify
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COOLIFY_URL: ${{ secrets.COOLIFY_URL }}
+          COOLIFY_API_TOKEN: ${{ secrets.COOLIFY_API_TOKEN }}
+          COOLIFY_APPLICATION_UUID: ${{ secrets.COOLIFY_APPLICATION_UUID }}
+          IMAGE_NAME: ghcr.io/${{ github.repository }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          set -Eeuo pipefail
+
+          : "${COOLIFY_URL:?Set the COOLIFY_URL production environment secret}"
+          : "${COOLIFY_API_TOKEN:?Set the COOLIFY_API_TOKEN production environment secret}"
+          : "${COOLIFY_APPLICATION_UUID:?Set the COOLIFY_APPLICATION_UUID production environment secret}"
+
+          coolify_url="${COOLIFY_URL%/}"
+          api_url="${coolify_url}/api/v1"
+          authorization="Authorization: Bearer ${COOLIFY_API_TOKEN}"
+
+          latest_main_sha="$(curl --fail-with-body --silent --show-error \
+            --connect-timeout 10 --max-time 60 \
+            --retry 3 --retry-all-errors \
+            --header "Authorization: Bearer ${GH_TOKEN}" \
+            --header 'Accept: application/vnd.github+json' \
+            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/commits/main" | jq -er '.sha')"
+
+          if [ "$latest_main_sha" != "$IMAGE_TAG" ]; then
+            echo "::notice::Skipping stale deployment of ${IMAGE_TAG}; main is ${latest_main_sha}."
+            exit 0
+          fi
+
+          application="$(curl --fail-with-body --silent --show-error \
+            --connect-timeout 10 --max-time 60 \
+            --retry 3 --retry-all-errors \
+            --header "$authorization" \
+            "${api_url}/applications/${COOLIFY_APPLICATION_UUID}")"
+
+          if [ "$(jq -r '.build_pack' <<<"$application")" != "dockerimage" ]; then
+            echo "::error::COOLIFY_APPLICATION_UUID must identify a Docker Image application."
+            exit 1
+          fi
+
+          update_payload="$(jq -cn \
+            --arg image "$IMAGE_NAME" \
+            --arg tag "$IMAGE_TAG" \
+            '{docker_registry_image_name: $image, docker_registry_image_tag: $tag}')"
+
+          curl --fail-with-body --silent --show-error \
+            --connect-timeout 10 --max-time 60 \
+            --retry 3 --retry-all-errors \
+            --request PATCH \
+            --header "$authorization" \
+            --header 'Content-Type: application/json' \
+            --data "$update_payload" \
+            --output /dev/null \
+            "${api_url}/applications/${COOLIFY_APPLICATION_UUID}"
+
+          deploy_payload="$(jq -cn --arg uuid "$COOLIFY_APPLICATION_UUID" '{uuid: $uuid}')"
+          deploy_response="$(curl --fail-with-body --silent --show-error \
+            --connect-timeout 10 --max-time 60 \
+            --request POST \
+            --header "$authorization" \
+            --header 'Content-Type: application/json' \
+            --data "$deploy_payload" \
+            "${api_url}/deploy")"
+          deployment_uuid="$(jq -er '.deployments[0].deployment_uuid' <<<"$deploy_response")"
+
+          echo "Coolify deployment queued: ${deployment_uuid}"
+          deadline=$((SECONDS + 900))
+
+          while (( SECONDS < deadline )); do
+            deployment="$(curl --fail-with-body --silent --show-error \
+              --connect-timeout 10 --max-time 60 \
+              --retry 3 --retry-all-errors \
+              --header "$authorization" \
+              "${api_url}/deployments/${deployment_uuid}")"
+            status="$(jq -er '.status' <<<"$deployment")"
+            echo "Coolify deployment status: ${status}"
+
+            case "$status" in
+              queued|in_progress)
+                ;;
+              finished)
+                exit 0
+                ;;
+              failed|cancelled-by-user)
+                echo "::error::Coolify deployment ${deployment_uuid} ended with status ${status}."
+                exit 1
+                ;;
+              *)
+                echo "::error::Unknown Coolify deployment status: ${status}"
+                exit 1
+                ;;
+            esac
+
+            sleep 5
+          done
+
+          echo "::error::Coolify deployment ${deployment_uuid} did not finish within 15 minutes."
+          exit 1

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -6,6 +6,10 @@ if [ -z "${LD_PRELOAD+x}" ]; then
     export LD_PRELOAD
 fi
 
+if [ "${WORKER:-false}" = "true" ]; then
+  set -- bundle exec good_job start
+fi
+
 # If running the rails server then create or migrate existing database
 if [ "${@: -2:1}" == "./bin/rails" ] && [ "${@: -1:1}" == "server" ]; then
   ./bin/rails db:prepare


### PR DESCRIPTION
## Summary of the problem

Coolify currently builds Hackatime from source during every production deployment. This repeats work already performed by CI.

Coolify's Docker image caching also seems to be rather broken (as in, it never does it...) which makes builds rather slow.

## Describe your changes

- Validate both production and development Dockerfiles without publishing images on pull requests.
- Build and publish the production image to GHCR only after commits land on `main`.
- Tag every production image with its immutable commit SHA.
- After all existing CI jobs pass, update a preconfigured Coolify Docker Image application and deploy that exact SHA through the Coolify API.
- Guard against stale workflow runs deploying an older commit after a newer commit has reached `main`.
- Poll Coolify with bounded request and deployment timeouts and fail on unsuccessful or unknown deployment states.

## Screenshots / Media

No visual changes.
