### PR TITLE
Preserve the image commit in the footer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -196,7 +196,7 @@ COPY --from=build --chown=1000:1000 /rails/storage /rails/storage
 COPY --from=build --chown=1000:1000 /rails/tmp /rails/tmp
 
 ARG SOURCE_COMMIT=unknown
-ENV SOURCE_COMMIT="${SOURCE_COMMIT}"
+RUN printf '%s\n' "$SOURCE_COMMIT" > REVISION
 
 USER 1000:1000
 

--- a/config/initializers/git_version.rb
+++ b/config/initializers/git_version.rb
@@ -1,4 +1,9 @@
-source_commit = ENV["SOURCE_COMMIT"].presence
+revision_path = Rails.root.join("REVISION") # this used to be SOURCE_COMMIT, but Coolify overrides it as HEAD
+source_commit = if revision_path.file?
+  revision_path.read.strip.presence
+else
+  ENV["SOURCE_COMMIT"].presence
+end
 
 if source_commit
   git_hash = source_commit


### PR DESCRIPTION
## Summary of the problem

Coolify sets `SOURCE_COMMIT` to `HEAD` at runtime, overriding the commit hash baked into the production image. This makes the footer display `Build HEAD` rather than the deployed commit 😭 

## Describe your changes

Store the build commit in a `REVISION` file within the image, then make the initializer read the hash from that

## Screenshots / Media

N/A