### PR TITLE
Fix OAuth scope and Bearer enforcement

### DIFF
--- a/app/controllers/api/v1/authenticated/application_controller.rb
+++ b/app/controllers/api/v1/authenticated/application_controller.rb
@@ -6,6 +6,11 @@ module Api
         before_action :doorkeeper_authorize!
         before_action :ensure_api_access_allowed
 
+        def self.require_oauth_scope(scope)
+          skip_before_action :doorkeeper_authorize!
+          before_action -> { doorkeeper_authorize! scope }, prepend: true
+        end
+
         private
 
         def current_user

--- a/app/controllers/api/v1/authenticated/heartbeats_controller.rb
+++ b/app/controllers/api/v1/authenticated/heartbeats_controller.rb
@@ -2,6 +2,9 @@ module Api
   module V1
     module Authenticated
       class HeartbeatsController < ApplicationController
+        skip_before_action :doorkeeper_authorize!
+        before_action -> { doorkeeper_authorize! :read }, prepend: true
+
         def latest
           heartbeat = current_user.heartbeats
                                   .where.not(source_type: :test_entry)

--- a/app/controllers/api/v1/authenticated/heartbeats_controller.rb
+++ b/app/controllers/api/v1/authenticated/heartbeats_controller.rb
@@ -2,8 +2,7 @@ module Api
   module V1
     module Authenticated
       class HeartbeatsController < ApplicationController
-        skip_before_action :doorkeeper_authorize!
-        before_action -> { doorkeeper_authorize! :read }, prepend: true
+        require_oauth_scope :read
 
         def latest
           heartbeat = current_user.heartbeats

--- a/app/controllers/api/v1/authenticated/hours_controller.rb
+++ b/app/controllers/api/v1/authenticated/hours_controller.rb
@@ -2,8 +2,7 @@ module Api
   module V1
     module Authenticated
       class HoursController < ApplicationController
-        skip_before_action :doorkeeper_authorize!
-        before_action -> { doorkeeper_authorize! :read }, prepend: true
+        require_oauth_scope :read
 
         def index
           start_date = params[:start_date]&.to_date || 7.days.ago.to_date

--- a/app/controllers/api/v1/authenticated/hours_controller.rb
+++ b/app/controllers/api/v1/authenticated/hours_controller.rb
@@ -2,6 +2,9 @@ module Api
   module V1
     module Authenticated
       class HoursController < ApplicationController
+        skip_before_action :doorkeeper_authorize!
+        before_action -> { doorkeeper_authorize! :read }, prepend: true
+
         def index
           start_date = params[:start_date]&.to_date || 7.days.ago.to_date
           end_date = params[:end_date]&.to_date || Date.current

--- a/app/controllers/api/v1/authenticated/me_controller.rb
+++ b/app/controllers/api/v1/authenticated/me_controller.rb
@@ -2,6 +2,8 @@ module Api
   module V1
     module Authenticated
       class MeController < ApplicationController
+        skip_before_action :doorkeeper_authorize!
+        before_action -> { doorkeeper_authorize! :profile }, prepend: true
         skip_before_action :ensure_api_access_allowed, only: :index
         before_action :ensure_no_pending_deletion, only: :index
 

--- a/app/controllers/api/v1/authenticated/me_controller.rb
+++ b/app/controllers/api/v1/authenticated/me_controller.rb
@@ -2,8 +2,7 @@ module Api
   module V1
     module Authenticated
       class MeController < ApplicationController
-        skip_before_action :doorkeeper_authorize!
-        before_action -> { doorkeeper_authorize! :profile }, prepend: true
+        require_oauth_scope :profile
         skip_before_action :ensure_api_access_allowed, only: :index
         before_action :ensure_no_pending_deletion, only: :index
 

--- a/app/controllers/api/v1/authenticated/projects_controller.rb
+++ b/app/controllers/api/v1/authenticated/projects_controller.rb
@@ -2,6 +2,9 @@ module Api
   module V1
     module Authenticated
       class ProjectsController < ApplicationController
+        skip_before_action :doorkeeper_authorize!
+        before_action -> { doorkeeper_authorize! :read }, prepend: true
+
         def index
           projects = project_stats_query.project_details.map do |project|
             {

--- a/app/controllers/api/v1/authenticated/projects_controller.rb
+++ b/app/controllers/api/v1/authenticated/projects_controller.rb
@@ -2,8 +2,7 @@ module Api
   module V1
     module Authenticated
       class ProjectsController < ApplicationController
-        skip_before_action :doorkeeper_authorize!
-        before_action -> { doorkeeper_authorize! :read }, prepend: true
+        require_oauth_scope :read
 
         def index
           projects = project_stats_query.project_details.map do |project|

--- a/app/controllers/api/v1/authenticated/streak_controller.rb
+++ b/app/controllers/api/v1/authenticated/streak_controller.rb
@@ -2,8 +2,7 @@ module Api
   module V1
     module Authenticated
       class StreakController < ApplicationController
-        skip_before_action :doorkeeper_authorize!
-        before_action -> { doorkeeper_authorize! :read }, prepend: true
+        require_oauth_scope :read
 
         def show
           render json: {

--- a/app/controllers/api/v1/authenticated/streak_controller.rb
+++ b/app/controllers/api/v1/authenticated/streak_controller.rb
@@ -2,6 +2,9 @@ module Api
   module V1
     module Authenticated
       class StreakController < ApplicationController
+        skip_before_action :doorkeeper_authorize!
+        before_action -> { doorkeeper_authorize! :read }, prepend: true
+
         def show
           render json: {
             streak_days: current_user.streak_days

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -91,12 +91,15 @@ class ApplicationController < ActionController::Base
   # Authenticates stats integrations with an AdminApiKey. STATS_API_KEY remains
   # available as a temporary fallback while the Flipper flag is enabled.
   def authenticate_stats_api_key!(allow_query_param: true, message: "Unauthorized")
-    header_token = request.headers["Authorization"]&.split(" ")&.last
-    if header_token.present?
-      return if auth_admin_api_key(header_token)
-      return if valid_legacy_stats_api_key?(header_token)
-    elsif allow_query_param
-      return if valid_legacy_stats_api_key?(params[:api_key])
+    authorization = request.headers["Authorization"]
+    if authorization.nil?
+      return if allow_query_param && valid_legacy_stats_api_key?(params[:api_key])
+    elsif authorization.match?(/\ABearer +\S+\z/i)
+      scheme, header_token = authorization_credentials
+      if bearer_scheme?(scheme)
+        return if auth_admin_api_key(header_token)
+        return if valid_legacy_stats_api_key?(header_token)
+      end
     end
 
     render_unauthorized(message)

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -7,6 +7,7 @@ Doorkeeper.configure do
   default_scopes "profile"
   optional_scopes "read", "admin"
   enforce_configured_scopes
+  access_token_methods :from_bearer_authorization
 
   resource_owner_authenticator do
     if respond_to?(:current_user, true)

--- a/spec/requests/api/v1/authenticated_spec.rb
+++ b/spec/requests/api/v1/authenticated_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe 'Api::V1::Authenticated', type: :request do
   path '/api/v1/authenticated/me' do
     get('Get current user info') do
       tags 'OAuth2-specific'
-      description 'Returns detailed information about the currently authenticated user. Requires an OAuth2 access token (Bearer header).'
-      security [ { Bearer: [] } ]
+      description 'Returns detailed information about the currently authenticated user. Requires an OAuth2 access token with the `profile` scope in the Bearer header.'
+      security [ { OAuth2: [ 'profile' ] } ]
       produces 'application/json'
 
       response(200, 'successful') do
@@ -31,6 +31,13 @@ RSpec.describe 'Api::V1::Authenticated', type: :request do
         end
       end
 
+      response(403, 'insufficient scope') do
+        before { Doorkeeper::AccessToken.by_token('dev-api-key-12345').update!(scopes: 'read') }
+
+        let(:Authorization) { "Bearer dev-api-key-12345" }
+        run_test!
+      end
+
       response(401, 'unauthorized — Returned when the OAuth access token is missing or invalid.') do
         let(:Authorization) { 'Bearer invalid' }
         run_test!
@@ -41,14 +48,16 @@ RSpec.describe 'Api::V1::Authenticated', type: :request do
   path '/api/v1/authenticated/hours' do
     get('Get hours') do
       tags 'OAuth2-specific'
-      description 'Returns the total coding hours for the authenticated user. Requires an OAuth2 access token (Bearer header).'
-      security [ { Bearer: [] } ]
+      description 'Returns the total coding hours for the authenticated user. Requires an OAuth2 access token with the `read` scope in the Bearer header.'
+      security [ { OAuth2: [ 'read' ] } ]
       produces 'application/json'
 
       parameter name: :start_date, in: :query, schema: { type: :string, format: :date }, description: 'Start date (YYYY-MM-DD)'
       parameter name: :end_date, in: :query, schema: { type: :string, format: :date }, description: 'End date (YYYY-MM-DD)'
 
       response(200, 'successful') do
+        before { Doorkeeper::AccessToken.by_token('dev-api-key-12345').update!(scopes: 'read') }
+
         let(:Authorization) { "Bearer dev-api-key-12345" }
         let(:start_date) { 7.days.ago.to_date.to_s }
         let(:end_date) { Date.today.to_s }
@@ -58,6 +67,13 @@ RSpec.describe 'Api::V1::Authenticated', type: :request do
             end_date: { type: :string, format: :date, example: '2024-03-20' },
             total_seconds: { type: :number, example: 153000.0 }
           }
+        run_test!
+      end
+
+      response(403, 'insufficient scope') do
+        let(:Authorization) { "Bearer dev-api-key-12345" }
+        let(:start_date) { 7.days.ago.to_date.to_s }
+        let(:end_date) { Date.today.to_s }
         run_test!
       end
 
@@ -73,16 +89,23 @@ RSpec.describe 'Api::V1::Authenticated', type: :request do
   path '/api/v1/authenticated/streak' do
     get('Get streak') do
       tags 'OAuth2-specific'
-      description 'Returns the current streak information (days coded in a row). Requires an OAuth2 access token (Bearer header).'
-      security [ { Bearer: [] } ]
+      description 'Returns the current streak information (days coded in a row). Requires an OAuth2 access token with the `read` scope in the Bearer header.'
+      security [ { OAuth2: [ 'read' ] } ]
       produces 'application/json'
 
       response(200, 'successful') do
+        before { Doorkeeper::AccessToken.by_token('dev-api-key-12345').update!(scopes: 'read') }
+
         let(:Authorization) { "Bearer dev-api-key-12345" }
         schema type: :object,
           properties: {
             streak_days: { type: :integer, example: 5 }
           }
+        run_test!
+      end
+
+      response(403, 'insufficient scope') do
+        let(:Authorization) { "Bearer dev-api-key-12345" }
         run_test!
       end
 
@@ -96,8 +119,8 @@ RSpec.describe 'Api::V1::Authenticated', type: :request do
   path '/api/v1/authenticated/projects' do
     get('Get projects') do
       tags 'OAuth2-specific'
-      description 'Returns a list of projects associated with the authenticated user. Requires an OAuth2 access token (Bearer header).'
-      security [ { Bearer: [] } ]
+      description 'Returns a list of projects associated with the authenticated user. Requires an OAuth2 access token with the `read` scope in the Bearer header.'
+      security [ { OAuth2: [ 'read' ] } ]
       produces 'application/json'
 
       parameter name: :include_archived, in: :query, type: :boolean, description: 'Include archived projects (true/false)'
@@ -111,6 +134,8 @@ RSpec.describe 'Api::V1::Authenticated', type: :request do
       parameter name: :end_date, in: :query, schema: { type: :string, format: :date_time }, description: 'Alias for end'
 
       response(200, 'successful') do
+        before { Doorkeeper::AccessToken.by_token('dev-api-key-12345').update!(scopes: 'read') }
+
         let(:Authorization) { "Bearer dev-api-key-12345" }
         let(:include_archived) { false }
         let(:projects) { nil }
@@ -137,6 +162,20 @@ RSpec.describe 'Api::V1::Authenticated', type: :request do
               }
             }
           }
+        run_test!
+      end
+
+      response(403, 'insufficient scope') do
+        let(:Authorization) { "Bearer dev-api-key-12345" }
+        let(:include_archived) { false }
+        let(:projects) { nil }
+        let(:since) { nil }
+        let(:until) { nil }
+        let(:until_date) { nil }
+        let(:start) { nil }
+        let(:end) { nil }
+        let(:start_date) { nil }
+        let(:end_date) { nil }
         run_test!
       end
 
@@ -182,12 +221,14 @@ RSpec.describe 'Api::V1::Authenticated', type: :request do
   path '/api/v1/authenticated/heartbeats/latest' do
     get('Get latest heartbeat') do
       tags 'OAuth2-specific'
-      description 'Returns the absolutely latest heartbeat processed for the user. Requires an OAuth2 access token (Bearer header). ' \
+      description 'Returns the absolutely latest heartbeat processed for the user. Requires an OAuth2 access token with the `read` scope in the Bearer header. ' \
                   'When the user has no non-test heartbeat, the response is `{ "heartbeat": null }`.'
-      security [ { Bearer: [] } ]
+      security [ { OAuth2: [ 'read' ] } ]
       produces 'application/json'
 
       response(200, 'successful') do
+        before { Doorkeeper::AccessToken.by_token('dev-api-key-12345').update!(scopes: 'read') }
+
         let(:Authorization) { "Bearer dev-api-key-12345" }
         schema oneOf: [
           {
@@ -217,6 +258,11 @@ RSpec.describe 'Api::V1::Authenticated', type: :request do
             required: %w[heartbeat]
           }
         ]
+        run_test!
+      end
+
+      response(403, 'insufficient scope') do
+        let(:Authorization) { "Bearer dev-api-key-12345" }
         run_test!
       end
 

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -309,6 +309,20 @@ RSpec.configure do |config|
       paths: {},
       components: {
         securitySchemes: {
+          OAuth2: {
+            type: :oauth2,
+            flows: {
+              authorizationCode: {
+                authorizationUrl: '/oauth/authorize',
+                tokenUrl: '/oauth/token',
+                scopes: {
+                  profile: 'Read profile information',
+                  read: 'Read coding activity data',
+                  admin: 'Access administrative operations'
+                }
+              }
+            }
+          },
           Bearer: {
             type: :http,
             scheme: :bearer,

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -707,9 +707,11 @@ paths:
       tags:
       - OAuth2-specific
       description: Returns detailed information about the currently authenticated
-        user. Requires an OAuth2 access token (Bearer header).
+        user. Requires an OAuth2 access token with the `profile` scope in the Bearer
+        header.
       security:
-      - Bearer: []
+      - OAuth2:
+        - profile
       responses:
         '200':
           description: successful
@@ -743,6 +745,8 @@ paths:
                       trust_value:
                         type: integer
                         example: 0
+        '403':
+          description: insufficient scope
         '401':
           description: unauthorized — Returned when the OAuth access token is missing
             or invalid.
@@ -752,9 +756,10 @@ paths:
       tags:
       - OAuth2-specific
       description: Returns the total coding hours for the authenticated user. Requires
-        an OAuth2 access token (Bearer header).
+        an OAuth2 access token with the `read` scope in the Bearer header.
       security:
-      - Bearer: []
+      - OAuth2:
+        - read
       parameters:
       - name: start_date
         in: query
@@ -787,6 +792,8 @@ paths:
                   total_seconds:
                     type: number
                     example: 153000.0
+        '403':
+          description: insufficient scope
         '401':
           description: 'unauthorized — Returned when the OAuth access token is missing
             or invalid (empty body), or when the authenticated user is banned (`trust_level
@@ -798,9 +805,10 @@ paths:
       tags:
       - OAuth2-specific
       description: Returns the current streak information (days coded in a row). Requires
-        an OAuth2 access token (Bearer header).
+        an OAuth2 access token with the `read` scope in the Bearer header.
       security:
-      - Bearer: []
+      - OAuth2:
+        - read
       responses:
         '200':
           description: successful
@@ -812,6 +820,8 @@ paths:
                   streak_days:
                     type: integer
                     example: 5
+        '403':
+          description: insufficient scope
         '401':
           description: unauthorized — Returned when the OAuth access token is missing
             or invalid.
@@ -821,9 +831,10 @@ paths:
       tags:
       - OAuth2-specific
       description: Returns a list of projects associated with the authenticated user.
-        Requires an OAuth2 access token (Bearer header).
+        Requires an OAuth2 access token with the `read` scope in the Bearer header.
       security:
-      - Bearer: []
+      - OAuth2:
+        - read
       parameters:
       - name: include_archived
         in: query
@@ -909,6 +920,8 @@ paths:
                         archived:
                           type: boolean
                           example: false
+        '403':
+          description: insufficient scope
         '401':
           description: unauthorized — Returned when the OAuth access token is missing
             or invalid.
@@ -941,10 +954,12 @@ paths:
       tags:
       - OAuth2-specific
       description: 'Returns the absolutely latest heartbeat processed for the user.
-        Requires an OAuth2 access token (Bearer header). When the user has no non-test
-        heartbeat, the response is `{ "heartbeat": null }`.'
+        Requires an OAuth2 access token with the `read` scope in the Bearer header.
+        When the user has no non-test heartbeat, the response is `{ "heartbeat": null
+        }`.'
       security:
-      - Bearer: []
+      - OAuth2:
+        - read
       responses:
         '200':
           description: successful
@@ -999,6 +1014,8 @@ paths:
                       example:
                   required:
                   - heartbeat
+        '403':
+          description: insufficient scope
         '401':
           description: unauthorized — Returned when the OAuth access token is missing
             or invalid.
@@ -2054,6 +2071,16 @@ paths:
                     example: U000000
 components:
   securitySchemes:
+    OAuth2:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: "/oauth/authorize"
+          tokenUrl: "/oauth/token"
+          scopes:
+            profile: Read profile information
+            read: Read coding activity data
+            admin: Access administrative operations
     Bearer:
       type: http
       scheme: bearer

--- a/test/controllers/api/v1/authenticated/me_controller_test.rb
+++ b/test/controllers/api/v1/authenticated/me_controller_test.rb
@@ -1,6 +1,105 @@
 require "test_helper"
 
 class Api::V1::Authenticated::MeControllerTest < ActionDispatch::IntegrationTest
+  CODING_DATA_PATHS = [
+    "/api/v1/authenticated/hours",
+    "/api/v1/authenticated/streak",
+    "/api/v1/authenticated/projects",
+    "/api/v1/authenticated/heartbeats/latest"
+  ].freeze
+
+  test "index explicitly requires the profile scope" do
+    user = User.create!(timezone: "UTC")
+    profile_token = create_oauth_access_token(user, scopes: "profile")
+    read_token = create_oauth_access_token(user, scopes: "read")
+
+    get "/api/v1/authenticated/me", headers: bearer_header(profile_token)
+    assert_response :success
+
+    get "/api/v1/authenticated/me", headers: bearer_header(read_token)
+    assert_response :forbidden
+    assert_includes response.headers["WWW-Authenticate"], 'error="insufficient_scope"'
+  end
+
+  test "coding data endpoints explicitly require the read scope" do
+    user = User.create!(timezone: "UTC")
+    profile_token = create_oauth_access_token(user, scopes: "profile")
+    read_token = create_oauth_access_token(user, scopes: "read")
+
+    CODING_DATA_PATHS.each do |path|
+      get path, headers: bearer_header(profile_token)
+      assert_response :forbidden, "expected profile-only token to be forbidden for #{path}"
+      assert_includes response.headers["WWW-Authenticate"], 'error="insufficient_scope"'
+
+      get path, headers: bearer_header(read_token)
+      assert_response :success, "expected read-only token to succeed for #{path}"
+    end
+  end
+
+  test "missing revoked and expired credentials remain unauthorized" do
+    user = User.create!(timezone: "UTC")
+    revoked_token = create_oauth_access_token(user, scopes: "profile")
+    revoked_token.revoke
+    expired_token = create_oauth_access_token(user, scopes: "profile", created_at: 2.hours.ago, expires_in: 1.hour)
+
+    [ nil, revoked_token, expired_token ].each do |token|
+      headers = token ? bearer_header(token) : {}
+      get "/api/v1/authenticated/me", headers: headers
+      assert_response :unauthorized
+    end
+  end
+
+  test "protected resources accept only bearer authorization credentials" do
+    user = User.create!(timezone: "UTC")
+    access_token = create_oauth_access_token(user, scopes: "profile")
+
+    get "/api/v1/authenticated/me", headers: bearer_header(access_token)
+    assert_response :success
+
+    get "/api/v1/authenticated/me", params: { access_token: access_token.token }
+    assert_response :unauthorized
+
+    get "/api/v1/authenticated/me", params: { bearer_token: access_token.token }
+    assert_response :unauthorized
+
+    get "/api/v1/authenticated/me", params: { access_token: access_token.token }, as: :json
+    assert_response :unauthorized
+
+    get "/api/v1/authenticated/me", params: { bearer_token: access_token.token }, as: :json
+    assert_response :unauthorized
+  end
+
+  test "OAuth token and revocation endpoints continue to accept body credentials" do
+    user = User.create!(timezone: "UTC")
+    application = create_oauth_application(user, scopes: "profile")
+    application_secret = application.plaintext_secret
+    grant = Doorkeeper::AccessGrant.create!(
+      application: application,
+      resource_owner_id: user.id,
+      expires_in: 10.minutes,
+      redirect_uri: application.redirect_uri,
+      scopes: "profile"
+    )
+
+    post "/oauth/token", params: {
+      grant_type: "authorization_code",
+      code: grant.token,
+      client_id: application.uid,
+      client_secret: application_secret,
+      redirect_uri: application.redirect_uri
+    }
+    assert_response :success
+    issued_token = response.parsed_body.fetch("access_token")
+
+    post "/oauth/revoke", params: {
+      token: issued_token,
+      client_id: application.uid,
+      client_secret: application_secret
+    }
+    assert_response :success
+    assert Doorkeeper::AccessToken.by_token(issued_token).revoked?
+  end
+
   test "index allows red users" do
     user = User.create!(timezone: "UTC", trust_level: :red)
     access_token = create_oauth_access_token(user)
@@ -22,19 +121,28 @@ class Api::V1::Authenticated::MeControllerTest < ActionDispatch::IntegrationTest
 
   private
 
-  def create_oauth_access_token(user, scopes: "profile")
-    application = user.oauth_applications.create!(
+  def bearer_header(access_token)
+    { "Authorization" => "Bearer #{access_token.token}" }
+  end
+
+  def create_oauth_application(user, scopes:)
+    user.oauth_applications.create!(
       name: "Test App",
       redirect_uri: "https://example.com/callback",
       scopes: scopes,
       confidential: true
     )
+  end
+
+  def create_oauth_access_token(user, scopes: "profile", **attributes)
+    application = create_oauth_application(user, scopes: scopes)
 
     Doorkeeper::AccessToken.create!(
       application: application,
       resource_owner_id: user.id,
       scopes: scopes,
-      expires_in: 16.years
+      expires_in: 16.years,
+      **attributes
     )
   end
 end

--- a/test/controllers/api/v1/stats_controller_test.rb
+++ b/test/controllers/api/v1/stats_controller_test.rb
@@ -185,8 +185,20 @@ class Api::V1::StatsControllerTest < ActionDispatch::IntegrationTest
     get "/api/v1/stats", headers: { "Authorization" => "Bearer #{admin_api_key.token}" }
     assert_response :success
 
+    get "/api/v1/stats", headers: { "Authorization" => "bearer #{admin_api_key.token}" }
+    assert_response :success
+
     get "/api/v1/stats", params: { api_key: admin_api_key.token }
     assert_response :unauthorized
+  end
+
+  test "aggregate stats rejects valid admin API keys under non-Bearer schemes" do
+    admin_api_key = create_admin_api_key
+
+    [ "Basic #{admin_api_key.token}", "Token #{admin_api_key.token}", admin_api_key.token ].each do |authorization|
+      get "/api/v1/stats", headers: { "Authorization" => authorization }
+      assert_response :unauthorized
+    end
   end
 
   test "aggregate stats rejects revoked admin API keys" do
@@ -212,8 +224,25 @@ class Api::V1::StatsControllerTest < ActionDispatch::IntegrationTest
     Flipper.enable(:allow_legacy_stats_api_key)
     get "/api/v1/stats", headers: { "Authorization" => "Bearer #{legacy_key}" }
     assert_response :success
+    get "/api/v1/stats", headers: { "Authorization" => "bearer #{legacy_key}" }
+    assert_response :success
     get "/api/v1/stats", params: { api_key: legacy_key }
     assert_response :success
+
+    [ "Basic #{legacy_key}", "Token #{legacy_key}", legacy_key, "Bearer\t#{legacy_key}" ].each do |authorization|
+      get "/api/v1/stats", headers: { "Authorization" => authorization }
+      assert_response :unauthorized
+    end
+
+    [ "", " ", "Token malformed" ].each do |authorization|
+      get "/api/v1/stats",
+        params: { api_key: legacy_key },
+        headers: { "Authorization" => authorization }
+      assert_response :unauthorized
+    end
+
+    get "/api/v1/users/lookup_email/nobody@example.com", params: { api_key: legacy_key }
+    assert_response :unauthorized
 
     admin_api_key = create_admin_api_key
     get "/api/v1/stats", params: { api_key: admin_api_key.token }


### PR DESCRIPTION
## Summary of the problem

- Authenticated OAuth endpoints inherited the default profile scope, which allowed profile-only tokens to read coding data
- Protected resources also accepted OAuth tokens from request parameters and stats authentication accepted valid credentials under unsupported schemes.

All of these things have been issues since 2025!

## Describe your changes

- Require the profile scope for the current-user endpoint and the read scope for each coding-data endpoint
- Restrict Doorkeeper protected-resource extraction to the Bearer header

## Screenshots / Media

N/A