### PR TITLE
Fix badges for dotted project names

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -236,7 +236,7 @@ Rails.application.routes.draw do
       get "leaderboard/weekly", to: "leaderboard#weekly"
 
       get "stats", to: "stats#show"
-      get "badge/:user_id/*project", to: "badges#show"
+      get "badge/:user_id/*project", to: "badges#show", format: false
 
       get "users/:username/stats", to: "stats#user_stats"
       get "users/:username/heartbeats/spans", to: "stats#user_spans"

--- a/spec/requests/api/v1/badges_spec.rb
+++ b/spec/requests/api/v1/badges_spec.rb
@@ -143,4 +143,25 @@ RSpec.describe 'Api::V1::Badges', type: :request do
       end
     end
   end
+
+  it 'supports project names containing dots' do
+    badge_user = User.create!(
+      slack_uid: "UDOTTED#{SecureRandom.hex(4)}",
+      timezone: 'UTC',
+      allow_public_stats_lookup: true
+    )
+    repository = Repository.create!(
+      url: 'https://github.com/pimlico/pimlico.dev',
+      host: 'github.com',
+      owner: 'pimlico',
+      name: 'pimlico.dev'
+    )
+    badge_user.project_repo_mappings.create!(project_name: 'pimlico.dev', repository: repository)
+    log_time(badge_user, 'pimlico.dev')
+
+    get "/api/v1/badge/#{badge_user.slack_uid}/pimlico/pimlico.dev"
+
+    expect(response).to have_http_status(:temporary_redirect)
+    expect(response.headers['Location']).to start_with('https://img.shields.io/badge/')
+  end
 end


### PR DESCRIPTION
## Summary of the problem

Badge URLs for projects whose repository names contain dots return `Project not found`. Rails interprets the final portion after the dot as a response format, so `pimlico/pimlico.dev` reaches the controller as project `pimlico/pimlico` with format `dev`.

Fixes #1488.

## Describe your changes

- Disable optional format parsing on the wildcard project badge route so dotted project names remain intact.
- Add a request regression spec covering a dotted repository path and its project mapping.

## Screenshots / Media

N/A