### PR TITLE
Smooth documentation navigation with View Transitions

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -6,6 +6,12 @@
 @import "./main.css";
 @import "./nav.css";
 
+@media (prefers-reduced-motion: no-preference) {
+  @view-transition {
+    navigation: auto;
+  }
+}
+
 html {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;

--- a/theme.css
+++ b/theme.css
@@ -2,6 +2,12 @@
   --blume-content-width: 48rem;
 }
 
+@media (prefers-reduced-motion: no-preference) {
+  @view-transition {
+    navigation: auto;
+  }
+}
+
 [data-blume-theme-toggle] {
   display: none;
 }


### PR DESCRIPTION
## Summary of the problem
Going between Hackatime + its static documentation or between Blume pages causes an abrupt full-page refresh because each page uses a separate document.

## Describe your changes

- Opts the app + every Blume documentation page into same-origin cross-document View Transitions
- Smooths app <> docs + Blume <> Blume navigation w/ the browser's native cross-fade
- Preserves standard navigation in unsupported browsers + disables the transition when reduced motion is preferred

## Screenshots / Media

[Video!](https://ampcode.com/user-content/artifacts/3aa35a7dce9803225f681762bb66e8e8c05a46577daa5cbf0a1a897405895355-file.webm)