### PR TITLE
Match Coding Rhythm hover movement to macOS Dock

### DIFF
--- a/app/javascript/pages/Home/signedIn/CodingRhythm.svelte
+++ b/app/javascript/pages/Home/signedIn/CodingRhythm.svelte
@@ -71,16 +71,15 @@
     );
   });
 
-  let tooltip = $state<{ label: string; x: number; y: number } | null>(null);
+  let tooltip = $state<{
+    slot: string;
+    label: string;
+    x: number;
+    y: number;
+  } | null>(null);
   let hideTimer: ReturnType<typeof setTimeout> | undefined;
   const tooltipX = new Spring<number | null>(null);
   const tooltipY = new Spring<number | null>(null);
-
-  $effect(() => {
-    if (!tooltip) return;
-    tooltipX.set(tooltip.x, { instant: tooltipX.target === null });
-    tooltipY.set(tooltip.y, { instant: tooltipY.target === null });
-  });
 
   function hourLabel(hour: number) {
     if (hour === 0) return "12 AM";
@@ -109,11 +108,16 @@
     const target = event.currentTarget as SVGRectElement;
     const bounds = target.getBoundingClientRect();
     const pointer = event instanceof PointerEvent;
+    const slotKey = `${slot.weekday}-${slot.hour}`;
+    const instant = tooltip === null || tooltip.slot !== slotKey;
     tooltip = {
+      slot: slotKey,
       label: slotLabel(slot.day, slot.hour, slot.seconds),
       x: pointer ? event.clientX + 10 : bounds.left + bounds.width / 2,
       y: pointer ? event.clientY + 10 : bounds.bottom + 8,
     };
+    tooltipX.set(tooltip.x, { instant });
+    tooltipY.set(tooltip.y, { instant });
   }
 
   function hideTooltip() {


### PR DESCRIPTION
## Summary of the problem

The Coding Rhythm tooltip used the same spring animation both within a cell and when moving to another cell. This made the tooltip trail behind the pointer while scanning the heatmap quickly.

## Describe your changes

Track the active Coding Rhythm slot and move the tooltip instantly when the pointer enters a different cell. Movement within the same cell keeps the existing spring behaviour while appearance and dismissal retain their fade.

## Screenshots / Media

[Watch the Coding Rhythm hover interaction](https://ampcode.com/user-content/artifacts/6b83d2de5cc487999e4dc7c952bedf1867c3628a84be19e9e1f12f8377d9ad03-file.webm)