### PR TITLE
Reject missing repository mappings

### DIFF
--- a/app/services/repo_host/github_service.rb
+++ b/app/services/repo_host/github_service.rb
@@ -23,7 +23,7 @@ module RepoHost
 
       case response.status.code
       when 200 then true
-      when 404 then github_repo_scope?(response) ? false : nil
+      when 404 then false
       else
         Rails.logger.warn "[#{self.class.name}] Could not verify #{owner}/#{repo}: #{response.status}"
         nil
@@ -58,10 +58,6 @@ module RepoHost
     end
 
     private
-
-    def github_repo_scope?(response)
-      response.headers["X-OAuth-Scopes"].to_s.split(",").map(&:strip).include?("repo")
-    end
 
     def api_headers
       self.class.api_headers_for(user.github_access_token)

--- a/test/models/project_repo_mapping_test.rb
+++ b/test/models/project_repo_mapping_test.rb
@@ -36,37 +36,17 @@ class ProjectRepoMappingTest < ActiveSupport::TestCase
     assert_predicate mapping, :valid?
   end
 
-  test "inaccessible GitHub repository URLs are invalid" do
+  test "nonexistent GitHub repository URLs are invalid" do
     user = User.create!(github_access_token: "github-token")
-    stub_request(:get, "https://api.github.com/repos/example/missing")
-      .to_return(
-        status: 404,
-        body: '{"message":"Not Found"}',
-        headers: { "X-OAuth-Scopes" => "repo, user:email" }
-      )
+    stub_request(:get, "https://api.github.com/repos/hackcl/hackatime")
+      .to_return(status: 404, body: '{"message":"Not Found"}')
     mapping = user.project_repo_mappings.build(
       project_name: "missing",
-      repo_url: "https://github.com/example/missing"
+      repo_url: "https://github.com/hackcl/hackatime"
     )
 
     assert_not mapping.valid?
     assert_includes mapping.errors[:repo_url], "does not exist or is not accessible"
-  end
-
-  test "a private repository hidden from a limited token is not treated as nonexistent" do
-    user = User.create!(github_access_token: "github-token")
-    stub_request(:get, "https://api.github.com/repos/example/private")
-      .to_return(
-        status: 404,
-        body: '{"message":"Not Found"}',
-        headers: { "X-OAuth-Scopes" => "user:email" }
-      )
-    mapping = user.project_repo_mappings.build(
-      project_name: "private",
-      repo_url: "https://github.com/example/private"
-    )
-
-    assert_predicate mapping, :valid?
   end
 
   test "temporary GitHub failures do not mark repository URLs as nonexistent" do


### PR DESCRIPTION
## Summary of the problem

GitHub returns `404` for both nonexistent repositories and private repositories hidden from a limited OAuth token. The repository mapping verifier treated limited-scope 404 responses as ambiguous and failed open, so typos such as `https://github.com/hackcl/hackatime` were accepted :(

## Describe your changes

Treat every GitHub repository API `404` as nonexistent or inaccessible

## Screenshots / Media

N/A