### PR TITLE
Fix production Bundler installation

### DIFF
--- a/.agents/setup
+++ b/.agents/setup
@@ -30,6 +30,13 @@ if ! command -v docker >/dev/null 2>&1; then
   sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 fi
 
+setup_user="$(id -un)"
+getent group docker >/dev/null || sudo groupadd --system docker
+if ! id -nG "$setup_user" | tr ' ' '\n' | grep -Fqx docker; then
+  echo "==> Granting $setup_user access to Docker"
+  sudo usermod -aG docker "$setup_user"
+fi
+
 if ! sudo docker info >/dev/null 2>&1; then
   echo "==> Starting Docker"
   if systemctl cat amp-svc-docker-daemon.service >/dev/null 2>&1; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -103,7 +103,8 @@ COPY Gemfile Gemfile.lock ./
 RUN --mount=type=cache,target=/root/.bundle/cache \
     --mount=type=cache,target=/usr/local/bundle/ruby/4.0.0/cache \
     BUNDLER_VERSION="$(awk 'END { print $1 }' Gemfile.lock)" && \
-    gem list --installed bundler --version "$BUNDLER_VERSION" && \
+    (gem list --installed bundler --version "$BUNDLER_VERSION" || \
+      gem install bundler --version "$BUNDLER_VERSION" --no-document) && \
     bundle "_${BUNDLER_VERSION}_" install && \
     rm -rf "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git
 


### PR DESCRIPTION
## Summary of the problem

The production image build assumes that the Ruby base image already contains the exact Bundler version recorded in the lockfile. Updating Bundler to 4.0.18 therefore stops the build before dependencies are installed.

Amp orb users are also excluded from the Docker group, so later development commands cannot access Docker without elevated privileges.

## Describe your changes

Conditionally install the lockfile-selected Bundler version when it is missing, while retaining the existing version when it matches.

Ensure the Docker group exists and add the setup user to it so fresh Amp sessions can access the secured Docker socket.

## Screenshots / Media

No visual changes.