### PR TITLE
Fix Slack profile synchronization for HCA users

### DIFF
--- a/app/jobs/slack_profile_sync_job.rb
+++ b/app/jobs/slack_profile_sync_job.rb
@@ -1,0 +1,26 @@
+class SlackProfileSyncJob < ApplicationJob
+  queue_as :literally_whenever
+
+  include GoodJob::ActiveJobExtensions::Concurrency
+
+  good_job_control_concurrency_with(
+    enqueue_limit: 1,
+    perform_limit: 1,
+    key: -> { "slack_profile_sync_job_#{arguments.first}" }
+  )
+
+  def perform(user_id)
+    user = User.find_by(id: user_id)
+    return unless user&.slack_uid.present?
+
+    user.update_from_slack
+    user.save! if user.changed?
+  rescue SlackIntegration::RateLimitedError => e
+    raise if executions >= 5
+
+    polynomial_delay = executions**4 + (Kernel.rand * executions**4 * 0.15) + 2
+    retry_job(wait: [ e.retry_after, polynomial_delay ].max.seconds)
+  rescue => e
+    report_error(e, message: "Failed to update Slack username and avatar for user #{user_id}")
+  end
+end

--- a/app/jobs/slack_username_update_job.rb
+++ b/app/jobs/slack_username_update_job.rb
@@ -11,15 +11,7 @@ class SlackUsernameUpdateJob < ApplicationJob
   def perform
     User
       .where.not(slack_uid: nil)
-      .order(Arel.sql("slack_synced_at IS NOT NULL, slack_synced_at ASC"))
-      .limit(100)
-      .each do |user|
-        begin
-          user.update_from_slack
-          user.save!
-        rescue => e
-          report_error(e, message: "Failed to update Slack username and avatar for user #{user.id}")
-        end
-      end
+      .where("slack_synced_at IS NULL OR slack_synced_at < ?", 1.day.ago)
+      .find_each { |user| SlackProfileSyncJob.perform_later(user.id) }
   end
 end

--- a/app/models/concerns/oauth_authentication.rb
+++ b/app/models/concerns/oauth_authentication.rb
@@ -50,7 +50,19 @@ module OauthAuthentication
       if @user
         attrs = { hca_scopes: hca_data["scopes"], hca_id: identity["id"], hca_access_token: access_token }
         attrs[:country_code] = country_code_from_ip(ip_address) if @user.country_code.blank?
-        @user.update(attrs)
+        @user.update!(attrs)
+
+        if @user.slack_uid.blank? && identity["slack_id"].present?
+          begin
+            @user.update!(slack_uid: identity["slack_id"])
+          rescue ActiveRecord::RecordNotUnique
+            @user.reload
+          rescue ActiveRecord::RecordInvalid => e
+            raise unless e.record.errors.of_kind?(:slack_uid, :taken)
+
+            @user.reload
+          end
+        end
       else
         ActiveRecord::Base.transaction do
           @user = User.create!(
@@ -61,6 +73,7 @@ module OauthAuthentication
           EmailAddress.create!(email: identity["primary_email"], user: @user) if identity["primary_email"].present?
         end
       end
+      SlackProfileSyncJob.perform_later(@user.id) if @user.slack_uid.present?
       @user
     end
 

--- a/app/models/concerns/slack_integration.rb
+++ b/app/models/concerns/slack_integration.rb
@@ -1,6 +1,15 @@
 module SlackIntegration
   extend ActiveSupport::Concern
 
+  class RateLimitedError < StandardError
+    attr_reader :retry_after
+
+    def initialize(retry_after)
+      @retry_after = [ retry_after.to_i, 1 ].max
+      super("Slack profile API rate limit exceeded")
+    end
+  end
+
   STATUS_EMOJI_BUCKETS = [
     [ 30.minutes,  %w[thinking cat-on-the-laptop loading-tumbleweed rac-yap] ],
     [ 1.hour,      %w[working-parrot meow_code] ],
@@ -15,12 +24,16 @@ module SlackIntegration
 
   def raw_slack_user_info
     return nil unless slack_uid.present?
-    return nil unless slack_access_token.present?
+    access_token = ENV["SLACK_USER_OAUTH_TOKEN"].presence || slack_access_token.presence
+    return nil unless access_token
 
-    @slack_user_info ||= HTTP.auth("Bearer #{slack_access_token}")
+    response = HTTP.auth("Bearer #{access_token}")
       .get("https://slack.com/api/users.info?user=#{slack_uid}")
+    raise RateLimitedError, response.headers["Retry-After"] if response.status.code == 429
+    return nil unless response.status.success?
 
-    JSON.parse(@slack_user_info.body.to_s).dig("user")
+    data = JSON.parse(response.body.to_s)
+    data["user"] if data["ok"]
   end
 
   def update_from_slack

--- a/test/jobs/slack_profile_sync_job_test.rb
+++ b/test/jobs/slack_profile_sync_job_test.rb
@@ -1,0 +1,95 @@
+require "test_helper"
+require "webmock/minitest"
+
+class SlackProfileSyncJobTest < ActiveJob::TestCase
+  setup do
+    @original_queue_adapter = ActiveJob::Base.queue_adapter
+    ActiveJob::Base.queue_adapter = :test
+    @original_token = ENV["SLACK_USER_OAUTH_TOKEN"]
+    ENV["SLACK_USER_OAUTH_TOKEN"] = "workspace-token"
+  end
+
+  teardown do
+    ActiveJob::Base.queue_adapter = @original_queue_adapter
+    ENV["SLACK_USER_OAUTH_TOKEN"] = @original_token
+    clear_enqueued_jobs
+    clear_performed_jobs
+  end
+
+  test "updates and persists the Slack profile" do
+    user = User.create!(timezone: "UTC", slack_uid: "U_PROFILE_SYNC")
+    stub_request(:get, "https://slack.com/api/users.info?user=U_PROFILE_SYNC")
+      .with(headers: { "Authorization" => "Bearer workspace-token" })
+      .to_return(body: {
+        ok: true,
+        user: {
+          name: "fallback-name",
+          profile: {
+            display_name_normalized: "slack-name",
+            image_192: "https://example.com/avatar.png"
+          }
+        }
+      }.to_json)
+
+    SlackProfileSyncJob.perform_now(user.id)
+
+    user.reload
+    assert_equal "slack-name", user.slack_username
+    assert_equal "https://example.com/avatar.png", user.slack_avatar_url
+    assert_not_nil user.slack_synced_at
+  end
+
+  test "retries Slack rate limits without changing the existing profile" do
+    user = User.create!(
+      timezone: "UTC",
+      slack_uid: "U_RATE_LIMITED",
+      slack_username: "existing-name",
+      slack_avatar_url: "https://example.com/existing-avatar.png"
+    )
+    stub_request(:get, "https://slack.com/api/users.info?user=U_RATE_LIMITED")
+      .to_return(
+        status: 429,
+        headers: { "Retry-After" => "60" },
+        body: { ok: false, error: "ratelimited" }.to_json
+      )
+
+    travel_to Time.current.change(usec: 0) do
+      assert_enqueued_with(job: SlackProfileSyncJob, args: [ user.id ], at: 60.seconds.from_now) do
+        SlackProfileSyncJob.perform_now(user.id)
+      end
+    end
+
+    user.reload
+    assert_equal "existing-name", user.slack_username
+    assert_equal "https://example.com/existing-avatar.png", user.slack_avatar_url
+    assert_nil user.slack_synced_at
+  end
+
+  test "preserves the existing profile when Slack returns an API error" do
+    synced_at = 2.days.ago
+    user = User.create!(
+      timezone: "UTC",
+      slack_uid: "U_API_ERROR",
+      slack_username: "existing-name",
+      slack_avatar_url: "https://example.com/existing-avatar.png",
+      slack_synced_at: synced_at
+    )
+    stub_request(:get, "https://slack.com/api/users.info?user=U_API_ERROR")
+      .to_return(status: 500, body: { ok: false, error: "internal_error" }.to_json)
+
+    SlackProfileSyncJob.perform_now(user.id)
+
+    user.reload
+    assert_equal "existing-name", user.slack_username
+    assert_equal "https://example.com/existing-avatar.png", user.slack_avatar_url
+    assert_in_delta synced_at, user.slack_synced_at, 1.second
+  end
+
+  test "does nothing when the user has no Slack ID" do
+    user = User.create!(timezone: "UTC")
+
+    SlackProfileSyncJob.perform_now(user.id)
+
+    assert_not_requested :get, /slack\.com/
+  end
+end

--- a/test/jobs/slack_username_update_job_test.rb
+++ b/test/jobs/slack_username_update_job_test.rb
@@ -1,0 +1,47 @@
+require "test_helper"
+
+class SlackUsernameUpdateJobTest < ActiveJob::TestCase
+  setup do
+    @original_queue_adapter = ActiveJob::Base.queue_adapter
+    ActiveJob::Base.queue_adapter = :test
+    User.where.not(slack_uid: nil).update_all(slack_synced_at: Time.current)
+  end
+
+  teardown do
+    ActiveJob::Base.queue_adapter = @original_queue_adapter
+    clear_enqueued_jobs
+    clear_performed_jobs
+  end
+
+  test "enqueues profile syncs for never-synced and stale Slack users" do
+    never_synced = User.create!(timezone: "UTC", slack_uid: "U_NEVER_SYNCED")
+    stale = User.create!(timezone: "UTC", slack_uid: "U_STALE", slack_synced_at: 2.days.ago)
+    User.create!(timezone: "UTC", slack_uid: "U_FRESH", slack_synced_at: 1.hour.ago)
+    User.create!(timezone: "UTC")
+
+    assert_enqueued_jobs 2, only: SlackProfileSyncJob do
+      SlackUsernameUpdateJob.perform_now
+    end
+
+    assert_enqueued_with(job: SlackProfileSyncJob, args: [ never_synced.id ])
+    assert_enqueued_with(job: SlackProfileSyncJob, args: [ stale.id ])
+  end
+
+  test "enqueues more than the old one hundred user limit" do
+    now = Time.current
+    users = 101.times.map do |index|
+      {
+        timezone: "UTC",
+        slack_uid: "U_BACKLOG_#{index}",
+        slack_synced_at: 2.days.ago,
+        created_at: now,
+        updated_at: now
+      }
+    end
+    User.insert_all!(users)
+
+    assert_enqueued_jobs 101, only: SlackProfileSyncJob do
+      SlackUsernameUpdateJob.perform_now
+    end
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require "webmock/minitest"
 
 class UserTest < ActiveSupport::TestCase
   include ActiveJob::TestHelper
@@ -121,6 +122,92 @@ class UserTest < ActiveSupport::TestCase
     assert_equal "new_slack", user.reload.slack_username
     assert_equal "Custom Name", user.display_name_override
     assert_equal "Custom Name", user.display_name
+  end
+
+  test "slack profile sync prefers the workspace token over the user's Slack token" do
+    user = User.create!(timezone: "UTC", slack_uid: "U_HCA", slack_access_token: "personal-token")
+    original_token = ENV["SLACK_USER_OAUTH_TOKEN"]
+    ENV["SLACK_USER_OAUTH_TOKEN"] = "workspace-token"
+    request = stub_request(:get, "https://slack.com/api/users.info?user=U_HCA")
+      .with(headers: { "Authorization" => "Bearer workspace-token" })
+      .to_return(body: {
+        ok: true,
+        user: {
+          name: "hca-user",
+          profile: { image_192: "https://example.com/hca-avatar.png" }
+        }
+      }.to_json)
+
+    user.update_from_slack
+    user.save!
+
+    assert_requested request
+    assert_equal "https://example.com/hca-avatar.png", user.reload.slack_avatar_url
+  ensure
+    ENV["SLACK_USER_OAUTH_TOKEN"] = original_token
+  end
+
+  test "HCA authentication fills a missing Slack ID on an existing account" do
+    user = User.create!(timezone: "UTC", hca_id: "hca-existing")
+    stub_request(:post, "https://hca.dinosaurbbq.org/oauth/token")
+      .to_return(body: { access_token: "hca-token" }.to_json)
+    stub_request(:get, "https://hca.dinosaurbbq.org/api/v1/me")
+      .with(headers: { "Authorization" => "Bearer hca-token" })
+      .to_return(body: {
+        identity: { id: "hca-existing", slack_id: "U_FROM_HCA" },
+        scopes: %w[email slack_id]
+      }.to_json)
+
+    authenticated_user = nil
+    assert_enqueued_with(job: SlackProfileSyncJob, args: [ user.id ]) do
+      authenticated_user = User.from_hca_token("code", "https://example.com/auth/hca/callback")
+    end
+
+    assert_equal user, authenticated_user
+    assert_equal "U_FROM_HCA", user.reload.slack_uid
+  end
+
+  test "HCA authentication does not replace an existing Slack ID" do
+    user = User.create!(
+      timezone: "UTC",
+      hca_id: "hca-linked",
+      slack_uid: "U_LINKED",
+      slack_synced_at: 1.hour.ago
+    )
+    stub_request(:post, "https://hca.dinosaurbbq.org/oauth/token")
+      .to_return(body: { access_token: "hca-token" }.to_json)
+    stub_request(:get, "https://hca.dinosaurbbq.org/api/v1/me")
+      .with(headers: { "Authorization" => "Bearer hca-token" })
+      .to_return(body: {
+        identity: { id: "hca-linked", slack_id: "U_DIFFERENT" },
+        scopes: %w[email slack_id]
+      }.to_json)
+
+    authenticated_user = nil
+    assert_enqueued_with(job: SlackProfileSyncJob, args: [ user.id ]) do
+      authenticated_user = User.from_hca_token("code", "https://example.com/auth/hca/callback")
+    end
+
+    assert_equal user, authenticated_user
+    assert_equal "U_LINKED", user.reload.slack_uid
+  end
+
+  test "HCA authentication does not claim a Slack ID linked to another account" do
+    user = User.create!(timezone: "UTC", hca_id: "hca-unlinked")
+    User.create!(timezone: "UTC", slack_uid: "U_ALREADY_LINKED")
+    stub_request(:post, "https://hca.dinosaurbbq.org/oauth/token")
+      .to_return(body: { access_token: "hca-token" }.to_json)
+    stub_request(:get, "https://hca.dinosaurbbq.org/api/v1/me")
+      .with(headers: { "Authorization" => "Bearer hca-token" })
+      .to_return(body: {
+        identity: { id: "hca-unlinked", slack_id: "U_ALREADY_LINKED" },
+        scopes: %w[email slack_id]
+      }.to_json)
+
+    authenticated_user = User.from_hca_token("code", "https://example.com/auth/hca/callback")
+
+    assert_equal user, authenticated_user
+    assert_nil user.reload.slack_uid
   end
 
   test "creating a user with an email address queues a welcome email" do


### PR DESCRIPTION
## Summary of the problem

Users authenticated through HCA can provide a Slack ID, but Hackatime did not adopt that ID or immediately synchronize the user's Slack profile. The existing nightly sync also processed only 100 users inline, so profile updates could remain stale for days and one failure could interfere with the sweep.

## Describe your changes

- Adopt HCA's Slack ID when the Hackatime user does not already have a Slack link and the ID is not claimed by another account
- Enqueue an independent `SlackProfileSyncJob` after HCA authentication for linked users
- Fetch Slack profile data with the shared workspace token when configured, persist username/avatar/sync time only on success, and retry Slack 429 responses with backoff honouring `Retry-After`
- Convert the nightly job into a reconciliation sweep that enqueues all stale or never-synchronized linked users rather than synchronously limiting work to 100 users

## Screenshots / Media
<!-- If there are any visual changes, please attach images, videos, or gifs. -->

N/A