### PR TITLE
Remove redundant test coverage

### DIFF
--- a/test/integration/email_login_test.rb
+++ b/test/integration/email_login_test.rb
@@ -72,19 +72,6 @@ class EmailLoginTest < ActionDispatch::IntegrationTest
     assert_nil session[:user_id]
   end
 
-  test "expired email token does not sign user in" do
-    user = User.create!(timezone: "UTC")
-    token = user.sign_in_tokens.create!(
-      auth_type: :email,
-      expires_at: 1.hour.ago
-    )
-
-    get auth_token_path(token: token.token)
-
-    assert_redirected_to root_path
-    assert_nil session[:user_id]
-  end
-
   test "invalid token shows error" do
     get auth_token_path(token: "completely-bogus-token")
 

--- a/test/services/wakatime_user_agent_parser_test.rb
+++ b/test/services/wakatime_user_agent_parser_test.rb
@@ -12,7 +12,7 @@ class WakatimeUserAgentParserTest < Minitest::Test
     result = WakatimeUserAgentParser.parse(user_agent)
     assert_equal "macos", result[:os]
     assert_equal "vscode", result[:editor]
-    assert_nil result[:error]
+    assert_nil result[:err]
   end
 
   def test_parse_user_agent_without_a_runtime_token
@@ -40,7 +40,7 @@ class WakatimeUserAgentParserTest < Minitest::Test
     result = WakatimeUserAgentParser.parse(user_agent)
     assert_equal "macos", result[:os]
     assert_equal "github-desktop", result[:editor]
-    assert_nil result[:error]
+    assert_nil result[:err]
   end
 
   def test_parse_user_agent_with_Figma
@@ -48,7 +48,7 @@ class WakatimeUserAgentParserTest < Minitest::Test
     result = WakatimeUserAgentParser.parse(user_agent)
     assert_equal "macos", result[:os]
     assert_equal "figma", result[:editor]
-    assert_nil result[:error]
+    assert_nil result[:err]
   end
 
   def test_parse_user_agent_with_Terminal
@@ -56,7 +56,7 @@ class WakatimeUserAgentParserTest < Minitest::Test
     result = WakatimeUserAgentParser.parse(user_agent)
     assert_equal "macos", result[:os]
     assert_equal "terminal", result[:editor]
-    assert_nil result[:error]
+    assert_nil result[:err]
   end
 
   def test_parse_user_agent_with_vim
@@ -64,7 +64,7 @@ class WakatimeUserAgentParserTest < Minitest::Test
     result = WakatimeUserAgentParser.parse(user_agent)
     assert_equal "macos", result[:os]
     assert_equal "vim", result[:editor]
-    assert_nil result[:error]
+    assert_nil result[:err]
   end
 
   def test_parse_user_agent_with_Windows
@@ -72,7 +72,7 @@ class WakatimeUserAgentParserTest < Minitest::Test
     result = WakatimeUserAgentParser.parse(user_agent)
     assert_equal "windows", result[:os]
     assert_equal "vscode", result[:editor]
-    assert_nil result[:error]
+    assert_nil result[:err]
   end
 
   def test_parse_user_agent_with_Cursor
@@ -80,7 +80,7 @@ class WakatimeUserAgentParserTest < Minitest::Test
     result = WakatimeUserAgentParser.parse(user_agent)
     assert_equal "macos", result[:os]
     assert_equal "cursor", result[:editor]
-    assert_nil result[:error]
+    assert_nil result[:err]
   end
 
   def test_parse_user_agent_separates_ai_model_from_claude_code_editor
@@ -613,7 +613,7 @@ class WakatimeUserAgentParserTest < Minitest::Test
     result = WakatimeUserAgentParser.parse(user_agent)
     assert_equal "linux", result[:os]
     assert_equal "firefox", result[:editor]
-    assert_nil result[:error]
+    assert_nil result[:err]
   end
 
   def test_parse_user_agent_uses_plugin_fallback_and_skips_middleware

--- a/test/system/heartbeat_export_test.rb
+++ b/test/system/heartbeat_export_test.rb
@@ -69,13 +69,6 @@ class HeartbeatExportTest < ApplicationSystemTestCase
     end
   end
 
-  test "export is not available for restricted users" do
-    @user.update!(trust_level: :red)
-    visit my_settings_imports_exports_path
-
-    assert_text "Data export is currently restricted for this account."
-  end
-
   test "export request is rejected when signed-in user has no email address" do
     user_without_email = users(:three)
     create_heartbeat(user_without_email, Time.current - 1.hour, "src/no_email.rb")


### PR DESCRIPTION
## Summary of the problem

The test suite contains duplicate coverage for expired sign-in tokens and restricted data exports. Several user agent parser assertions also check a result key that does not exist, so they cannot detect parser errors.

## Describe your changes

Remove the two tests whose behaviour is already covered by stronger tests at the same layer. Update the user agent parser assertions to check the parser's actual `err` result key.

## Screenshots / Media

Not applicable. This is a test-only change.