### PR TITLE
Self-host documentation fonts

### DIFF
--- a/blume.config.ts
+++ b/blume.config.ts
@@ -102,6 +102,33 @@ export default defineConfig({
   theme: {
     accent: defaultTheme.preview.primary,
     background: defaultTheme.preview.dark,
+    fonts: {
+      body: {
+        name: "Inter",
+        variants: [
+          {
+            src: "node_modules/@fontsource-variable/inter/files/inter-latin-wght-normal.woff2",
+            weight: "100..900",
+          },
+        ],
+      },
+      display: {
+        name: "Inter Tight",
+        variants: [
+          {
+            src: "node_modules/@fontsource-variable/inter-tight/files/inter-tight-latin-wght-normal.woff2",
+            weight: "100..900",
+          },
+        ],
+      },
+      mono: {
+        name: "IBM Plex Mono",
+        variants: [400, 500, 600].map((weight) => ({
+          src: `node_modules/@fontsource/ibm-plex-mono/files/ibm-plex-mono-latin-${weight}-normal.woff2`,
+          weight,
+        })),
+      },
+    },
     mode: defaultTheme.color_scheme,
     radius: "lg",
   },

--- a/bun.lock
+++ b/bun.lock
@@ -4,7 +4,10 @@
   "workspaces": {
     "": {
       "dependencies": {
+        "@fontsource-variable/inter": "^5.3.0",
+        "@fontsource-variable/inter-tight": "^5.3.0",
         "@fontsource-variable/spline-sans": "^5.3.0",
+        "@fontsource/ibm-plex-mono": "^5.3.0",
         "@img/sharp-libvips-linux-arm64": "1.3.2",
         "@img/sharp-libvips-linux-x64": "1.3.2",
         "@inertiajs/svelte": "^3.6.1",
@@ -244,7 +247,13 @@
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.10", "", {}, "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="],
 
+    "@fontsource-variable/inter": ["@fontsource-variable/inter@5.3.0", "", {}, "sha512-OupL48va4JNofb97w6NYeF9S7W/kHNKM0Er8Dem5nqi4jeOLrVJDoE8tZEpnMJmtkvNbB1EIPPwHcdkF6b1oUA=="],
+
+    "@fontsource-variable/inter-tight": ["@fontsource-variable/inter-tight@5.3.0", "", {}, "sha512-ZhZZ29sNZ15P1K+cUt13GeBRYON0akgmNiftshUeDLos7X7zGcRgPzt434879Xhq1QbwlW3M/apBMk7jWabwvA=="],
+
     "@fontsource-variable/spline-sans": ["@fontsource-variable/spline-sans@5.3.0", "", {}, "sha512-a0EVY1u6qvI5uk66ImOKbh3QD8y3LtMpuqMMyN4OB9eJwivKPXNTn8rJUB+YLrJ5LxS85vqSmG1xeYG/mF8MDw=="],
+
+    "@fontsource/ibm-plex-mono": ["@fontsource/ibm-plex-mono@5.3.0", "", {}, "sha512-eTgnZjZEGk1QtD3ZstF+Vclo2HLAni8YMy34/DxllwZvyz1lR/1RF/xTiAquOBO7MvqBx8D2Ig2WCPMVfdZu7Q=="],
 
     "@hono/node-server": ["@hono/node-server@2.0.12", "", { "peerDependencies": { "hono": "^4" } }, "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg=="],
 

--- a/knip.json
+++ b/knip.json
@@ -15,6 +15,9 @@
     "app/assets/**/*.css"
   ],
   "ignoreDependencies": [
+    "@fontsource-variable/inter",
+    "@fontsource-variable/inter-tight",
+    "@fontsource/ibm-plex-mono",
     "@js-from-routes/client",
     "@img/sharp-libvips-linux-arm64",
     "@img/sharp-libvips-linux-x64"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "knip": "knip"
   },
   "dependencies": {
+    "@fontsource-variable/inter": "^5.3.0",
+    "@fontsource-variable/inter-tight": "^5.3.0",
     "@fontsource-variable/spline-sans": "^5.3.0",
+    "@fontsource/ibm-plex-mono": "^5.3.0",
     "@img/sharp-libvips-linux-arm64": "1.3.2",
     "@img/sharp-libvips-linux-x64": "1.3.2",
     "@inertiajs/svelte": "^3.6.1",


### PR DESCRIPTION
## Summary of the problem
Production docs builds depend on versioned Google Fonts URLs. Google removed the referenced Inter Tight file, so Docker builds now fail with a 404 while Astro bundles the documentation.

## Describe your changes

- Self-hosts the existing Inter, Inter Tight + IBM Plex Mono documentation fonts from versioned Fontsource packages
- Configures Blume to bundle five local font files instead of downloading fonts during every build
- Keeps the existing typography unchanged while making production builds deterministic

## Screenshots / Media
No visual changes.
