### PR TITLE
Add Ctrl+F search to projects page

### DIFF
--- a/app/javascript/pages/Projects/Index.svelte
+++ b/app/javascript/pages/Projects/Index.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { Deferred, Link, router } from "@inertiajs/svelte";
   import Search from "hcicons-svelte/search";
+  import { onDestroy, onMount, tick } from "svelte";
+  import { ChevronDown, ChevronUp, Icon, XMark } from "svelte-hero-icons";
   import { WindowVirtualizer } from "virtua/svelte";
   import Button from "../../components/Button.svelte";
   import Modal from "../../components/Modal.svelte";
@@ -88,8 +90,69 @@
   const PROJECT_ROW_ESTIMATE = 208;
 
   let projectGridContainer: HTMLDivElement | undefined = $state();
+  let projectVirtualizer: WindowVirtualizer<ProjectCardType[]> | undefined =
+    $state();
   let projectColumnCount = $state(1);
   let searchQuery = $state("");
+  let searchOpen = $state(false);
+  let searchInput: HTMLInputElement | undefined = $state();
+  let currentMatchIndex = $state(0);
+
+  const normalizedSearchQuery = $derived(
+    searchQuery.trim().toLocaleLowerCase(),
+  );
+  const matchingProjects = $derived(
+    normalizedSearchQuery
+      ? (projects_data?.projects || []).filter((project) =>
+          project.name.toLocaleLowerCase().includes(normalizedSearchQuery),
+        )
+      : [],
+  );
+  const visibleProjects = $derived(
+    normalizedSearchQuery ? matchingProjects : projects_data?.projects || [],
+  );
+
+  const openSearch = async () => {
+    searchOpen = true;
+    await tick();
+    searchInput?.focus();
+    searchInput?.select();
+  };
+
+  const closeSearch = () => {
+    searchOpen = false;
+    searchQuery = "";
+    currentMatchIndex = 0;
+  };
+
+  const navigateMatches = (direction: 1 | -1) => {
+    if (matchingProjects.length === 0) return;
+
+    currentMatchIndex =
+      (currentMatchIndex + direction + matchingProjects.length) %
+      matchingProjects.length;
+    projectVirtualizer?.scrollToIndex(
+      Math.floor(currentMatchIndex / projectColumnCount),
+      { align: "center", smooth: true },
+    );
+  };
+
+  const handleSearchKeydown = (event: KeyboardEvent) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      navigateMatches(event.shiftKey ? -1 : 1);
+    }
+  };
+
+  const handlePageKeydown = (event: KeyboardEvent) => {
+    if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === "f") {
+      event.preventDefault();
+      void openSearch();
+    } else if (event.key === "Escape" && searchOpen) {
+      event.preventDefault();
+      closeSearch();
+    }
+  };
 
   const updateProjectColumnCount = () => {
     if (!projectGridContainer) return;
@@ -105,17 +168,22 @@
   };
 
   const projectRows = $derived.by(() => {
-    const query = searchQuery.trim().toLocaleLowerCase();
-    const projects = (projects_data?.projects || []).filter((project) =>
-      project.name.toLocaleLowerCase().includes(query),
-    );
     const rows: ProjectCardType[][] = [];
 
-    for (let index = 0; index < projects.length; index += projectColumnCount) {
-      rows.push(projects.slice(index, index + projectColumnCount));
+    for (
+      let index = 0;
+      index < visibleProjects.length;
+      index += projectColumnCount
+    ) {
+      rows.push(visibleProjects.slice(index, index + projectColumnCount));
     }
 
     return rows;
+  });
+
+  $effect(() => {
+    searchQuery;
+    currentMatchIndex = 0;
   });
 
   $effect(() => {
@@ -128,6 +196,9 @@
 
     return () => observer.disconnect();
   });
+
+  onMount(() => document.addEventListener("keydown", handlePageKeydown));
+  onDestroy(() => document.removeEventListener("keydown", handlePageKeydown));
 
   const changeInterval = (
     nextInterval: string,
@@ -206,6 +277,65 @@
   <title>{page_title}</title>
 </svelte:head>
 
+{#if searchOpen}
+  <div
+    role="search"
+    aria-label="Find projects"
+    class="fixed right-4 top-4 z-50 flex h-10 w-[min(22rem,calc(100vw-2rem))] items-center rounded-lg border border-surface-200 bg-dark px-2 shadow-xl shadow-black/30"
+  >
+    <label for="project-search" class="sr-only">Find projects</label>
+    <input
+      bind:this={searchInput}
+      id="project-search"
+      name="project-search"
+      type="text"
+      bind:value={searchQuery}
+      onkeydown={handleSearchKeydown}
+      placeholder="Find in projects"
+      autocomplete="off"
+      class="h-full min-w-0 flex-1 border-0 bg-transparent px-2 text-sm text-surface-content placeholder:text-muted focus:outline-none focus:ring-0"
+    />
+    <span
+      aria-live="polite"
+      class="w-14 shrink-0 text-center text-xs tabular-nums text-muted"
+    >
+      {matchingProjects.length > 0
+        ? currentMatchIndex + 1
+        : 0}/{matchingProjects.length}
+    </span>
+    <Button
+      type="button"
+      unstyled
+      aria-label="Previous match"
+      title="Previous match (Shift+Enter)"
+      class="flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center rounded-full text-muted hover:bg-surface-200 hover:text-surface-content focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
+      onclick={() => navigateMatches(-1)}
+    >
+      <Icon src={ChevronUp} size="17" />
+    </Button>
+    <Button
+      type="button"
+      unstyled
+      aria-label="Next match"
+      title="Next match (Enter)"
+      class="flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center rounded-full text-muted hover:bg-surface-200 hover:text-surface-content focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
+      onclick={() => navigateMatches(1)}
+    >
+      <Icon src={ChevronDown} size="17" />
+    </Button>
+    <Button
+      type="button"
+      unstyled
+      aria-label="Close search"
+      title="Close (Escape)"
+      class="flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center rounded-full text-muted hover:bg-surface-200 hover:text-surface-content focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
+      onclick={closeSearch}
+    >
+      <Icon src={XMark} size="18" />
+    </Button>
+  </div>
+{/if}
+
 <div>
   <div class="mb-4 flex flex-wrap items-center justify-between gap-4">
     <div class="flex items-center gap-4">
@@ -233,21 +363,35 @@
 
   <div class="flex items-center gap-3">
     <div class="relative min-w-0 flex-1">
-      <label for="project-search" class="sr-only">Search projects</label>
+      <label for="project-filter" class="sr-only">Search projects</label>
       <Search
         size={24}
         aria-hidden="true"
         class="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-muted"
       />
       <input
-        id="project-search"
-        name="project-search"
+        id="project-filter"
+        name="project-filter"
         type="search"
         bind:value={searchQuery}
         placeholder="Search projects"
         class="h-10 w-full rounded-lg border border-surface-200 bg-input pl-11 pr-4 text-base text-surface-content placeholder:text-muted focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30"
       />
     </div>
+
+    <Button
+      type="button"
+      variant="surface"
+      class="h-10 shrink-0 gap-2 px-3"
+      onclick={openSearch}
+    >
+      <Search size={18} aria-hidden="true" class="text-muted" />
+      <span>Find</span>
+      <kbd
+        class="hidden rounded border border-surface-300 bg-dark px-1.5 py-0.5 font-sans text-[10px] font-medium text-muted sm:inline"
+        >Ctrl F</kbd
+      >
+    </Button>
 
     <div class="w-44 shrink-0 sm:w-56">
       <IntervalSelect
@@ -343,6 +487,7 @@
           {:else}
             <div bind:this={projectGridContainer} class="mt-6">
               <WindowVirtualizer
+                bind:this={projectVirtualizer}
                 data={projectRows}
                 getKey={(row) => row[0]?.id || "empty-row"}
                 itemSize={PROJECT_ROW_ESTIMATE}
@@ -354,21 +499,40 @@
                     style={`grid-template-columns: repeat(${projectColumnCount}, minmax(0, 1fr));`}
                   >
                     {#each row as project (project.id)}
-                      <ProjectCard
-                        {project}
-                        showArchived={show_archived}
-                        {intervalQueryString}
-                        onEditMapping={openMappingEditor}
-                        onArchive={openStatusChangeModal}
-                        onShowBrokenInfo={() => (brokenNameModalOpen = true)}
-                        editing={editingProjectKey === project.project_key}
-                        repoUrlError={errors.repo_url_project_name ===
-                        project.project_key
-                          ? errors.repo_url
-                          : undefined}
-                        bind:repoUrlDraft
-                        onCancelEdit={closeMappingEditor}
-                      />
+                      <div
+                        class:rounded-2xl={searchQuery &&
+                          matchingProjects[currentMatchIndex]?.id ===
+                            project.id}
+                        class:ring-2={searchQuery &&
+                          matchingProjects[currentMatchIndex]?.id ===
+                            project.id}
+                        class:ring-primary={searchQuery &&
+                          matchingProjects[currentMatchIndex]?.id ===
+                            project.id}
+                        class:ring-offset-2={searchQuery &&
+                          matchingProjects[currentMatchIndex]?.id ===
+                            project.id}
+                        class:ring-offset-surface={searchQuery &&
+                          matchingProjects[currentMatchIndex]?.id ===
+                            project.id}
+                      >
+                        <ProjectCard
+                          {project}
+                          showArchived={show_archived}
+                          {intervalQueryString}
+                          onEditMapping={openMappingEditor}
+                          onArchive={openStatusChangeModal}
+                          onShowBrokenInfo={() => (brokenNameModalOpen = true)}
+                          editing={editingProjectKey === project.project_key}
+                          repoUrlError={errors.repo_url_project_name ===
+                          project.project_key
+                            ? errors.repo_url
+                            : undefined}
+                          highlightQuery={searchQuery}
+                          bind:repoUrlDraft
+                          onCancelEdit={closeMappingEditor}
+                        />
+                      </div>
                     {/each}
                   </div>
                 {/snippet}

--- a/app/javascript/pages/Projects/components/ProjectCard.svelte
+++ b/app/javascript/pages/Projects/components/ProjectCard.svelte
@@ -22,6 +22,7 @@
     repoUrlError,
     repoUrlDraft = $bindable(""),
     onCancelEdit,
+    highlightQuery = "",
   }: {
     project: ProjectCard;
     showArchived: boolean;
@@ -33,6 +34,7 @@
     repoUrlError?: string;
     repoUrlDraft?: string;
     onCancelEdit: () => void;
+    highlightQuery?: string;
   } = $props();
 
   const key = $derived(project.url_safe ? project.project_key : null);
@@ -52,6 +54,43 @@
       ? `${showPath}${intervalQueryString ? `?${intervalQueryString}` : ""}`
       : null,
   );
+  const highlightedNameParts = $derived.by(() => {
+    const query = highlightQuery.trim();
+    if (!query) return [{ text: project.name, highlighted: false }];
+
+    const parts: { text: string; highlighted: boolean }[] = [];
+    const normalizedName = project.name.toLocaleLowerCase();
+    const normalizedQuery = query.toLocaleLowerCase();
+    let cursor = 0;
+    let matchStart = normalizedName.indexOf(normalizedQuery);
+
+    while (matchStart >= 0) {
+      if (matchStart > cursor) {
+        parts.push({
+          text: project.name.slice(cursor, matchStart),
+          highlighted: false,
+        });
+      }
+      const matchEnd = matchStart + query.length;
+      parts.push({
+        text: project.name.slice(matchStart, matchEnd),
+        highlighted: true,
+      });
+      cursor = matchEnd;
+      matchStart = normalizedName.indexOf(normalizedQuery, cursor);
+    }
+
+    if (cursor < project.name.length) {
+      parts.push({
+        text: project.name.slice(cursor),
+        highlighted: false,
+      });
+    }
+
+    return parts.length > 0
+      ? parts
+      : [{ text: project.name, highlighted: false }];
+  });
 
   const actionClass =
     "inline-flex h-10 w-10 items-center justify-center rounded-xl border border-surface-200/60 bg-surface-content/5 text-surface-content/70 shadow-sm transition-colors duration-200 ease-out hover:bg-surface-content/10 hover:text-surface-content focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 cursor-pointer";
@@ -77,7 +116,15 @@
         class="min-w-0 flex-1 truncate text-xl font-bold tracking-tight text-surface-content"
         title={project.name}
       >
-        {project.name}
+        {#each highlightedNameParts as part}
+          {#if part.highlighted}
+            <mark class="rounded-sm bg-yellow px-0.5 text-black"
+              >{part.text}</mark
+            >
+          {:else}
+            {part.text}
+          {/if}
+        {/each}
       </h3>
       <p class="shrink-0 text-lg font-semibold tabular-nums text-primary/80">
         {project.duration_label}

--- a/test/system/projects_test.rb
+++ b/test/system/projects_test.rb
@@ -57,6 +57,32 @@ class ProjectsTest < ApplicationSystemTestCase
     assert_no_text "recent-project"
   end
 
+  test "finds projects with the browser find shortcut" do
+    create_project_heartbeats(@user, "alpha-project", started_at: 2.days.ago.noon)
+    create_project_heartbeats(@user, "beta-project", started_at: 2.days.ago.change(hour: 14))
+    DashboardRollupRefreshService.new(user: @user).call
+
+    visit my_projects_path
+    assert_text "alpha-project"
+    assert_text "beta-project"
+    assert_selector "#project-filter[placeholder='Search projects']"
+
+    page.driver.browser.action.key_down(:control).send_keys("f").key_up(:control).perform
+
+    assert_selector "[role='search'][aria-label='Find projects']"
+    fill_in "Find projects", with: "alpha"
+    assert_text "1/1"
+    assert_text "alpha-project"
+    assert_selector "mark.bg-yellow", text: "alpha"
+    assert_no_text "beta-project"
+
+    find("#project-search").send_keys(:escape)
+
+    assert_no_selector "[role='search'][aria-label='Find projects']"
+    assert_text "alpha-project"
+    assert_text "beta-project"
+  end
+
   test "opens projects whose names contain reserved URL characters" do
     project_name = "folder/café ?# 100%25"
     create_project_heartbeats(@user, project_name, started_at: 2.days.ago.noon)


### PR DESCRIPTION
## Summary of the problem
The projects page has an inline filter but does not support the familiar browser find workflow for quickly navigating project matches.

## Describe your changes
Adds a compact Chrome-style Ctrl+F and Cmd+F overlay while preserving the existing search bar. Both controls share the same query, show match counts, support previous and next navigation and highlight matching project name text in yellow.

## Screenshots / Media

https://ampcode.com/user-content/artifacts/db724bd693d7b8ea9ca6da2e8f715b691cd0723a31fcdb14c7cb399276102116-file.webm