### PR TITLE
Simplify LayerChart pie rendering

### DIFF
--- a/.amp/services.yaml
+++ b/.amp/services.yaml
@@ -1,7 +1,7 @@
 services:
   hackatime:
-    command: sudo docker compose up -d db && sudo env PUBLIC_URL="$PUBLIC_URL" docker compose --profile portal up --no-deps portal
+    command: sudo docker compose up -d db && sudo docker build -t repo-portal-production . && (sudo docker rm -f repo-portal-production >/dev/null 2>&1 || true) && exec sudo docker run --rm --name repo-portal-production --network repo_default -p 3001:80 --env-file .env -e RAILS_ENV=production -e PORT=80 -e PUBLIC_URL="$PUBLIC_URL" -e POOL_DATABASE_URL=postgres://postgres:secureorpheus123@db:5432/app_development -e DATABASE_URL=postgres://postgres:secureorpheus123@db:5432/app_development -e SAILORS_LOG_DATABASE_URL=postgres://postgres:secureorpheus123@db:5432/app_development -e S3_ENDPOINT=http://127.0.0.1 -e S3_BUCKET=dummy -e S3_ACCESS_KEY_ID=dummy -e S3_SECRET_ACCESS_KEY=dummy -e MAXMIND_ACCOUNT_ID= -e MAXMIND_LICENSE_KEY= repo-portal-production
     port: 3001
     portal:
       title: Hackatime
-      description: Use /__dev/log-me-in/test@example.com to sign in as the seeded development user.
+      description: Production Rails, production Vite assets and Inertia SSR against the seeded local database.

--- a/.amp/services.yaml
+++ b/.amp/services.yaml
@@ -1,7 +1,7 @@
 services:
   hackatime:
-    command: sudo docker compose up -d db && sudo docker build -t repo-portal-production . && (sudo docker rm -f repo-portal-production >/dev/null 2>&1 || true) && exec sudo docker run --rm --name repo-portal-production --network repo_default -p 3001:80 --env-file .env -e RAILS_ENV=production -e PORT=80 -e PUBLIC_URL="$PUBLIC_URL" -e POOL_DATABASE_URL=postgres://postgres:secureorpheus123@db:5432/app_development -e DATABASE_URL=postgres://postgres:secureorpheus123@db:5432/app_development -e SAILORS_LOG_DATABASE_URL=postgres://postgres:secureorpheus123@db:5432/app_development -e S3_ENDPOINT=http://127.0.0.1 -e S3_BUCKET=dummy -e S3_ACCESS_KEY_ID=dummy -e S3_SECRET_ACCESS_KEY=dummy -e MAXMIND_ACCOUNT_ID= -e MAXMIND_LICENSE_KEY= repo-portal-production
+    command: sudo docker compose up -d db && sudo env PUBLIC_URL="$PUBLIC_URL" docker compose --profile portal up --no-deps portal
     port: 3001
     portal:
       title: Hackatime
-      description: Production Rails, production Vite assets and Inertia SSR against the seeded local database.
+      description: Use /__dev/log-me-in/test@example.com to sign in as the seeded development user.

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,7 @@ RUN apt-get update -qq && \
 FROM frontend-base AS javascript-dependencies
 
 COPY package.json bun.lock bunfig.toml ./
+COPY patches patches
 RUN --mount=type=cache,target=/root/.bun/install/cache \
     bun i --frozen-lockfile --linker=isolated && \
     mkdir -p node_modules/.vite-client node_modules/.vite-ssr node_modules/.vite-temp

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -29,6 +29,7 @@ WORKDIR /app
 
 # Install npm dependencies for Vite.
 COPY package.json bun.lock ./
+COPY patches patches
 RUN bun install
 
 # Make Spline Sans available to librsvg/libvips via fontconfig. Pango does not

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -477,6 +477,30 @@ html[data-theme="rose_pine_dawn"] {
   height: 100% !important;
 }
 
+.hackatime-pie-chart {
+  min-width: 0;
+  position: relative;
+}
+
+.hackatime-pie-chart .lc-tooltip-context,
+.hackatime-pie-chart .lc-tooltip-context-container,
+.hackatime-pie-chart .lc-layout-svg {
+  position: absolute;
+}
+
+.hackatime-pie-chart .lc-layout-svg {
+  inset: 0;
+}
+
+.hackatime-pie-chart .lc-legend-container[data-placement="bottom"] {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  max-width: 100%;
+  min-width: 0;
+  transform: translateX(-50%);
+}
+
 .lc-tooltip-container[data-variant="default"] {
   background-color: color-mix(
     in oklab,

--- a/app/javascript/pages/Home/signedIn/HorizontalBarList.svelte
+++ b/app/javascript/pages/Home/signedIn/HorizontalBarList.svelte
@@ -34,7 +34,7 @@
           </div>
           <div class="flex-1 relative">
             <div
-              class="bg-primary rounded-md h-6 flex items-center justify-end px-3 transition-all duration-500 ease-out"
+              class="bg-primary rounded-md h-6 flex items-center justify-end px-3"
               style={`width:${Math.max(barWidth(seconds), 15)}%`}
             >
               <span class="text-xs font-mono text-on-primary whitespace-nowrap">

--- a/app/javascript/pages/Home/signedIn/PieChart.svelte
+++ b/app/javascript/pages/Home/signedIn/PieChart.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { onMount } from "svelte";
   import { PieChart } from "layerchart/svg";
   import { secondsToDisplay, CHART_COLORS as FALLBACK_COLORS } from "./utils";
 
@@ -20,16 +19,6 @@
     Object.entries(stats).map(([name, value]) => ({ name, value })),
   );
 
-  let hasMounted = $state(false);
-  let interactiveReady = $state(false);
-
-  onMount(() => {
-    hasMounted = true;
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => (interactiveReady = true));
-    });
-  });
-
   const colors = $derived.by(() => {
     if (!Object.keys(colorMap).length) return FALLBACK_COLORS;
     let idx = 0;
@@ -43,120 +32,46 @@
     Math.min(96, 24 + Math.max(1, Math.ceil(data.length / 4)) * 18),
   );
 
-  const staticArcs = $derived.by(() => {
-    const radius = (CHART_HEIGHT - legendPadding) / 2;
-    const total = data.reduce((sum, item) => sum + Math.max(0, item.value), 0);
-    if (total === 0) return [];
-
-    const arcs = Array<{ path: string; color: string }>(data.length);
-    let angle = 0;
-    const indices = data
-      .map((_, index) => index)
-      .sort((a, b) => data[b].value - data[a].value || a - b);
-
-    for (const index of indices) {
-      const start = angle;
-      const sweep = (Math.max(0, data[index].value) / total) * Math.PI * 2;
-      const end = start + sweep;
-      angle = end;
-
-      const startX = radius * Math.cos(start - Math.PI / 2);
-      const startY = radius * Math.sin(start - Math.PI / 2);
-      const endX = radius * Math.cos(end - Math.PI / 2);
-      const endY = radius * Math.sin(end - Math.PI / 2);
-      const path =
-        sweep >= Math.PI * 2 - Number.EPSILON
-          ? `M0,${-radius} A${radius},${radius} 0 1 1 0,${radius} A${radius},${radius} 0 1 1 0,${-radius} Z`
-          : `M0,0 L${startX},${startY} A${radius},${radius} 0 ${sweep > Math.PI ? 1 : 0} 1 ${endX},${endY} Z`;
-      arcs[index] = { path, color: colors[index % colors.length] };
-    }
-
-    return arcs;
-  });
-
   const formatDuration = (v: number | null | undefined) =>
     secondsToDisplay(v ?? 0);
 </script>
 
 <div
-  class="bg-dark/50 border border-surface-200 rounded-xl p-6 flex flex-col h-full"
+  class="bg-dark/50 border border-surface-200 rounded-xl p-6 flex min-w-0 flex-col h-full"
 >
   <h2 class="mb-4 text-lg font-semibold text-surface-content/90">{title}</h2>
-  <div class="relative h-[260px] sm:h-[290px] lg:h-[330px]">
+  <div class="h-[260px] min-w-0 sm:h-[290px] lg:h-[330px]">
     {#if data.length > 0}
-      {#if hasMounted}
-        <div class="absolute inset-0" class:invisible={!interactiveReady}>
-          <PieChart
-            {data}
-            width={CHART_WIDTH}
-            height={CHART_HEIGHT}
-            class="hackatime-pie-chart"
-            key="name"
-            value="value"
-            cRange={colors}
-            legend={true}
-            motion="none"
-            padding={{ bottom: legendPadding }}
-            props={{
-              svg: {
-                class: "h-full w-full",
-                role: "img",
-                "aria-label": title,
-                viewBox: `0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`,
-                preserveAspectRatio: "xMidYMid meet",
-              },
-              legend: {
-                classes: {
-                  root: "w-full px-2",
-                  items: "flex-wrap justify-center",
-                  label: "text-xs text-surface-content/70",
-                },
-              },
-              tooltip: { item: { format: formatDuration } },
-            }}
-          />
-        </div>
-      {/if}
-
-      {#if !interactiveReady}
-        <div class="absolute inset-0">
-          <svg
-            class="h-full w-full"
-            viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`}
-            preserveAspectRatio="xMidYMid meet"
-            role="img"
-            aria-label={title}
-          >
-            <g
-              transform={`translate(${CHART_WIDTH / 2}, ${(CHART_HEIGHT - legendPadding) / 2})`}
-            >
-              {#each staticArcs as arc}
-                <path d={arc.path} fill={arc.color} stroke="none" />
-              {/each}
-            </g>
-          </svg>
-
-          <div
-            class="absolute bottom-0 left-1/2 z-[1] inline-block w-full -translate-x-1/2 px-2"
-          >
-            <div class="flex flex-wrap justify-center gap-x-4 gap-y-1">
-              {#each data as item, index}
-                <div class="flex gap-1">
-                  <div
-                    class="h-4 w-4 rounded-full"
-                    style:background-color={colors[index % colors.length]}
-                  ></div>
-                  <div
-                    class="whitespace-nowrap text-xs text-surface-content/70"
-                  >
-                    {item.name}
-                  </div>
-                </div>
-              {/each}
-            </div>
-          </div>
-        </div>
-      {/if}
+      <PieChart
+        {data}
+        ssr={true}
+        width={CHART_WIDTH}
+        height={CHART_HEIGHT}
+        class="hackatime-pie-chart"
+        key="name"
+        value="value"
+        cRange={colors}
+        legend={true}
+        motion="none"
+        padding={{ bottom: legendPadding }}
+        props={{
+          svg: {
+            class: "h-full w-full",
+            role: "img",
+            "aria-label": title,
+            viewBox: `0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`,
+            preserveAspectRatio: "xMidYMid meet",
+          },
+          legend: {
+            classes: {
+              root: "w-full px-2",
+              items: "flex-wrap justify-center",
+              label: "text-xs text-surface-content/70",
+            },
+          },
+          tooltip: { item: { format: formatDuration } },
+        }}
+      />
     {/if}
   </div>
 </div>

--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
         "blume": "^1.3.1",
         "canvas-confetti": "^1.9.4",
         "hcicons-svelte": "0.2.2",
-        "layerchart": "^2.0.4",
+        "layerchart": "2.0.4",
         "plur": "^6.0.0",
         "runed": "^0.37.1",
         "svelte": "^5.56.8",
@@ -39,6 +39,9 @@
         "prettier-plugin-svelte": "^3.5.2",
       },
     },
+  },
+  "patchedDependencies": {
+    "layerchart@2.0.4": "patches/layerchart@2.0.4.patch",
   },
   "packages": {
     "@ai-sdk/gateway": ["@ai-sdk/gateway@4.0.46", "", { "dependencies": { "@ai-sdk/provider": "4.0.7", "@ai-sdk/provider-utils": "5.0.25", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-LIAO6kAG8fpXQb9L0iwPk1FIbXftvqnyC56v5NEAzeWTeL8fUsy/Hx86VPBTWEDFdwbVprjWifJOAqS6AOj3mA=="],

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "blume": "^1.3.1",
     "canvas-confetti": "^1.9.4",
     "hcicons-svelte": "0.2.2",
-    "layerchart": "^2.0.4",
+    "layerchart": "2.0.4",
     "plur": "^6.0.0",
     "runed": "^0.37.1",
     "svelte": "^5.56.8",
@@ -43,5 +43,8 @@
     "knip": "^6.32.0",
     "prettier": "^3.9.6",
     "prettier-plugin-svelte": "^3.5.2"
+  },
+  "patchedDependencies": {
+    "layerchart@2.0.4": "patches/layerchart@2.0.4.patch"
   }
 }

--- a/patches/layerchart@2.0.4.patch
+++ b/patches/layerchart@2.0.4.patch
@@ -20,6 +20,19 @@ index f9883073675235ca656226322484142c428ad931..97642652b27ac74caf97bf5813531723
    {/if}
  
    {#if typeof tooltip === 'function'}
+diff --git a/dist/components/Chart/Chart.base.svelte b/dist/components/Chart/Chart.base.svelte
+index 11df6da4ccbb9fe7b87c456321677803401354db..2551336c09b82042a77ffc8a73dc89c28d994696 100644
+--- a/dist/components/Chart/Chart.base.svelte
++++ b/dist/components/Chart/Chart.base.svelte
+@@ -465,7 +465,7 @@
+     class={['lc-root-container', className]}
+     {...restProps}
+   >
+-    {#key chartState.isMounted}
++    {#key ssr || chartState.isMounted}
+       {#if transform && TransformContext}
+         <!-- Lazy-load TransformContext only when transform is enabled -->
+         {@const {
 diff --git a/dist/components/charts/PieChart/PieChart.base.svelte b/dist/components/charts/PieChart/PieChart.base.svelte
 index 62198a1924b1d00471c72c90d979d2dcc6247e4f..6ab55af4e475efe3f2c671d7dc76891292b2a43b 100644
 --- a/dist/components/charts/PieChart/PieChart.base.svelte

--- a/patches/layerchart@2.0.4.patch
+++ b/patches/layerchart@2.0.4.patch
@@ -1,0 +1,46 @@
+diff --git a/dist/components/ChartChildren/ChartChildren.base.svelte b/dist/components/ChartChildren/ChartChildren.base.svelte
+index f9883073675235ca656226322484142c428ad931..97642652b27ac74caf97bf581353172382cc6f15 100644
+--- a/dist/components/ChartChildren/ChartChildren.base.svelte
++++ b/dist/components/ChartChildren/ChartChildren.base.svelte
+@@ -36,5 +36,6 @@
+   import { asAny } from '../../utils/types.js';
+   import { getObjectOrNull } from '../../utils/common.js';
++  import Legend from '../Legend.svelte';
+ 
+   const context = getChartContext<TData, XScale, YScale>();
+   const settings = getSettings();
+@@ -197,9 +198,7 @@
+   {#if typeof legend === 'function'}
+     {@render legend(snippetProps)}
+   {:else if legend}
+-    {#await import('../Legend.svelte') then { default: Legend }}
+-      <Legend placement="bottom" {...getObjectOrNull(legend)} {...props.legend} />
+-    {/await}
++    <Legend placement="bottom" {...getObjectOrNull(legend)} {...props.legend} />
+   {/if}
+ 
+   {#if typeof tooltip === 'function'}
+diff --git a/dist/components/charts/PieChart/PieChart.base.svelte b/dist/components/charts/PieChart/PieChart.base.svelte
+index 62198a1924b1d00471c72c90d979d2dcc6247e4f..6ab55af4e475efe3f2c671d7dc76891292b2a43b 100644
+--- a/dist/components/charts/PieChart/PieChart.base.svelte
++++ b/dist/components/charts/PieChart/PieChart.base.svelte
+@@ -56,7 +56,7 @@
+     props = {},
+     profile = false,
+     tooltipContext = true,
+-    marks,
++    marks: marksProp,
+     tooltip: tooltipProp,
+     pie,
+     arc,
+@@ -223,8 +223,8 @@
+   }}
+ >
+   {#snippet marks(snippetProps: any)}
+-    {#if typeof marks === 'function'}
+-      {@render marks(snippetProps)}
++    {#if typeof marksProp === 'function'}
++      {@render marksProp(snippetProps)}
+     {:else}
+       <Group {...getGroupProps()}>
+         <!-- Use `series` instead of `visibleSeries` since data is filtered (legend) instead of series -->


### PR DESCRIPTION
## Summary of the problem

The SSR fix in #1550 rendered a native fallback and an invisible LayerChart pie at the same time, then used animation frames to swap them. The duplicate renderers introduced a visible legend handoff and made a simple chart responsible for custom arc geometry plus mount coordination.

LayerChart 2.0.4 can provide the v1 behaviour with one SSR and hydrated chart, but three upstream issues prevent it: the pie's `marks` prop recursively shadows its snippet, the legend is loaded asynchronously during hydration and the chart subtree is deliberately remounted when hydration completes. That remount caused an intermittent 133 ms interval where the SSR arcs disappeared before the client arcs painted. LayerChart's delayed positioning CSS also allowed the SSR SVG to use the viewport as its containing block for early frames.

## Describe your changes

- Use one LayerChart `PieChart` for both SSR and client interaction.
- Remove the native arc renderer, duplicate legend, mount state and animation-frame handoff.
- Patch the LayerChart `marks` collision and load its existing legend synchronously.
- Keep `ssr={true}` chart contents mounted across hydration while retaining LayerChart's existing remount for client-only charts.
- Add stable chart containment and legend positioning before hydration.
- Remove the initial Project Duration width transition so its bars do not animate through an empty state on refresh.
- Pin LayerChart 2.0.4 while the version-specific patch is required.

### Benchmark

The responsive audit used populated 8, 4 and 3-slice pies with cold page loads and an animation-frame sampler at 390, 768, 1280 and 1440 px.

| Metric | Duplicate-renderer implementation | Single LayerChart implementation |
| --- | ---: | ---: |
| Pie component source | 162 lines | 77 lines, **52.5% fewer** |
| Concurrent chart renderers during handoff | 2 | 1 |
| Missing arc or legend frames | User-visible legend gap | **0 across 999 visible frames** |
| 1280 px early SVG maximum | 1280 by 577 px before containment | **405 by 330 px** |
| SSR pies | 3 SVGs, 15 arcs, 15 legend items | **Unchanged** |
| Hydrated Languages legend filter | 8 to 1 to 8 arcs | **Unchanged** |
| Chart CLS in the responsive audit | 0 | **0** |

The sampler observed 268 frames at 390 px, 269 at 768 px, 197 at 1280 px and 265 at 1440 px. Every visible frame contained all three charts, at least three arcs per chart and at least three legend buttons per chart. The SVG never exceeded its own chart container. Hover tooltips and legend select and restore behaviour remain interactive after hydration.

After diagnosing the intermittent hydration remount, a separate production SSR stress recording covered 10 consecutive refreshes. All 10 retained the pie arcs, legends, Project Duration bars and card contents without an oversized or partially styled frame. The original recording's blank chart interval lasted about 133 ms across four frames.

The dashboard migration benchmark from #1545 remains unchanged by this rendering simplification: route JavaScript was 275,641 to 253,457 gzip bytes, a reduction of 22,184 bytes or 8.0%, while the native timeline reduced DOM elements from 1,126 to 922 and SVG descendants from 626 to 422. This follow-up does not claim a new CPU improvement.

## Screenshots / Media

Original oversized pie refresh flash: https://ampcode.com/user-content/attachments/768c60cb1f6d56771dc878d4a85c8476dd3b544c87ce173f7dfe164c33131333-Screen-Recording-2026-08-10-at-21.06.14.mov

Intermittent hydration flicker that exposed the chart remount: https://ampcode.com/user-content/attachments/7916d40f662a90e0c8d84d20cf537d72c564b7aaf0d522ed41b55c9debcba1c9-Screen-Recording-2026-08-10-at-22.58.12.mov