### PR TITLE
Show the image commit in the footer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,7 @@ jobs:
       - name: Build and publish production image
         uses: useblacksmith/build-push-action@v2
         with:
+          build-args: SOURCE_COMMIT=${{ github.sha }}
           context: "{{defaultContext}}"
           file: Dockerfile
           labels: org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -195,6 +195,9 @@ COPY --from=build --chown=1000:1000 /rails/log /rails/log
 COPY --from=build --chown=1000:1000 /rails/storage /rails/storage
 COPY --from=build --chown=1000:1000 /rails/tmp /rails/tmp
 
+ARG SOURCE_COMMIT=unknown
+ENV SOURCE_COMMIT="${SOURCE_COMMIT}"
+
 USER 1000:1000
 
 # Entrypoint prepares the database.

--- a/config/initializers/git_version.rb
+++ b/config/initializers/git_version.rb
@@ -1,22 +1,17 @@
-# Get the first 6 characters of the current git commit hash
-git_hash = ENV["SOURCE_COMMIT"] || `git rev-parse HEAD` rescue "unknown"
+source_commit = ENV["SOURCE_COMMIT"].presence
+
+if source_commit
+  git_hash = source_commit
+  is_dirty = false
+else
+  git_hash = `git rev-parse HEAD 2>/dev/null`.strip.presence || "unknown"
+  is_dirty = `git status --porcelain 2>/dev/null`.present?
+end
 
 commit_link = git_hash != "unknown" ? "https://github.com/hackclub/hackatime/commit/#{git_hash}" : nil
-
 short_hash = git_hash[0..7]
-
-commit_count = `git rev-list --count HEAD`.strip rescue 0
-
-# Check if there are any uncommitted changes
-is_dirty = `git status --porcelain`.strip.length > 0 rescue false
-
-# Append "-dirty" if there are uncommitted changes
 version = is_dirty ? "#{short_hash}-dirty" : short_hash
 
-# Store server start time
 Rails.application.config.server_start_time = Time.current
-
-# Store the version
 Rails.application.config.git_version = version
-Rails.application.config.git_commit_count = commit_count
 Rails.application.config.commit_link = commit_link


### PR DESCRIPTION
## Summary

- bake the main commit SHA into the production image
- show the short SHA and link to the full commit
- remove the unused commit count

## Checks

- production image build
- Rails runner footer metadata check
- RuboCop
- Ruby syntax check