### PR TITLE
Restore persistent Docker layer caching

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -66,3 +66,5 @@ pg-dump-all-*
 # Ignore Docker-related files
 /.dockerignore
 /Dockerfile*
+/buildkitd.toml
+/docker-container-buildkitd.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Build ${{ matrix.dockerfile }}
         uses: useblacksmith/build-push-action@v2
         with:
-          context: .
+          context: "{{defaultContext}}"
           file: ${{ matrix.dockerfile }}
           load: false
           push: false
@@ -168,7 +168,7 @@ jobs:
       - name: Build and publish production image
         uses: useblacksmith/build-push-action@v2
         with:
-          context: .
+          context: "{{defaultContext}}"
           file: Dockerfile
           labels: org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
           load: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,9 @@ jobs:
 
       - name: Setup Blacksmith Builder
         uses: useblacksmith/setup-docker-builder@v2
+        with:
+          cache-key: hackatime/${{ matrix.dockerfile }}
+          nofallback: true
 
       - name: Build ${{ matrix.dockerfile }}
         uses: useblacksmith/build-push-action@v2
@@ -151,6 +154,9 @@ jobs:
 
       - name: Setup Blacksmith Builder
         uses: useblacksmith/setup-docker-builder@v2
+        with:
+          cache-key: hackatime/Dockerfile
+          nofallback: true
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3


### PR DESCRIPTION
## Summary of the problem

The v2 upgrade of `useblacksmith/setup-docker-builder` omitted its newly required `cache-key`. Blacksmith consequently warned and silently fell back from its persistent remote BuildKit daemon to a fresh local `docker-container` builder, rebuilding every Dockerfile layer on each CI run.

## Describe your changes

- Give production and development Dockerfiles separate stable Blacksmith cache keys.
- Share the production key between pull-request validation and the `main` image publication job.
- Set `nofallback: true` so a future persistent-cache setup failure fails visibly instead of silently running an uncached build.
- Exclude BuildKit configuration files generated in the checked-out workspace from local Docker contexts.

## Screenshots / Media

No visual changes.