### PR TITLE
Remove obsolete Solid Queue tooling

### DIFF
--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -13,8 +13,6 @@ fi
 # If running the rails server then create or migrate existing database
 if [ "${@: -2:1}" == "./bin/rails" ] && [ "${@: -1:1}" == "server" ]; then
   ./bin/rails db:prepare
-  # echo "Warming up caches for production deployment..."
-  # ./bin/rails cache:warmup
 
   # Start the Inertia SSR server in the background if the SSR bundle exists
   SSR_ENTRYPOINT="public/vite-ssr/ssr.js"

--- a/bin/jobs
+++ b/bin/jobs
@@ -1,6 +1,0 @@
-#!/usr/bin/env ruby
-
-require_relative "../config/environment"
-require "solid_queue/cli"
-
-SolidQueue::Cli.start(ARGV)

--- a/bin/setup
+++ b/bin/setup
@@ -16,11 +16,6 @@ FileUtils.chdir APP_ROOT do
   system("bundle check") || system!("bundle install")
   system! "bun install --frozen-lockfile"
 
-  # puts "\n== Copying sample files =="
-  # unless File.exist?("config/database.yml")
-  #   FileUtils.cp "config/database.yml.sample", "config/database.yml"
-  # end
-
   puts "\n== Preparing database =="
   system! "bin/rails db:prepare"
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -81,7 +81,6 @@ Rails.application.configure do
 
   # Replace the default in-process and non-durable queuing backend for Active Job.
   config.active_job.queue_adapter = :good_job
-  # config.solid_queue.connects_to = { database: { writing: :queue } }
 
   # ActiveJob cache refreshes can run inline during requests and drown out page
   # logs. Keep failures visible through Rails.logger calls in job code, but hide

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -53,7 +53,6 @@ Rails.application.configure do
 
   # Replace the default in-process and non-durable queuing backend for Active Job.
   config.active_job.queue_adapter = :good_job
-  # config.solid_queue.connects_to = { database: { writing: :queue } }
 
   # Configure email delivery
   config.action_mailer.raise_delivery_errors = true

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -33,9 +33,6 @@ port ENV.fetch("PORT", 4000)
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart
 
-# Run the Solid Queue supervisor inside of Puma for single-server deployments
-plugin :solid_queue if ENV["SOLID_QUEUE_IN_PUMA"]
-
 # Specify the PID file. Defaults to tmp/pids/server.pid in development.
 # In other environments, only set the PID file if requested.
 pidfile ENV["PIDFILE"] if ENV["PIDFILE"]


### PR DESCRIPTION
## Summary of the problem

Hackatime uses GoodJob for Active Job and worker execution, but obsolete Solid Queue tooling and configuration remained in the repository from the default Rails template :(

## Describe your changes

- Removed the obsolete `bin/jobs` Solid Queue binstub.
- Removed dormant Solid Queue configuration from Puma and the development and production environment configuration.
- Removed stale commented setup and deployment snippets referencing `config/database.yml.sample` and `cache:warmup`.
- Confirmed with a repository-wide search that no Solid Queue references remain.


## Screenshots / Media

N/A