### PR TITLE
Remove unused backend helpers

### DIFF
--- a/app/controllers/concerns/auth_helpers.rb
+++ b/app/controllers/concerns/auth_helpers.rb
@@ -9,7 +9,6 @@ module AuthHelpers
   extend ActiveSupport::Concern
 
   ADMIN_LEVELS = %w[admin superadmin ultraadmin].freeze
-  SUPERADMIN_LEVELS = %w[superadmin ultraadmin].freeze
 
   # Redirects unsigned-in users; returns true if signed in.
   def require_signed_in!(message = "Please sign in first", redirect_path: root_path)
@@ -20,14 +19,6 @@ module AuthHelpers
 
   def require_admin!(redirect_path: root_path, alert: "You are not authorized to access this page")
     unless current_user&.admin_level.in?(ADMIN_LEVELS)
-      redirect_to redirect_path, alert: alert
-      return false
-    end
-    true
-  end
-
-  def require_superadmin_html!(redirect_path: root_path, alert: "You are not authorized to access this page")
-    unless current_user&.admin_level.in?(SUPERADMIN_LEVELS)
       redirect_to redirect_path, alert: alert
       return false
     end

--- a/app/controllers/concerns/dashboard_data.rb
+++ b/app/controllers/concerns/dashboard_data.rb
@@ -15,10 +15,6 @@ module DashboardData
     dashboard_stats.today_stats_data
   end
 
-  def dashboard_filters
-    DashboardStats::FILTERS
-  end
-
   def dashboard_stats
     @dashboard_stats ||= DashboardStats.new(user: current_user, params: params)
   end

--- a/app/controllers/inertia_controller.rb
+++ b/app/controllers/inertia_controller.rb
@@ -167,19 +167,4 @@ class InertiaController < ApplicationController
 
     props
   end
-
-  def currently_hacking_props
-    data = Cache::CurrentlyHackingJob.perform_now
-    users = (data[:users] || []).map do |u|
-      proj = data[:active_projects]&.dig(u.id)
-      {
-        id: u.id,
-        display_name: u.display_name,
-        slack_uid: u.slack_uid,
-        avatar_url: u.avatar_url,
-        active_project: proj && { name: proj.project_name, repo_url: proj.repo_url }
-      }
-    end
-    { count: users.size, users: users, interval: 30_000 }
-  end
 end

--- a/app/controllers/settings/base_controller.rb
+++ b/app/controllers/settings/base_controller.rb
@@ -83,8 +83,6 @@ class Settings::BaseController < InertiaController
     end
   end
 
-  def options_props = base_options.merge(goals: goal_options)
-
   BASE_OPTION_BUILDERS = {
     countries: -> { ISO3166::Country.all.map { |c| { label: c.common_name, value: c.alpha2 } }.sort_by { |c| c[:label] } },
     # see .timezone_options below; a user's current zone, if outside the list,

--- a/app/services/heartbeat_import_dump_client.rb
+++ b/app/services/heartbeat_import_dump_client.rb
@@ -52,8 +52,6 @@ class HeartbeatImportDumpClient
     Array(request_json(method: :get, path: "/users/current/user_agents")["data"]).map { normalize_user_agent(_1) }
   end
 
-  def self.base_url_for(source_kind) = BASE_URLS.fetch(source_kind.to_s)
-
   def self.valid_wakatime_download_url?(download_url)
     uri = URI.parse(download_url.to_s)
     uri.scheme == "https" && uri.host == WAKATIME_DOWNLOAD_HOST && uri.path.present?

--- a/app/services/heartbeat_import_service.rb
+++ b/app/services/heartbeat_import_service.rb
@@ -40,12 +40,6 @@ class HeartbeatImportService
       skipped_count: total_count - imported_count, errors: errors + [ e.message ] }
   end
 
-  def self.count_heartbeats(file_content)
-    total_count = 0
-    Oj.saj_parse(HeartbeatSaxHandler.new { |_hb| total_count += 1 }, file_content)
-    total_count
-  end
-
   class HeartbeatSaxHandler < Oj::Saj
     def initialize(&block)
       @block = block

--- a/app/services/leaderboard_cache.rb
+++ b/app/services/leaderboard_cache.rb
@@ -7,19 +7,11 @@ module LeaderboardCache
     "leaderboard_#{period}_#{date}"
   end
 
-  def timezone_key(offset, date, period)
-    "tz_leaderboard_#{offset}_#{date}_#{period}"
-  end
-
   def write(key, data)
     Rails.cache.write(key, data, expires_in: CACHE_EXPIRATION)
   end
 
   def read(key)
     Rails.cache.read(key)
-  end
-
-  def fetch(key, &block)
-    Rails.cache.fetch(key, expires_in: CACHE_EXPIRATION, &block)
   end
 end

--- a/lib/flavor_text.rb
+++ b/lib/flavor_text.rb
@@ -152,10 +152,6 @@ class FlavorText
     ]
   end
 
-  def self.rare_compliment
-    [ "Don't let your dreams be memes!" ]
-  end
-
   def self.motto
     [
       "track your time before it tracks you!",


### PR DESCRIPTION
## Summary of the problem

The backend accumulated isolated helpers and constants that no longer had callers. Keeping these definition-only symbols made the server code harder to navigate and obscured the active implementations.

## Describe your changes

- Remove unused controller and concern helpers for authorization, dashboard data, settings options, and currently-hacking props.
- Remove unused leaderboard cache, heartbeat import, and import dump client methods.
- Remove an unused flavor-text method and the authorization constant orphaned by this cleanup.
- Preserve all routes, middleware, generated code, dynamic entry points, and external HTTP APIs.

Verification included repo-wide direct-reference and dynamic-dispatch searches, a post-rebase symbol scan, and `git diff --check`. The full `bin/ci` suite could not run locally because the Amp orb does not provide Docker or Ruby; GitHub Actions is expected to provide full-suite coverage for this PR.

## Screenshots / Media

Not applicable; there are no visual changes.