### PR TITLE
Prevent pie legend flicker before hydration

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -501,6 +501,29 @@ html[data-theme="rose_pine_dawn"] {
   transform: translateX(-50%);
 }
 
+/* Keep the SSR legend stable until LayerChart's async chart stylesheet loads. */
+.hackatime-pie-chart .lc-legend-swatch-group,
+.hackatime-pie-chart .lc-legend-swatch-button {
+  display: flex;
+  align-items: center;
+}
+
+.hackatime-pie-chart .lc-legend-swatch-group {
+  gap: 0.25rem 1rem;
+}
+
+.hackatime-pie-chart .lc-legend-swatch-button {
+  gap: 0.25rem;
+  white-space: nowrap;
+}
+
+.hackatime-pie-chart .lc-legend-swatch {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  border-radius: 9999px;
+}
+
 .lc-tooltip-container[data-variant="default"] {
   background-color: color-mix(
     in oklab,


### PR DESCRIPTION
## Summary of the problem

Production SSR emits complete LayerChart legend markup before LayerChart's chart stylesheet is requested by the client. The legend labels therefore have intrinsic size but the coloured swatches can remain zero-height for a frame, causing a rare refresh flicker.

A controlled reproduction blocked `Chart-*.css`. All 15 legend swatches retained their inline colours but measured 0 px high while their labels remained visible, matching the recorded failure.

## Describe your changes

Add the small set of legend layout and swatch dimensions required for first paint to the existing critical pie chart CSS. The rules match LayerChart's final styles, so loading the asynchronous chart stylesheet does not change the legend geometry.

With `Chart-*.css` still blocked, the same swatches measure 16 by 16 px and all three SSR legends retain their final layout. The production application stylesheet increases by 0.36 kB raw and 0.08 kB gzip.

## Screenshots / Media

Refresh recording showing the missing legend swatches: https://ampcode.com/user-content/attachments/7916d40f662a90e0c8d84d20cf537d72c564b7aaf0d522ed41b55c9debcba1c9-Screen-Recording-2026-08-10-at-22.58.12.mov