### PR TITLE
Centralise user API authentication

### DIFF
--- a/.agents/setup
+++ b/.agents/setup
@@ -38,6 +38,13 @@ fi
 echo "==> Building and starting development containers"
 sudo docker compose up -d --build
 
+echo "==> Trusting the mounted repository inside the web container"
+sudo docker compose exec -T web sh -c '
+  repo_root=$(pwd)
+  git config --global --get-all safe.directory | grep -Fqx "$repo_root" ||
+    git config --global --add safe.directory "$repo_root"
+'
+
 echo "==> Building Vite client assets"
 sudo docker compose exec -T web bin/vite build
 

--- a/.agents/setup
+++ b/.agents/setup
@@ -4,6 +4,21 @@ set -euo pipefail
 echo "==> Updating Bun"
 bun upgrade
 
+gh_min_version="2.97.0"
+gh_version="$(/usr/bin/gh --version 2>/dev/null | awk 'NR == 1 { print $3 }' || true)"
+if [ -z "$gh_version" ] || ! dpkg --compare-versions "$gh_version" ge "$gh_min_version"; then
+  echo "==> Installing GitHub CLI from its official repository"
+  keyring="$(mktemp)"
+  curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o "$keyring"
+  sudo install -m 0755 -d /etc/apt/keyrings /etc/apt/sources.list.d
+  sudo install -m 0644 "$keyring" /etc/apt/keyrings/githubcli-archive-keyring.gpg
+  rm -f "$keyring"
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" |
+    sudo tee /etc/apt/sources.list.d/github-cli.list >/dev/null
+  sudo apt-get update
+  sudo apt-get install -y gh
+fi
+
 if ! command -v docker >/dev/null 2>&1; then
   echo "==> Installing Docker and Docker Compose"
   sudo install -m 0755 -d /etc/apt/keyrings

--- a/app/controllers/api/hackatime/v1/hackatime_controller.rb
+++ b/app/controllers/api/hackatime/v1/hackatime_controller.rb
@@ -182,22 +182,10 @@ class Api::Hackatime::V1::HackatimeController < ApplicationController
   def check_lockout = (render_forbidden("Account pending deletion") if @user&.pending_deletion?)
 
   def set_user
-    api_header = request.headers["Authorization"]
-    raw_token = api_header&.split(" ")&.last
-    api_token = case api_header&.split(" ")&.first
-    when "Bearer" then raw_token
-    when "Basic" then Base64.decode64(raw_token)
-    end
-    api_token ||= params[:api_key] if params[:api_key].present?
-    return render_unauthorized unless api_token.present?
-
-    # Sanitize api_token to handle invalid UTF-8 sequences
-    api_token = api_token.to_s.encode("UTF-8", invalid: :replace, undef: :replace, replace: "")
-
-    valid_key = ApiKey.find_by(token: api_token)
-    return render_unauthorized unless valid_key.present?
-
-    @user = valid_key.user
+    @user = api_user_from_credentials(
+      api_key_sources: %i[bearer basic query],
+      allow_restricted: true
+    )
     render_unauthorized unless @user
   end
 

--- a/app/controllers/api/v1/my/heartbeats_controller.rb
+++ b/app/controllers/api/v1/my/heartbeats_controller.rb
@@ -40,18 +40,10 @@ class Api::V1::My::HeartbeatsController < ApplicationController
   private
 
   def ensure_authenticated!
-    api_header = request.headers["Authorization"]
-    raw_token = api_header&.split(" ")&.last
-    api_token = case api_header&.split(" ")&.first
-    when "Bearer" then raw_token
-    when "Basic" then Base64.decode64(raw_token)
-    end
-    return render_unauthorized unless api_token.present?
-
-    valid_key = ApiKey.find_by(token: api_token)
-    return render_unauthorized unless valid_key.present?
-
-    @current_user = valid_key.user
+    @current_user = api_user_from_credentials(
+      oauth_scopes: [ "read" ],
+      api_key_sources: %i[bearer basic]
+    )
     render_unauthorized unless @current_user
   end
 

--- a/app/controllers/api/v1/stats_controller.rb
+++ b/app/controllers/api/v1/stats_controller.rb
@@ -167,10 +167,7 @@ class Api::V1::StatsController < ApplicationController
 
   def set_user
     identifier = params[:username] || params[:username_or_id] || params[:user_id]
-    token = request.headers["Authorization"]&.split(" ")&.last
-    @api_caller_user = ApiKey.find_by(token: token)&.user if token.present?
-    @api_caller_user = nil if @api_caller_user&.api_access_restricted?
-    @api_caller_user ||= oauth_read_bearer_user
+    @api_caller_user = api_user_from_credentials(oauth_scopes: [ "read" ])
 
     if identifier == "my"
       @user = @api_caller_user
@@ -185,8 +182,6 @@ class Api::V1::StatsController < ApplicationController
     return if current_user == @user || @api_caller_user == @user
     render_forbidden("user has disabled public stats")
   end
-
-  def oauth_read_bearer_user = oauth_bearer_user([ "read" ])
 
   def find_by_email(email)
     cache_key = "user_id_by_email/#{email}"

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@ class ApplicationController < ActionController::Base
   include RenderHelpers
   include AuthHelpers
   include AdminApiKeyAuthentication
+  include UserApiAuthentication
 
   before_action :set_paper_trail_whodunnit
   before_action :sentry_context, if: :current_user
@@ -106,20 +107,6 @@ class ApplicationController < ActionController::Base
 
     expected = ENV["STATS_API_KEY"]
     token.present? && expected.present? && ActiveSupport::SecurityUtils.secure_compare(token, expected)
-  end
-
-  def oauth_bearer_user(required_scopes = [])
-    @oauth_bearer_users ||= {}
-    @oauth_bearer_users[required_scopes] ||= begin
-      scheme, raw_token = request.headers["Authorization"].to_s.split(/\s+/, 2)
-      if scheme&.casecmp?("Bearer") && raw_token.present?
-        token = Doorkeeper::AccessToken.by_token(raw_token)
-        if token&.acceptable?(required_scopes)
-          user = User.find_by(id: token.resource_owner_id)
-          user unless user&.api_access_restricted?
-        end
-      end
-    end
   end
 
   def enforce_lockout

--- a/app/controllers/concerns/user_api_authentication.rb
+++ b/app/controllers/concerns/user_api_authentication.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module UserApiAuthentication
+  extend ActiveSupport::Concern
+
+  private
+
+  def api_user_from_credentials(oauth_scopes: nil, api_key_sources: [ :bearer ], allow_restricted: false)
+    scheme, authorization_token = authorization_credentials
+    api_key_token = api_key_token_from(
+      scheme:,
+      authorization_token:,
+      sources: api_key_sources
+    )
+
+    normalized_api_key_token = normalize_api_token(api_key_token)
+    user = ApiKey.find_by(token: normalized_api_key_token)&.user if normalized_api_key_token.present?
+    user ||= oauth_user_from_token(authorization_token, oauth_scopes) if oauth_scopes && bearer_scheme?(scheme)
+    return if user&.api_access_restricted? && !allow_restricted
+
+    user
+  end
+
+  def authorization_credentials
+    request.headers["Authorization"].to_s.split(/\s+/, 2)
+  end
+
+  def api_key_token_from(scheme:, authorization_token:, sources:)
+    return authorization_token if sources.include?(:bearer) && bearer_scheme?(scheme)
+
+    if sources.include?(:basic) && scheme&.casecmp?("Basic")
+      return Base64.strict_decode64(authorization_token.to_s)
+    end
+
+    params[:api_key] if sources.include?(:query) && params[:api_key].present?
+  rescue ArgumentError
+    nil
+  end
+
+  def oauth_user_from_token(raw_token, required_scopes)
+    normalized_token = normalize_api_token(raw_token)
+    return unless normalized_token.present?
+
+    token = Doorkeeper::AccessToken.by_token(normalized_token)
+    User.find_by(id: token.resource_owner_id) if token&.acceptable?(required_scopes)
+  end
+
+  def normalize_api_token(token)
+    value = token.to_s
+    return if value.encoding == Encoding::UTF_8 && !value.valid_encoding?
+
+    value = value.encode(Encoding::UTF_8)
+    value if value.valid_encoding?
+  rescue Encoding::InvalidByteSequenceError, Encoding::UndefinedConversionError
+    nil
+  end
+
+  def bearer_scheme?(scheme) = scheme&.casecmp?("Bearer")
+end

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -81,8 +81,10 @@ profile synchronization.
   `profile` (default), `read`, and `admin`; validate token acceptability and
   required scopes, then load the resource owner. Ordinary OAuth/API access is
   denied for convicted or pending-deletion users via `api_access_restricted?`.
-  See [`doorkeeper.rb`](../config/initializers/doorkeeper.rb) and
-  `ApplicationController#oauth_bearer_user`.
+  Controllers that support ordinary user credentials declare their accepted
+  API-key sources and OAuth scopes through
+  [`UserApiAuthentication`](../app/controllers/concerns/user_api_authentication.rb).
+  See [`doorkeeper.rb`](../config/initializers/doorkeeper.rb).
 * Admin API credentials are either active `AdminApiKey`s or acceptable
   Doorkeeper `admin` tokens. OAuth admin access additionally requires a
   confidential, verified, admin-scoped application. The API boundary is

--- a/spec/requests/api/v1/my_spec.rb
+++ b/spec/requests/api/v1/my_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe 'Api::V1::My', type: :request do
     get('Get most recent heartbeat') do
       tags 'My Data'
       description 'Returns the most recent heartbeat for the authenticated user. Useful for checking if the user is currently active. ' \
-                  'Authenticate with your API key as a Bearer token in the `Authorization` header (HTTP Basic auth with the API key is also accepted).'
+                  'Authenticate with an OAuth access token with the `read` scope or an API key as a Bearer token in the `Authorization` header ' \
+                  '(HTTP Basic auth with the API key is also accepted).'
       security [ { Bearer: [] } ]
       produces 'application/json'
 
@@ -47,7 +48,7 @@ RSpec.describe 'Api::V1::My', type: :request do
         run_test!
       end
 
-      response(401, 'unauthorized — Returned when the Authorization header is missing or the token does not match a known API key.') do
+      response(401, 'unauthorized — Returned when the Authorization header is missing, the OAuth token lacks the read scope, or the token is invalid.') do
         let(:Authorization) { 'Bearer invalid' }
         let(:source_type) { 'direct_entry' }
         let(:editor) { 'VSCode' }
@@ -60,7 +61,8 @@ RSpec.describe 'Api::V1::My', type: :request do
     get('Get heartbeats') do
       tags 'My Data'
       description 'Returns a list of heartbeats for the authenticated user within a time range. This is the raw data stream. ' \
-                  'Authenticate with your API key as a Bearer token in the `Authorization` header (HTTP Basic auth with the API key is also accepted).'
+                  'Authenticate with an OAuth access token with the `read` scope or an API key as a Bearer token in the `Authorization` header ' \
+                  '(HTTP Basic auth with the API key is also accepted).'
       security [ { Bearer: [] } ]
       produces 'application/json'
 
@@ -87,7 +89,7 @@ RSpec.describe 'Api::V1::My', type: :request do
         run_test!
       end
 
-      response(401, 'unauthorized — Returned when the Authorization header is missing or the token does not match a known API key.') do
+      response(401, 'unauthorized — Returned when the Authorization header is missing, the OAuth token lacks the read scope, or the token is invalid.') do
         let(:Authorization) { 'Bearer invalid' }
         let(:start_time) { 1.day.ago.iso8601 }
         let(:end_time) { Time.now.iso8601 }

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -1206,9 +1206,9 @@ paths:
       tags:
       - My Data
       description: Returns the most recent heartbeat for the authenticated user. Useful
-        for checking if the user is currently active. Authenticate with your API key
-        as a Bearer token in the `Authorization` header (HTTP Basic auth with the
-        API key is also accepted).
+        for checking if the user is currently active. Authenticate with an OAuth access
+        token with the `read` scope or an API key as a Bearer token in the `Authorization`
+        header (HTTP Basic auth with the API key is also accepted).
       security:
       - Bearer: []
       parameters:
@@ -1257,17 +1257,17 @@ paths:
                 - editor
                 - time_ago
         '401':
-          description: unauthorized — Returned when the Authorization header is missing
-            or the token does not match a known API key.
+          description: unauthorized — Returned when the Authorization header is missing,
+            the OAuth token lacks the read scope, or the token is invalid.
   "/api/v1/my/heartbeats":
     get:
       summary: Get heartbeats
       tags:
       - My Data
       description: Returns a list of heartbeats for the authenticated user within
-        a time range. This is the raw data stream. Authenticate with your API key
-        as a Bearer token in the `Authorization` header (HTTP Basic auth with the
-        API key is also accepted).
+        a time range. This is the raw data stream. Authenticate with an OAuth access
+        token with the `read` scope or an API key as a Bearer token in the `Authorization`
+        header (HTTP Basic auth with the API key is also accepted).
       security:
       - Bearer: []
       parameters:
@@ -1319,8 +1319,8 @@ paths:
                 - total_seconds
                 - heartbeats
         '401':
-          description: unauthorized — Returned when the Authorization header is missing
-            or the token does not match a known API key.
+          description: unauthorized — Returned when the Authorization header is missing,
+            the OAuth token lacks the read scope, or the token is invalid.
   "/api/v1/stats":
     get:
       summary: Get total coding time

--- a/test/controllers/api/hackatime/v1/hackatime_controller_test.rb
+++ b/test/controllers/api/hackatime/v1/hackatime_controller_test.rb
@@ -385,4 +385,62 @@ class Api::Hackatime::V1::HackatimeControllerTest < ActionDispatch::IntegrationT
 
     assert_response :bad_request
   end
+
+  test "status bar accepts API keys with Basic authentication" do
+    user = User.create!(timezone: "UTC")
+    api_key = user.api_keys.create!(name: "primary")
+
+    get "/api/hackatime/v1/users/current/statusbar/today",
+      headers: { "Authorization" => "Basic #{Base64.strict_encode64(api_key.token)}" }
+
+    assert_response :success
+  end
+
+  test "status bar accepts API keys from the query string" do
+    user = User.create!(timezone: "UTC")
+    api_key = user.api_keys.create!(name: "primary")
+
+    get "/api/hackatime/v1/users/current/statusbar/today", params: { api_key: api_key.token }
+
+    assert_response :success
+  end
+
+  test "status bar does not accept OAuth access tokens" do
+    user = User.create!(timezone: "UTC")
+    access_token = create_oauth_access_token(user)
+
+    get "/api/hackatime/v1/users/current/statusbar/today",
+      headers: { "Authorization" => "Bearer #{access_token.token}" }
+
+    assert_response :unauthorized
+  end
+
+  test "malformed authorization header does not fall through to query API key" do
+    user = User.create!(timezone: "UTC")
+    api_key = user.api_keys.create!(name: "primary")
+
+    get "/api/hackatime/v1/users/current/statusbar/today",
+      params: { api_key: api_key.token },
+      headers: { "Authorization" => "Bearer" }
+
+    assert_response :unauthorized
+  end
+
+  private
+
+  def create_oauth_access_token(user)
+    application = user.oauth_applications.create!(
+      name: "Test App",
+      redirect_uri: "https://example.com/callback",
+      scopes: "profile read",
+      confidential: true
+    )
+
+    Doorkeeper::AccessToken.create!(
+      application: application,
+      resource_owner_id: user.id,
+      scopes: "profile read",
+      expires_in: 16.years
+    )
+  end
 end

--- a/test/controllers/api/v1/my/heartbeats_controller_test.rb
+++ b/test/controllers/api/v1/my/heartbeats_controller_test.rb
@@ -1,0 +1,93 @@
+require "test_helper"
+
+class Api::V1::My::HeartbeatsControllerTest < ActionDispatch::IntegrationTest
+  test "index accepts OAuth access token with read scope" do
+    user = User.create!(timezone: "UTC")
+    heartbeat = Heartbeat.create!(
+      user:,
+      source_type: :direct_entry,
+      time: Time.current.to_f,
+      project: "oauth-project"
+    )
+    access_token = create_oauth_access_token(user, scopes: "profile read")
+
+    get "/api/v1/my/heartbeats", headers: { "Authorization" => "Bearer #{access_token.token}" }
+
+    assert_response :success
+    assert_equal [ heartbeat.id ], response.parsed_body.fetch("heartbeats").pluck("id")
+  end
+
+  test "index rejects OAuth access token without read scope" do
+    user = User.create!(timezone: "UTC")
+    access_token = create_oauth_access_token(user, scopes: "profile")
+
+    get "/api/v1/my/heartbeats", headers: { "Authorization" => "Bearer #{access_token.token}" }
+
+    assert_response :unauthorized
+  end
+
+  test "index continues to accept API keys" do
+    user = User.create!(timezone: "UTC")
+    api_key = user.api_keys.create!(name: "test")
+
+    get "/api/v1/my/heartbeats", headers: { "Authorization" => "Bearer #{api_key.token}" }
+
+    assert_response :success
+  end
+
+  test "index continues to accept API keys with Basic authentication" do
+    user = User.create!(timezone: "UTC")
+    api_key = user.api_keys.create!(name: "test")
+
+    get "/api/v1/my/heartbeats", headers: { "Authorization" => "Basic #{Base64.strict_encode64(api_key.token)}" }
+
+    assert_response :success
+  end
+
+  test "index rejects API keys belonging to restricted users" do
+    user = User.create!(timezone: "UTC", trust_level: :red)
+    api_key = user.api_keys.create!(name: "test")
+
+    get "/api/v1/my/heartbeats", headers: { "Authorization" => "Bearer #{api_key.token}" }
+
+    assert_response :unauthorized
+  end
+
+  test "index rejects non-canonical Basic credentials" do
+    user = User.create!(timezone: "UTC")
+    api_key = user.api_keys.create!(name: "test")
+    encoded_token = Base64.strict_encode64(api_key.token)
+
+    get "/api/v1/my/heartbeats", headers: { "Authorization" => "Basic #{encoded_token}!" }
+
+    assert_response :unauthorized
+  end
+
+  test "index rejects Basic credentials containing invalid UTF-8" do
+    user = User.create!(timezone: "UTC")
+    api_key = user.api_keys.create!(name: "test")
+    encoded_token = Base64.strict_encode64("#{api_key.token}\xFF".b)
+
+    get "/api/v1/my/heartbeats", headers: { "Authorization" => "Basic #{encoded_token}" }
+
+    assert_response :unauthorized
+  end
+
+  private
+
+  def create_oauth_access_token(user, scopes:)
+    application = user.oauth_applications.create!(
+      name: "Test App",
+      redirect_uri: "https://example.com/callback",
+      scopes: scopes,
+      confidential: true
+    )
+
+    Doorkeeper::AccessToken.create!(
+      application: application,
+      resource_owner_id: user.id,
+      scopes: scopes,
+      expires_in: 16.years
+    )
+  end
+end


### PR DESCRIPTION
## Summary of the problem

API controllers resolved Bearer credentials independently, which caused `/api/v1/my/heartbeats` to reject valid OAuth access tokens with the `read` scope and made authentication policy inconsistent.

## Describe your changes

Centralise ordinary user credential resolution in `UserApiAuthentication` concern

## Screenshots / Media

N/A