### PR TITLE
Search display name overrides in user fuzzy search

### DIFF
--- a/app/models/concerns/user_fuzzy_search.rb
+++ b/app/models/concerns/user_fuzzy_search.rb
@@ -18,6 +18,7 @@ module UserFuzzySearch
       candidate_parts = [
         "SELECT id FROM users WHERE slack_uid = :exact",
         "SELECT id FROM users WHERE username ILIKE :contains",
+        "SELECT id FROM users WHERE display_name_override ILIKE :contains",
         "SELECT id FROM users WHERE github_username ILIKE :contains",
         "SELECT id FROM users WHERE slack_username ILIKE :contains",
         "SELECT user_id AS id FROM email_addresses WHERE email ILIKE :contains"
@@ -32,6 +33,10 @@ module UserFuzzySearch
         CASE WHEN users.username ILIKE :ilike_exact THEN 100
              WHEN users.username ILIKE :prefix THEN 50
              WHEN users.username ILIKE :contains THEN 10
+             ELSE 0 END +
+        CASE WHEN users.display_name_override ILIKE :ilike_exact THEN 100
+             WHEN users.display_name_override ILIKE :prefix THEN 50
+             WHEN users.display_name_override ILIKE :contains THEN 10
              ELSE 0 END +
         CASE WHEN users.github_username ILIKE :ilike_exact THEN 100
              WHEN users.github_username ILIKE :prefix THEN 50

--- a/db/migrate/20260804184518_add_trgm_index_to_users_display_name_override.rb
+++ b/db/migrate/20260804184518_add_trgm_index_to_users_display_name_override.rb
@@ -1,0 +1,21 @@
+class AddTrgmIndexToUsersDisplayNameOverride < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def up
+    enable_extension :pg_trgm unless extension_enabled?(:pg_trgm)
+
+    add_index :users, :display_name_override,
+              name: :index_users_on_display_name_override_trgm,
+              using: :gin,
+              opclass: :gin_trgm_ops,
+              algorithm: :concurrently,
+              if_not_exists: true
+  end
+
+  def down
+    remove_index :users, :display_name_override,
+                 name: :index_users_on_display_name_override_trgm,
+                 algorithm: :concurrently,
+                 if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_30_191404) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_04_184518) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -711,6 +711,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_30_191404) do
     t.string "username"
     t.boolean "uses_slack_status", default: false, null: false
     t.boolean "weekly_summary_email_enabled", default: true, null: false
+    t.index ["display_name_override"], name: "index_users_on_display_name_override_trgm", opclass: :gin_trgm_ops, using: :gin
     t.index ["github_uid", "github_access_token"], name: "index_users_on_github_uid_and_access_token"
     t.index ["github_uid"], name: "index_users_on_github_uid"
     t.index ["github_username"], name: "index_users_on_github_username_trgm", opclass: :gin_trgm_ops, using: :gin

--- a/test/models/concerns/user_fuzzy_search_test.rb
+++ b/test/models/concerns/user_fuzzy_search_test.rb
@@ -13,6 +13,7 @@ require "test_helper"
 #   - rank scoring tiers (id/slack_uid exact = 1000; field exact = 100;
 #     prefix = 50; contains = 10; tiers compound additively)
 #   - case-insensitive ILIKE on username/email fields
+#   - display name overrides are searchable and ranked like other name fields
 #   - case-sensitive equality on slack_uid
 #   - matched_email picks best email (exact > prefix > contains > any)
 #   - matched_email is nil only when the user has zero emails
@@ -112,6 +113,16 @@ class UserFuzzySearchTest < ActiveSupport::TestCase
     u = create_user(username: "MixedCaseUser")
     assert User.fuzzy_ranked_search("mixedcaseuser").any? { |r| r.id == u.id }
     assert User.fuzzy_ranked_search("MIXEDCASEUSER").any? { |r| r.id == u.id }
+  end
+
+  test "display name override is searchable and ranked case-insensitively" do
+    u = create_user(username: "unrelated_username", display_name_override: "Custom Display Name")
+
+    exact = User.fuzzy_ranked_search("custom display name").find { |r| r.id == u.id }
+    substring = User.fuzzy_ranked_search("DISPLAY").find { |r| r.id == u.id }
+
+    assert_operator exact.rank_score, :>=, 100
+    assert_operator substring.rank_score, :>=, 10
   end
 
   # ----- multi-field tiers -----


### PR DESCRIPTION
## Summary of the problem
User fuzzy search did not consider custom display name overrides, so searching for the name shown in the UI could fail to find the corresponding user.

## Describe your changes
- Include `display_name_override` in fuzzy-search candidate selection.
- Rank exact, prefix, and substring display-name matches using the same tiers as other username fields.
- Add regression coverage for case-insensitive exact and substring searches.

## Screenshots / Media
No visual changes.
