### PR TITLE
Stabilise admin heartbeat pagination ordering

### DIFF
--- a/app/controllers/concerns/api/admin/v1/user_utilities.rb
+++ b/app/controllers/concerns/api/admin/v1/user_utilities.rb
@@ -306,7 +306,7 @@ module Api
 
           total_count = query.count
           source_types = Heartbeat.source_types.invert
-          rows = query.order(time: :asc).limit(limit).offset(offset).pluck(*HEARTBEAT_RESPONSE_COLUMNS)
+          rows = query.order(time: :asc, id: :asc).limit(limit).offset(offset).pluck(*HEARTBEAT_RESPONSE_COLUMNS)
           ja4s_by_id = Ja4.where(id: rows.filter_map(&:last).uniq).index_by(&:id)
           heartbeats = rows.map do |id, time, created_at, lineno, cursorpos, is_write, project, language, entity, branch, category, dependencies, editor, machine, operating_system, type, project_root_count, user_agent, line_additions, line_deletions, ip_address, lines, source_type, ja4_id|
             {


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
hbs were ordered with no order as timestamps could be the same sometimes, so pretty much you could find the same heartbeat in another page when you already used the same hb in the other page


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
do the same as we do in heartbeattable.rb or any other function that calculates duration windows, where hbs are ordered by (time, id), this one will now do (user_id, time, id)

## Screenshots / Media
<!-- If there are any visual changes, please attach images, videos, or gifs. -->
mrph meow
