### PR TITLE
Add WakaTime-compatible profile and summary endpoints

### DIFF
--- a/app/controllers/api/hackatime/v1/hackatime_controller.rb
+++ b/app/controllers/api/hackatime/v1/hackatime_controller.rb
@@ -12,6 +12,48 @@ class Api::Hackatime::V1::HackatimeController < ApplicationController
   ].freeze
 
   MAX_BULK_HEARTBEATS = 100
+  MAX_SUMMARY_DAYS = 366
+
+  def show_user
+    render json: {
+      data: {
+        id: @user.id.to_s,
+        username: @user.username,
+        display_name: @user.display_name,
+        full_name: @user.display_name,
+        photo: @user.avatar_url,
+        timezone: @user.timezone,
+        created_at: @user.created_at.iso8601,
+        modified_at: @user.updated_at.iso8601,
+        plan: "free"
+      }
+    }
+  end
+
+  def summaries
+    start_date = parse_summary_date(params[:start])
+    end_date = parse_summary_date(params[:end])
+    return render_bad_request("start and end must be valid dates in YYYY-MM-DD format") unless start_date && end_date
+    return render_bad_request("end must not be before start") if end_date < start_date
+    return render_bad_request("date range cannot exceed #{MAX_SUMMARY_DAYS} days") if (end_date - start_date).to_i >= MAX_SUMMARY_DAYS
+
+    timezone = params[:timezone].presence || @user.timezone
+    return render_bad_request("Invalid timezone") unless valid_timezone?(timezone)
+
+    Time.use_zone(timezone) do
+      scope = @user.heartbeats
+      scope = scope.where(project: params[:project]) if params[:project].present?
+      service = WakatimeService.new(
+        user: @user,
+        scope: scope,
+        allow_cache: false,
+        start_date: start_date.beginning_of_day,
+        end_date: (end_date + 1.day).beginning_of_day
+      )
+
+      render json: service.generate_daily_summaries(timezone:, start_date:, end_date:)
+    end
+  end
 
   def push_heartbeats
     if params["format"] == "bulk"
@@ -118,6 +160,21 @@ class Api::Hackatime::V1::HackatimeController < ApplicationController
   private
 
   def hms(total) = [ total / 3600, (total % 3600) / 60, total % 60 ]
+
+  def parse_summary_date(value)
+    return unless value.to_s.match?(/\A\d{4}-\d{2}-\d{2}\z/)
+
+    Date.iso8601(value)
+  rescue Date::Error
+    nil
+  end
+
+  def valid_timezone?(timezone)
+    TZInfo::Timezone.get(timezone)
+    true
+  rescue TZInfo::InvalidTimezoneIdentifier
+    false
+  end
 
   def format_hr(total)
     h, m, _ = hms(total)

--- a/app/models/concerns/heartbeatable.rb
+++ b/app/models/concerns/heartbeatable.rb
@@ -99,31 +99,27 @@ module Heartbeatable
       uncached_users = user_ids.select { |id| streak_cache["#{cache_prefix}_#{id}"].nil? }
       return user_ids.index_with { |id| streak_cache["#{cache_prefix}_#{id}"] || 0 } if uncached_users.empty?
 
-      timeout = heartbeat_timeout_duration.to_i
       day_group_sql = "DATE_TRUNC('day', to_timestamp(time) AT TIME ZONE users.timezone)"
-      streak_diff_sql = <<~SQL.squish
-        LEAST(
-          time - LAG(time) OVER (PARTITION BY user_id, #{day_group_sql} ORDER BY time, #{quoted_table_name}.id),
-          #{timeout}
-        ) as diff
-      SQL
+      previous_time_sql = "LAG(time) OVER (PARTITION BY user_id, #{day_group_sql} ORDER BY time, #{quoted_table_name}.id) as previous_time"
       raw_durations = joins(:user)
         .where(user_id: uncached_users)
         .where.not(category: "browsing")
         .with_valid_timestamps
         .where(time: start_date..Time.current)
         .select(
+          :time,
           :user_id,
           "users.timezone as user_timezone",
           Arel.sql("#{day_group_sql} as day_group"),
-          Arel.sql(streak_diff_sql)
+          Arel.sql(previous_time_sql)
         )
       raw_durations = raw_durations.excluding_browser_time if exclude_browser_time
+      capped_durations = with_capped_duration(raw_durations)
 
       # Then aggregate the results
       daily_durations = connection.select_all(
-        "SELECT user_id, user_timezone, day_group, COALESCE(SUM(diff), 0)::integer as duration
-         FROM (#{raw_durations.to_sql}) AS diffs
+        "SELECT user_id, user_timezone, day_group, COALESCE(SUM(duration), 0)::integer as duration
+         FROM (#{capped_durations.to_sql}) AS durations
          GROUP BY user_id, user_timezone, day_group"
       ).group_by { |row| row["user_id"] }
        .transform_values do |rows|
@@ -194,20 +190,59 @@ module Heartbeatable
         .map { |date, duration| [ date.to_date, duration ] }
     end
 
+    def daily_activity_summary_rows(scope:, timezone:)
+      quoted_timezone = connection.quote(timezone)
+      local_date_sql = "(to_timestamp(daily_summary_heartbeats.time) AT TIME ZONE #{quoted_timezone})::date"
+      summary_heartbeats = scope.with_valid_timestamps
+        .where.not(time: nil)
+        .select(:id, :time, :project, :ai_model, :ai_input_tokens, :ai_output_tokens, :ai_line_changes)
+      heartbeat_gaps = unscoped.from(summary_heartbeats, :daily_summary_heartbeats).select(<<~SQL.squish)
+        daily_summary_heartbeats.project,
+        daily_summary_heartbeats.ai_model,
+        daily_summary_heartbeats.ai_input_tokens,
+        daily_summary_heartbeats.ai_output_tokens,
+        daily_summary_heartbeats.ai_line_changes,
+        daily_summary_heartbeats.time,
+        #{local_date_sql} AS local_date,
+        LAG(daily_summary_heartbeats.time) OVER (
+          PARTITION BY #{local_date_sql}
+          ORDER BY daily_summary_heartbeats.time, daily_summary_heartbeats.id
+        ) AS previous_time
+      SQL
+      capped_durations = with_capped_duration(heartbeat_gaps)
+
+      connection.select_all(<<~SQL.squish)
+        SELECT local_date,
+               project,
+               ai_model,
+               COALESCE(SUM(duration), 0)::integer AS duration,
+               COALESCE(SUM(ai_input_tokens), 0)::bigint AS ai_input_tokens,
+               COUNT(ai_input_tokens)::integer AS ai_input_token_count,
+               COALESCE(SUM(ai_output_tokens), 0)::bigint AS ai_output_tokens,
+               COUNT(ai_output_tokens)::integer AS ai_output_token_count,
+               COALESCE(SUM(ai_line_changes), 0)::bigint AS ai_line_changes
+        FROM (#{capped_durations.to_sql}) daily_durations
+        GROUP BY local_date, project, ai_model
+        ORDER BY local_date, project, ai_model
+      SQL
+    end
+
     def attributed_durations_by(scope, field)
       scope = scope.with_valid_timestamps
-      timeout = heartbeat_timeout_duration.to_i
       field_expr = connection.quote_column_name(field.to_s)
-      base_sql = scope.unscope(:group, :select, :order).select(:id, :time, field).to_sql
+      attribution_heartbeats = scope.unscope(:group, :select, :order).select(:id, :time, field)
+      heartbeat_gaps = unscoped.from(attribution_heartbeats, :attribution_heartbeats).select(<<~SQL.squish)
+        attribution_heartbeats.#{field_expr} AS bucket,
+        attribution_heartbeats.time,
+        LAG(attribution_heartbeats.time) OVER (
+          ORDER BY attribution_heartbeats.time, attribution_heartbeats.id
+        ) AS previous_time
+      SQL
+      capped_durations = with_capped_duration(heartbeat_gaps)
 
       sql = <<~SQL.squish
-        SELECT bucket, COALESCE(SUM(diff), 0)::integer AS duration
-        FROM (
-          SELECT #{field_expr} AS bucket,
-                 CASE WHEN LAG(time) OVER (ORDER BY time, id) IS NULL THEN 0
-                      ELSE LEAST(time - LAG(time) OVER (ORDER BY time, id), #{timeout}) END AS diff
-          FROM (#{base_sql}) heartbeats_for_attribution
-        ) capped_diffs
+        SELECT bucket, COALESCE(SUM(duration), 0)::integer AS duration
+        FROM (#{capped_durations.to_sql}) attributed_durations
         WHERE bucket IS NOT NULL AND bucket <> ''
         GROUP BY bucket
       SQL
@@ -217,7 +252,6 @@ module Heartbeatable
 
     def duration_seconds(scope = all)
       scope = scope.with_valid_timestamps
-      timeout = heartbeat_timeout_duration.to_i
 
       if scope.group_values.any?
         raise NotImplementedError, "Multiple group values are not supported" if scope.group_values.length > 1
@@ -226,16 +260,18 @@ module Heartbeatable
         # Don't quote if it's a SQL function (contains parentheses)
         group_expr = group_column.to_s.include?("(") ? group_column : connection.quote_column_name(group_column)
 
-        capped_diffs = scope.select("#{group_expr} as grouped_time, CASE WHEN LAG(time) OVER (PARTITION BY #{group_expr} ORDER BY time, #{quoted_table_name}.id) IS NULL THEN 0 ELSE LEAST(time - LAG(time) OVER (PARTITION BY #{group_expr} ORDER BY time, #{quoted_table_name}.id), #{timeout}) END as diff")
+        heartbeat_gaps = scope.select("#{group_expr} as grouped_time, time, LAG(time) OVER (PARTITION BY #{group_expr} ORDER BY time, #{quoted_table_name}.id) as previous_time")
           .where.not(time: nil).unscope(:group)
+        capped_durations = with_capped_duration(heartbeat_gaps)
 
         connection.select_all(
-          "SELECT grouped_time, COALESCE(SUM(diff), 0)::integer as duration FROM (#{capped_diffs.to_sql}) AS diffs GROUP BY grouped_time"
+          "SELECT grouped_time, COALESCE(SUM(duration), 0)::integer as duration FROM (#{capped_durations.to_sql}) AS durations GROUP BY grouped_time"
         ).each_with_object({}) { |row, hash| hash[row["grouped_time"]] = row["duration"].to_i }
       else
         # when not grouped, return a single value
-        capped_diffs = scope.select("CASE WHEN LAG(time) OVER (ORDER BY time, #{quoted_table_name}.id) IS NULL THEN 0 ELSE LEAST(time - LAG(time) OVER (ORDER BY time, #{quoted_table_name}.id), #{timeout}) END as diff").where.not(time: nil)
-        connection.select_value("SELECT COALESCE(SUM(diff), 0)::integer FROM (#{capped_diffs.to_sql}) AS diffs").to_i
+        heartbeat_gaps = scope.select("time, LAG(time) OVER (ORDER BY time, #{quoted_table_name}.id) as previous_time").where.not(time: nil)
+        capped_durations = with_capped_duration(heartbeat_gaps)
+        connection.select_value("SELECT COALESCE(SUM(duration), 0)::integer FROM (#{capped_durations.to_sql}) AS durations").to_i
       end
     end
 
@@ -258,12 +294,24 @@ module Heartbeatable
         base_scope.where(time: start_time..end_time)
 
       # we calc w/ the boundary heartbeat, but we only sum within the orignal constraint
-      timeout = heartbeat_timeout_duration.to_i
-      capped_diffs = combined_scope
-        .select("time, CASE WHEN LAG(time) OVER (ORDER BY time, #{quoted_table_name}.id) IS NULL THEN 0 ELSE LEAST(time - LAG(time) OVER (ORDER BY time, #{quoted_table_name}.id), #{timeout}) END as diff")
+      heartbeat_gaps = combined_scope
+        .select("time, LAG(time) OVER (ORDER BY time, #{quoted_table_name}.id) as previous_time")
         .where.not(time: nil).order(time: :asc, id: :asc)
+      capped_durations = with_capped_duration(heartbeat_gaps)
 
-      connection.select_value("SELECT COALESCE(SUM(diff), 0)::integer FROM (#{capped_diffs.to_sql}) AS diffs WHERE time >= #{connection.quote(start_time)}").to_i
+      connection.select_value("SELECT COALESCE(SUM(duration), 0)::integer FROM (#{capped_durations.to_sql}) AS durations WHERE time >= #{connection.quote(start_time)}").to_i
+    end
+
+    private
+
+    def with_capped_duration(heartbeat_gaps)
+      timeout = heartbeat_timeout_duration.to_i
+
+      unscoped.from(heartbeat_gaps, :heartbeat_gaps).select(<<~SQL.squish)
+        heartbeat_gaps.*,
+        CASE WHEN heartbeat_gaps.previous_time IS NULL THEN 0
+             ELSE LEAST(heartbeat_gaps.time - heartbeat_gaps.previous_time, #{timeout}) END AS duration
+      SQL
     end
   end
 end

--- a/app/models/concerns/heartbeatable.rb
+++ b/app/models/concerns/heartbeatable.rb
@@ -100,18 +100,18 @@ module Heartbeatable
       return user_ids.index_with { |id| streak_cache["#{cache_prefix}_#{id}"] || 0 } if uncached_users.empty?
 
       day_group_sql = "DATE_TRUNC('day', to_timestamp(time) AT TIME ZONE users.timezone)"
-      previous_time_sql = "LAG(time) OVER (PARTITION BY user_id, #{day_group_sql} ORDER BY time, #{quoted_table_name}.id) as previous_time"
+      duration_start_sql = "LAG(time) OVER (PARTITION BY user_id, #{day_group_sql} ORDER BY time, #{quoted_table_name}.id) as duration_start"
       raw_durations = joins(:user)
         .where(user_id: uncached_users)
         .where.not(category: "browsing")
         .with_valid_timestamps
         .where(time: start_date..Time.current)
         .select(
-          :time,
+          Arel.sql("#{quoted_table_name}.time as duration_end"),
           :user_id,
           "users.timezone as user_timezone",
           Arel.sql("#{day_group_sql} as day_group"),
-          Arel.sql(previous_time_sql)
+          Arel.sql(duration_start_sql)
         )
       raw_durations = raw_durations.excluding_browser_time if exclude_browser_time
       capped_durations = with_capped_duration(raw_durations)
@@ -202,12 +202,12 @@ module Heartbeatable
         daily_summary_heartbeats.ai_input_tokens,
         daily_summary_heartbeats.ai_output_tokens,
         daily_summary_heartbeats.ai_line_changes,
-        daily_summary_heartbeats.time,
+        daily_summary_heartbeats.time AS duration_start,
         #{local_date_sql} AS local_date,
-        LAG(daily_summary_heartbeats.time) OVER (
+        LEAD(daily_summary_heartbeats.time) OVER (
           PARTITION BY #{local_date_sql}
           ORDER BY daily_summary_heartbeats.time, daily_summary_heartbeats.id
-        ) AS previous_time
+        ) AS duration_end
       SQL
       capped_durations = with_capped_duration(heartbeat_gaps)
 
@@ -233,10 +233,10 @@ module Heartbeatable
       attribution_heartbeats = scope.unscope(:group, :select, :order).select(:id, :time, field)
       heartbeat_gaps = unscoped.from(attribution_heartbeats, :attribution_heartbeats).select(<<~SQL.squish)
         attribution_heartbeats.#{field_expr} AS bucket,
-        attribution_heartbeats.time,
         LAG(attribution_heartbeats.time) OVER (
           ORDER BY attribution_heartbeats.time, attribution_heartbeats.id
-        ) AS previous_time
+        ) AS duration_start,
+        attribution_heartbeats.time AS duration_end
       SQL
       capped_durations = with_capped_duration(heartbeat_gaps)
 
@@ -260,7 +260,7 @@ module Heartbeatable
         # Don't quote if it's a SQL function (contains parentheses)
         group_expr = group_column.to_s.include?("(") ? group_column : connection.quote_column_name(group_column)
 
-        heartbeat_gaps = scope.select("#{group_expr} as grouped_time, time, LAG(time) OVER (PARTITION BY #{group_expr} ORDER BY time, #{quoted_table_name}.id) as previous_time")
+        heartbeat_gaps = scope.select("#{group_expr} as grouped_time, LAG(time) OVER (PARTITION BY #{group_expr} ORDER BY time, #{quoted_table_name}.id) as duration_start, time as duration_end")
           .where.not(time: nil).unscope(:group)
         capped_durations = with_capped_duration(heartbeat_gaps)
 
@@ -269,7 +269,7 @@ module Heartbeatable
         ).each_with_object({}) { |row, hash| hash[row["grouped_time"]] = row["duration"].to_i }
       else
         # when not grouped, return a single value
-        heartbeat_gaps = scope.select("time, LAG(time) OVER (ORDER BY time, #{quoted_table_name}.id) as previous_time").where.not(time: nil)
+        heartbeat_gaps = scope.select("LAG(time) OVER (ORDER BY time, #{quoted_table_name}.id) as duration_start, time as duration_end").where.not(time: nil)
         capped_durations = with_capped_duration(heartbeat_gaps)
         connection.select_value("SELECT COALESCE(SUM(duration), 0)::integer FROM (#{capped_durations.to_sql}) AS durations").to_i
       end
@@ -295,22 +295,22 @@ module Heartbeatable
 
       # we calc w/ the boundary heartbeat, but we only sum within the orignal constraint
       heartbeat_gaps = combined_scope
-        .select("time, LAG(time) OVER (ORDER BY time, #{quoted_table_name}.id) as previous_time")
+        .select("LAG(time) OVER (ORDER BY time, #{quoted_table_name}.id) as duration_start, time as duration_end")
         .where.not(time: nil).order(time: :asc, id: :asc)
       capped_durations = with_capped_duration(heartbeat_gaps)
 
-      connection.select_value("SELECT COALESCE(SUM(duration), 0)::integer FROM (#{capped_durations.to_sql}) AS durations WHERE time >= #{connection.quote(start_time)}").to_i
+      connection.select_value("SELECT COALESCE(SUM(duration), 0)::integer FROM (#{capped_durations.to_sql}) AS durations WHERE duration_end >= #{connection.quote(start_time)}").to_i
     end
 
     private
 
-    def with_capped_duration(heartbeat_gaps)
+    def with_capped_duration(heartbeat_intervals)
       timeout = heartbeat_timeout_duration.to_i
 
-      unscoped.from(heartbeat_gaps, :heartbeat_gaps).select(<<~SQL.squish)
-        heartbeat_gaps.*,
-        CASE WHEN heartbeat_gaps.previous_time IS NULL THEN 0
-             ELSE LEAST(heartbeat_gaps.time - heartbeat_gaps.previous_time, #{timeout}) END AS duration
+      unscoped.from(heartbeat_intervals, :heartbeat_intervals).select(<<~SQL.squish)
+        heartbeat_intervals.*,
+        CASE WHEN heartbeat_intervals.duration_start IS NULL OR heartbeat_intervals.duration_end IS NULL THEN 0
+             ELSE LEAST(heartbeat_intervals.duration_end - heartbeat_intervals.duration_start, #{timeout}) END AS duration
       SQL
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -338,6 +338,8 @@ Rails.application.routes.draw do
     namespace :hackatime do
       namespace :v1 do
         get "/", to: redirect("/", status: 302) # some clients seem to link this as the user's dashboard instead of /api/v1/hackatime
+        get "/users/:id", to: "hackatime#show_user"
+        get "/users/:id/summaries", to: "hackatime#summaries"
         get "/users/:id/statusbar/today", to: "hackatime#status_bar_today"
         post "/users/:id/heartbeats", to: "hackatime#push_heartbeats"
         get "/users/current/stats/last_7_days", to: "hackatime#stats_last_7_days"

--- a/lib/wakatime_service.rb
+++ b/lib/wakatime_service.rb
@@ -168,7 +168,7 @@ class WakatimeService
       }
     end
 
-    daily_activity_rows(timezone).each do |row|
+    Heartbeat.daily_activity_summary_rows(scope: @scope, timezone: timezone).each do |row|
       activity = activity_by_date[row.fetch("local_date").to_date]
       duration = row.fetch("duration").to_i
       activity[:total_seconds] += duration
@@ -181,43 +181,6 @@ class WakatimeService
     end
 
     activity_by_date
-  end
-
-  def daily_activity_rows(timezone)
-    quoted_timezone = Heartbeat.connection.quote(timezone)
-    local_date_sql = "(to_timestamp(time) AT TIME ZONE #{quoted_timezone})::date"
-    scope_sql = @scope.with_valid_timestamps
-      .where.not(time: nil)
-      .select(:id, :time, :project, :ai_model, :ai_input_tokens, :ai_output_tokens, :ai_line_changes)
-      .to_sql
-    timeout = Heartbeat.heartbeat_timeout_duration.to_i
-
-    Heartbeat.connection.select_all(<<~SQL.squish)
-      SELECT local_date,
-             project,
-             ai_model,
-             COALESCE(SUM(diff), 0)::integer AS duration,
-             COALESCE(SUM(ai_input_tokens), 0)::bigint AS ai_input_tokens,
-             COUNT(ai_input_tokens)::integer AS ai_input_token_count,
-             COALESCE(SUM(ai_output_tokens), 0)::bigint AS ai_output_tokens,
-             COUNT(ai_output_tokens)::integer AS ai_output_token_count,
-             COALESCE(SUM(ai_line_changes), 0)::bigint AS ai_line_changes
-      FROM (
-        SELECT project,
-               ai_model,
-               ai_input_tokens,
-               ai_output_tokens,
-               ai_line_changes,
-               #{local_date_sql} AS local_date,
-               CASE
-                 WHEN LAG(time) OVER (PARTITION BY #{local_date_sql} ORDER BY time, id) IS NULL THEN 0
-                 ELSE LEAST(time - LAG(time) OVER (PARTITION BY #{local_date_sql} ORDER BY time, id), #{timeout})
-               END AS diff
-        FROM (#{scope_sql}) daily_summary_heartbeats
-      ) daily_durations
-      GROUP BY local_date, project, ai_model
-      ORDER BY local_date, project, ai_model
-    SQL
   end
 
   def build_daily_summary(date, activity, timezone)

--- a/lib/wakatime_service.rb
+++ b/lib/wakatime_service.rb
@@ -37,6 +37,32 @@ class WakatimeService
     build_summary
   end
 
+  def generate_daily_summaries(timezone:, start_date:, end_date:)
+    activity_by_date = daily_activity(timezone)
+    data = (start_date..end_date).map do |date|
+      build_daily_summary(date, activity_by_date[date], timezone)
+    end
+    total_seconds = data.sum { |summary| summary.dig(:grand_total, :total_seconds) }
+    active_days = data.count { |summary| summary.dig(:grand_total, :total_seconds).positive? }
+    average_seconds = data.any? ? total_seconds / data.length : 0
+
+    {
+      data: data,
+      cumulative_total: cumulative_duration(total_seconds),
+      daily_average: {
+        holidays: data.length - active_days,
+        days_including_holidays: data.length,
+        days_minus_holidays: active_days,
+        seconds: average_seconds,
+        seconds_including_other_language: average_seconds,
+        text: duration_text(average_seconds),
+        text_including_other_language: duration_text(average_seconds)
+      },
+      start: start_date.iso8601,
+      end: end_date.iso8601
+    }
+  end
+
   def cached_summary
     Rails.cache.fetch(summary_cache_key, expires_in: 1.minute) do
       build_summary
@@ -128,6 +154,157 @@ class WakatimeService
   end
 
   private
+
+  def daily_activity(timezone)
+    activity_by_date = Hash.new do |hash, date|
+      hash[date] = {
+        total_seconds: 0,
+        projects: Hash.new(0),
+        ai_input_tokens: 0,
+        ai_input_token_count: 0,
+        ai_output_tokens: 0,
+        ai_output_token_count: 0,
+        ai_models: Hash.new(0)
+      }
+    end
+
+    daily_activity_rows(timezone).each do |row|
+      activity = activity_by_date[row.fetch("local_date").to_date]
+      duration = row.fetch("duration").to_i
+      activity[:total_seconds] += duration
+      activity[:projects][row["project"].presence || "Other"] += duration
+      activity[:ai_input_tokens] += row.fetch("ai_input_tokens").to_i
+      activity[:ai_input_token_count] += row.fetch("ai_input_token_count").to_i
+      activity[:ai_output_tokens] += row.fetch("ai_output_tokens").to_i
+      activity[:ai_output_token_count] += row.fetch("ai_output_token_count").to_i
+      activity[:ai_models][row["ai_model"]] += row.fetch("ai_line_changes").to_i if row["ai_model"].present?
+    end
+
+    activity_by_date
+  end
+
+  def daily_activity_rows(timezone)
+    quoted_timezone = Heartbeat.connection.quote(timezone)
+    local_date_sql = "(to_timestamp(time) AT TIME ZONE #{quoted_timezone})::date"
+    scope_sql = @scope.with_valid_timestamps
+      .where.not(time: nil)
+      .select(:id, :time, :project, :ai_model, :ai_input_tokens, :ai_output_tokens, :ai_line_changes)
+      .to_sql
+    timeout = Heartbeat.heartbeat_timeout_duration.to_i
+
+    Heartbeat.connection.select_all(<<~SQL.squish)
+      SELECT local_date,
+             project,
+             ai_model,
+             COALESCE(SUM(diff), 0)::integer AS duration,
+             COALESCE(SUM(ai_input_tokens), 0)::bigint AS ai_input_tokens,
+             COUNT(ai_input_tokens)::integer AS ai_input_token_count,
+             COALESCE(SUM(ai_output_tokens), 0)::bigint AS ai_output_tokens,
+             COUNT(ai_output_tokens)::integer AS ai_output_token_count,
+             COALESCE(SUM(ai_line_changes), 0)::bigint AS ai_line_changes
+      FROM (
+        SELECT project,
+               ai_model,
+               ai_input_tokens,
+               ai_output_tokens,
+               ai_line_changes,
+               #{local_date_sql} AS local_date,
+               CASE
+                 WHEN LAG(time) OVER (PARTITION BY #{local_date_sql} ORDER BY time, id) IS NULL THEN 0
+                 ELSE LEAST(time - LAG(time) OVER (PARTITION BY #{local_date_sql} ORDER BY time, id), #{timeout})
+               END AS diff
+        FROM (#{scope_sql}) daily_summary_heartbeats
+      ) daily_durations
+      GROUP BY local_date, project, ai_model
+      ORDER BY local_date, project, ai_model
+    SQL
+  end
+
+  def build_daily_summary(date, activity, timezone)
+    activity ||= {
+      total_seconds: 0,
+      projects: {},
+      ai_input_tokens: 0,
+      ai_input_token_count: 0,
+      ai_output_tokens: 0,
+      ai_output_token_count: 0,
+      ai_models: {}
+    }
+    total_seconds = activity[:total_seconds]
+    grand_total = duration(total_seconds)
+    grand_total[:ai_input_tokens] = activity[:ai_input_tokens] if activity[:ai_input_token_count].positive?
+    grand_total[:ai_output_tokens] = activity[:ai_output_tokens] if activity[:ai_output_token_count].positive?
+    if activity[:ai_models].any?
+      grand_total[:ai_model_breakdown] = activity[:ai_models]
+        .sort_by { |name, lines| [ -lines, name ] }
+        .map { |name, lines| { name: name, lines: lines } }
+    end
+
+    day_start = date.beginning_of_day
+    {
+      grand_total: grand_total,
+      branches: [],
+      categories: [],
+      dependencies: [],
+      editors: [],
+      entities: [],
+      languages: [],
+      machines: [],
+      operating_systems: [],
+      projects: project_breakdown(activity[:projects], total_seconds),
+      range: {
+        date: date.iso8601,
+        start: day_start.utc.iso8601,
+        end: day_start.end_of_day.utc.iso8601,
+        text: summary_date_text(date),
+        timezone: timezone
+      }
+    }
+  end
+
+  def project_breakdown(projects, total_seconds)
+    projects.filter_map do |name, seconds|
+      next unless seconds.positive?
+
+      duration(seconds).merge(
+        name: name,
+        percent: total_seconds.positive? ? ((seconds.to_f / total_seconds) * 100).round(2) : 0
+      )
+    end.sort_by { |project| [ -project[:total_seconds], project[:name] ] }
+  end
+
+  def duration(total_seconds)
+    total_seconds = total_seconds.to_i
+    hours, remainder = total_seconds.divmod(3600)
+    minutes, seconds = remainder.divmod(60)
+    {
+      total_seconds: total_seconds,
+      hours: hours,
+      minutes: minutes,
+      seconds: seconds,
+      digital: ApplicationController.helpers.digital_time(total_seconds),
+      decimal: format("%.2f", total_seconds / 3600.0),
+      text: duration_text(total_seconds)
+    }
+  end
+
+  def cumulative_duration(total_seconds)
+    value = duration(total_seconds)
+    value[:seconds] = value.delete(:total_seconds)
+    value
+  end
+
+  def duration_text(total_seconds)
+    ApplicationController.helpers.short_time_detailed(total_seconds).presence || "0s"
+  end
+
+  def summary_date_text(date)
+    today = Date.current
+    return "Today" if date == today
+    return "Yesterday" if date == today - 1.day
+
+    date.to_fs(:long)
+  end
 
   def convert_to_unix_timestamp(timestamp)
     # our lord and savior stack overflow for this bit of code

--- a/spec/requests/api/hackatime/v1/compatibility_spec.rb
+++ b/spec/requests/api/hackatime/v1/compatibility_spec.rb
@@ -99,10 +99,10 @@ RSpec.describe 'Api::Hackatime::V1::Compatibility', type: :request do
         let(:Authorization) { "Bearer dev-api-key-12345" }
         let(:api_key) { "dev-api-key-12345" }
         let(:id) { 'current' }
-        let(:heartbeats) { [ { entity: 'file.rb', time: 2.hours.from_now.to_f } ] }
+        let(:heartbeats) { [ { entity: 'file.rb', time: 2026 } ] }
         schema type: :object,
           properties: {
-            error: { type: :string, example: 'time must not be more than 1 hour in the future' },
+            error: { type: :string, example: 'time must be a valid Unix epoch timestamp' },
             type: { type: :string, example: 'HeartbeatIngest::InvalidHeartbeatTime' }
           }
         run_test!
@@ -228,6 +228,186 @@ RSpec.describe 'Api::Hackatime::V1::Compatibility', type: :request do
         let(:api_key) { 'invalid' }
         let(:id) { 'current' }
         let(:heartbeats) { [ { entity: 'file.rb', time: Time.now.to_f } ] }
+        run_test!
+      end
+    end
+  end
+
+  path '/api/hackatime/v1/users/{id}' do
+    get('Get current user (WakaTime compatible)') do
+      tags 'WakaTime Compatibility'
+      description 'Returns profile metadata for the user authenticated by the API key.'
+      security [ Bearer: [], ApiKeyAuth: [] ]
+      produces 'application/json'
+
+      parameter name: :id, in: :path, type: :string, description: 'User ID or "current" (recommended). The authenticated user is resolved from the API token.'
+
+      response(200, 'successful') do
+        let(:Authorization) { "Bearer dev-api-key-12345" }
+        let(:api_key) { "dev-api-key-12345" }
+        let(:id) { 'current' }
+        schema type: :object,
+          properties: {
+            data: {
+              type: :object,
+              properties: {
+                id: { type: :string, example: '42' },
+                username: { type: :string, nullable: true, example: 'orpheus' },
+                display_name: { type: :string, example: 'Orpheus' },
+                full_name: { type: :string, example: 'Orpheus' },
+                photo: { type: :string, example: 'https://example.com/orpheus.png' },
+                timezone: { type: :string, example: 'America/New_York' },
+                created_at: { type: :string, format: :date_time },
+                modified_at: { type: :string, format: :date_time },
+                plan: { type: :string, example: 'free' }
+              },
+              required: %w[id display_name full_name photo timezone created_at modified_at plan]
+            }
+          },
+          required: [ 'data' ]
+        run_test!
+      end
+
+      response(401, 'unauthorized') do
+        let(:Authorization) { 'Bearer invalid' }
+        let(:api_key) { 'invalid' }
+        let(:id) { 'current' }
+        run_test!
+      end
+    end
+  end
+
+  path '/api/hackatime/v1/users/{id}/summaries' do
+    get('Get daily summaries (WakaTime compatible)') do
+      tags 'WakaTime Compatibility'
+      description 'Returns coding activity for an inclusive date range as WakaTime-compatible daily summaries.'
+      security [ Bearer: [], ApiKeyAuth: [] ]
+      produces 'application/json'
+
+      parameter name: :id, in: :path, type: :string, description: 'User ID or "current" (recommended). The authenticated user is resolved from the API token.'
+      parameter name: :start, in: :query, type: :string, format: :date, required: true, description: 'Inclusive start date in YYYY-MM-DD format.'
+      parameter name: :end, in: :query, type: :string, format: :date, required: true, description: 'Inclusive end date in YYYY-MM-DD format. The range may contain at most 366 days.'
+      parameter name: :project, in: :query, type: :string, required: false, description: 'Only include activity for this project.'
+      parameter name: :timezone, in: :query, type: :string, required: false, description: "Timezone used to segment days. Defaults to the user's timezone."
+
+      response(200, 'successful') do
+        let(:Authorization) { "Bearer dev-api-key-12345" }
+        let(:api_key) { "dev-api-key-12345" }
+        let(:id) { 'current' }
+        let(:start) { Date.current.iso8601 }
+        let(:end) { Date.current.iso8601 }
+        let(:project) { nil }
+        let(:timezone) { nil }
+        schema type: :object,
+          properties: {
+            data: {
+              type: :array,
+              items: {
+                type: :object,
+                properties: {
+                  grand_total: {
+                    type: :object,
+                    properties: {
+                      total_seconds: { type: :integer, example: 7200 },
+                      hours: { type: :integer, example: 2 },
+                      minutes: { type: :integer, example: 0 },
+                      seconds: { type: :integer, example: 0 },
+                      digital: { type: :string, example: '02:00:00' },
+                      decimal: { type: :string, example: '2.00' },
+                      text: { type: :string, example: '2h' },
+                      ai_input_tokens: { type: :integer, format: :int64, nullable: true, example: 1200 },
+                      ai_output_tokens: { type: :integer, format: :int64, nullable: true, example: 350 },
+                      ai_model_breakdown: {
+                        type: :array,
+                        nullable: true,
+                        items: {
+                          type: :object,
+                          properties: {
+                            name: { type: :string, example: 'gpt/5.6' },
+                            lines: { type: :integer, example: 18 }
+                          }
+                        }
+                      }
+                    },
+                    required: %w[total_seconds hours minutes seconds digital decimal text]
+                  },
+                  projects: {
+                    type: :array,
+                    items: {
+                      type: :object,
+                      properties: {
+                        name: { type: :string, example: 'hackatime' },
+                        total_seconds: { type: :integer, example: 7200 },
+                        percent: { type: :number, example: 100.0 },
+                        hours: { type: :integer, example: 2 },
+                        minutes: { type: :integer, example: 0 },
+                        seconds: { type: :integer, example: 0 },
+                        digital: { type: :string, example: '02:00:00' },
+                        decimal: { type: :string, example: '2.00' },
+                        text: { type: :string, example: '2h' }
+                      }
+                    }
+                  },
+                  range: {
+                    type: :object,
+                    properties: {
+                      date: { type: :string, format: :date },
+                      start: { type: :string, format: :date_time },
+                      end: { type: :string, format: :date_time },
+                      text: { type: :string, example: 'Today' },
+                      timezone: { type: :string, example: 'America/New_York' }
+                    },
+                    required: %w[date start end text timezone]
+                  }
+                },
+                required: %w[grand_total projects range]
+              }
+            },
+            cumulative_total: {
+              type: :object,
+              properties: {
+                seconds: { type: :integer, example: 7200 },
+                text: { type: :string, example: '2h' },
+                decimal: { type: :string, example: '2.00' },
+                digital: { type: :string, example: '02:00:00' }
+              }
+            },
+            daily_average: {
+              type: :object,
+              properties: {
+                holidays: { type: :integer, example: 0 },
+                days_including_holidays: { type: :integer, example: 1 },
+                days_minus_holidays: { type: :integer, example: 1 },
+                seconds: { type: :integer, example: 7200 },
+                text: { type: :string, example: '2h' }
+              }
+            },
+            start: { type: :string, format: :date },
+            end: { type: :string, format: :date }
+          },
+          required: %w[data cumulative_total daily_average start end]
+        run_test!
+      end
+
+      response(400, 'invalid date range') do
+        let(:Authorization) { "Bearer dev-api-key-12345" }
+        let(:api_key) { "dev-api-key-12345" }
+        let(:id) { 'current' }
+        let(:start) { 'invalid' }
+        let(:end) { Date.current.iso8601 }
+        let(:project) { nil }
+        let(:timezone) { nil }
+        run_test!
+      end
+
+      response(401, 'unauthorized') do
+        let(:Authorization) { 'Bearer invalid' }
+        let(:api_key) { 'invalid' }
+        let(:id) { 'current' }
+        let(:start) { Date.current.iso8601 }
+        let(:end) { Date.current.iso8601 }
+        let(:project) { nil }
+        let(:timezone) { nil }
         run_test!
       end
     end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -275,6 +275,297 @@ paths:
                   plugin:
                     type: string
                     example: vscode/1.96.0 vscode-wakatime/24.6.0
+  "/api/hackatime/v1/users/{id}":
+    get:
+      summary: Get current user (WakaTime compatible)
+      tags:
+      - WakaTime Compatibility
+      description: Returns profile metadata for the user authenticated by the API
+        key.
+      security:
+      - Bearer: []
+        ApiKeyAuth: []
+      parameters:
+      - name: id
+        in: path
+        description: User ID or "current" (recommended). The authenticated user is
+          resolved from the API token.
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        example: '42'
+                      username:
+                        type: string
+                        nullable: true
+                        example: orpheus
+                      display_name:
+                        type: string
+                        example: Orpheus
+                      full_name:
+                        type: string
+                        example: Orpheus
+                      photo:
+                        type: string
+                        example: https://example.com/orpheus.png
+                      timezone:
+                        type: string
+                        example: America/New_York
+                      created_at:
+                        type: string
+                        format: date_time
+                      modified_at:
+                        type: string
+                        format: date_time
+                      plan:
+                        type: string
+                        example: free
+                    required:
+                    - id
+                    - display_name
+                    - full_name
+                    - photo
+                    - timezone
+                    - created_at
+                    - modified_at
+                    - plan
+                required:
+                - data
+        '401':
+          description: unauthorized
+  "/api/hackatime/v1/users/{id}/summaries":
+    get:
+      summary: Get daily summaries (WakaTime compatible)
+      tags:
+      - WakaTime Compatibility
+      description: Returns coding activity for an inclusive date range as WakaTime-compatible
+        daily summaries.
+      security:
+      - Bearer: []
+        ApiKeyAuth: []
+      parameters:
+      - name: id
+        in: path
+        description: User ID or "current" (recommended). The authenticated user is
+          resolved from the API token.
+        required: true
+        schema:
+          type: string
+      - name: start
+        in: query
+        format: date
+        required: true
+        description: Inclusive start date in YYYY-MM-DD format.
+        schema:
+          type: string
+      - name: end
+        in: query
+        format: date
+        required: true
+        description: Inclusive end date in YYYY-MM-DD format. The range may contain
+          at most 366 days.
+        schema:
+          type: string
+      - name: project
+        in: query
+        required: false
+        description: Only include activity for this project.
+        schema:
+          type: string
+      - name: timezone
+        in: query
+        required: false
+        description: Timezone used to segment days. Defaults to the user's timezone.
+        schema:
+          type: string
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        grand_total:
+                          type: object
+                          properties:
+                            total_seconds:
+                              type: integer
+                              example: 7200
+                            hours:
+                              type: integer
+                              example: 2
+                            minutes:
+                              type: integer
+                              example: 0
+                            seconds:
+                              type: integer
+                              example: 0
+                            digital:
+                              type: string
+                              example: '02:00:00'
+                            decimal:
+                              type: string
+                              example: '2.00'
+                            text:
+                              type: string
+                              example: 2h
+                            ai_input_tokens:
+                              type: integer
+                              format: int64
+                              nullable: true
+                              example: 1200
+                            ai_output_tokens:
+                              type: integer
+                              format: int64
+                              nullable: true
+                              example: 350
+                            ai_model_breakdown:
+                              type: array
+                              nullable: true
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                    example: gpt/5.6
+                                  lines:
+                                    type: integer
+                                    example: 18
+                          required:
+                          - total_seconds
+                          - hours
+                          - minutes
+                          - seconds
+                          - digital
+                          - decimal
+                          - text
+                        projects:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                example: hackatime
+                              total_seconds:
+                                type: integer
+                                example: 7200
+                              percent:
+                                type: number
+                                example: 100.0
+                              hours:
+                                type: integer
+                                example: 2
+                              minutes:
+                                type: integer
+                                example: 0
+                              seconds:
+                                type: integer
+                                example: 0
+                              digital:
+                                type: string
+                                example: '02:00:00'
+                              decimal:
+                                type: string
+                                example: '2.00'
+                              text:
+                                type: string
+                                example: 2h
+                        range:
+                          type: object
+                          properties:
+                            date:
+                              type: string
+                              format: date
+                            start:
+                              type: string
+                              format: date_time
+                            end:
+                              type: string
+                              format: date_time
+                            text:
+                              type: string
+                              example: Today
+                            timezone:
+                              type: string
+                              example: America/New_York
+                          required:
+                          - date
+                          - start
+                          - end
+                          - text
+                          - timezone
+                      required:
+                      - grand_total
+                      - projects
+                      - range
+                  cumulative_total:
+                    type: object
+                    properties:
+                      seconds:
+                        type: integer
+                        example: 7200
+                      text:
+                        type: string
+                        example: 2h
+                      decimal:
+                        type: string
+                        example: '2.00'
+                      digital:
+                        type: string
+                        example: '02:00:00'
+                  daily_average:
+                    type: object
+                    properties:
+                      holidays:
+                        type: integer
+                        example: 0
+                      days_including_holidays:
+                        type: integer
+                        example: 1
+                      days_minus_holidays:
+                        type: integer
+                        example: 1
+                      seconds:
+                        type: integer
+                        example: 7200
+                      text:
+                        type: string
+                        example: 2h
+                  start:
+                    type: string
+                    format: date
+                  end:
+                    type: string
+                    format: date
+                required:
+                - data
+                - cumulative_total
+                - daily_average
+                - start
+                - end
+        '400':
+          description: invalid date range
+        '401':
+          description: unauthorized
   "/api/hackatime/v1/users/{id}/statusbar/today":
     get:
       summary: Get status bar today

--- a/test/controllers/api/hackatime/v1/hackatime_controller_test.rb
+++ b/test/controllers/api/hackatime/v1/hackatime_controller_test.rb
@@ -386,6 +386,104 @@ class Api::Hackatime::V1::HackatimeControllerTest < ActionDispatch::IntegrationT
     assert_response :bad_request
   end
 
+  test "current user returns a WakaTime compatible profile" do
+    user = User.create!(
+      display_name_override: "Ada Lovelace",
+      slack_avatar_url: "https://example.com/ada.png",
+      timezone: "Europe/London",
+      username: "ada"
+    )
+    api_key = user.api_keys.create!(name: "primary")
+
+    get "/api/hackatime/v1/users/current",
+      headers: { "Authorization" => "Basic #{Base64.strict_encode64(api_key.token)}" }
+
+    assert_response :success
+    assert_equal(
+      {
+        "id" => user.id.to_s,
+        "username" => "ada",
+        "display_name" => "Ada Lovelace",
+        "full_name" => "Ada Lovelace",
+        "photo" => "https://example.com/ada.png",
+        "timezone" => "Europe/London",
+        "created_at" => user.created_at.iso8601,
+        "modified_at" => user.updated_at.iso8601,
+        "plan" => "free"
+      },
+      JSON.parse(response.body).fetch("data")
+    )
+  end
+
+  test "summaries return WakaTime compatible daily activity" do
+    user = User.create!(timezone: "UTC")
+    api_key = user.api_keys.create!(name: "primary")
+    start_time = Time.utc(2026, 8, 10, 10)
+
+    user.heartbeats.create!(
+      category: "coding", entity: "app/first.rb", project: "alpha",
+      source_type: :test_entry, time: start_time.to_f, type: "file"
+    )
+    user.heartbeats.create!(
+      ai_input_tokens: 100, ai_line_changes: 5, ai_model: "gpt/5.6", ai_output_tokens: 20,
+      category: "coding", entity: "app/second.rb", project: "alpha",
+      source_type: :test_entry, time: (start_time + 1.minute).to_f, type: "file"
+    )
+    user.heartbeats.create!(
+      category: "coding", entity: "app/third.rb", project: "beta",
+      source_type: :test_entry, time: (start_time + 2.minutes).to_f, type: "file"
+    )
+
+    get "/api/hackatime/v1/users/current/summaries",
+      params: { start: "2026-08-10", end: "2026-08-11" },
+      headers: { "Authorization" => "Basic #{Base64.strict_encode64(api_key.token)}" }
+
+    assert_response :success
+    payload = JSON.parse(response.body)
+    assert_equal [ "2026-08-10", "2026-08-11" ], payload.fetch("data").map { |day| day.dig("range", "date") }
+
+    active_day = payload.fetch("data").first
+    assert_equal 120, active_day.dig("grand_total", "total_seconds")
+    assert_equal 100, active_day.dig("grand_total", "ai_input_tokens")
+    assert_equal 20, active_day.dig("grand_total", "ai_output_tokens")
+    assert_equal [ { "name" => "gpt/5.6", "lines" => 5 } ], active_day.dig("grand_total", "ai_model_breakdown")
+    assert_equal(
+      [
+        { "name" => "alpha", "total_seconds" => 60, "percent" => 50.0 },
+        { "name" => "beta", "total_seconds" => 60, "percent" => 50.0 }
+      ],
+      active_day.fetch("projects").map { |project| project.slice("name", "total_seconds", "percent") }
+    )
+
+    assert_equal 0, payload.fetch("data").second.dig("grand_total", "total_seconds")
+    assert_equal 120, payload.dig("cumulative_total", "seconds")
+  end
+
+  test "summaries reject missing or invalid date ranges" do
+    user = User.create!(timezone: "UTC")
+    api_key = user.api_keys.create!(name: "primary")
+    headers = { "Authorization" => "Basic #{Base64.strict_encode64(api_key.token)}" }
+
+    get "/api/hackatime/v1/users/current/summaries", headers: headers
+    assert_response :bad_request
+
+    get "/api/hackatime/v1/users/current/summaries",
+      params: { start: "not-a-date", end: "2026-08-11" }, headers: headers
+    assert_response :bad_request
+
+    get "/api/hackatime/v1/users/current/summaries",
+      params: { start: "2026-08-12", end: "2026-08-11" }, headers: headers
+    assert_response :bad_request
+
+    get "/api/hackatime/v1/users/current/summaries",
+      params: { start: "2025-08-10", end: "2026-08-11" }, headers: headers
+    assert_response :bad_request
+
+    get "/api/hackatime/v1/users/current/summaries",
+      params: { start: "2026-08-11", end: "2026-08-11", timezone: "Not/A_Timezone" }, headers: headers
+    assert_response :bad_request
+  end
+
   test "status bar accepts API keys with Basic authentication" do
     user = User.create!(timezone: "UTC")
     api_key = user.api_keys.create!(name: "primary")

--- a/test/controllers/api/hackatime/v1/hackatime_controller_test.rb
+++ b/test/controllers/api/hackatime/v1/hackatime_controller_test.rb
@@ -449,8 +449,7 @@ class Api::Hackatime::V1::HackatimeControllerTest < ActionDispatch::IntegrationT
     assert_equal [ { "name" => "gpt/5.6", "lines" => 5 } ], active_day.dig("grand_total", "ai_model_breakdown")
     assert_equal(
       [
-        { "name" => "beta", "total_seconds" => 120, "percent" => 66.67 },
-        { "name" => "alpha", "total_seconds" => 60, "percent" => 33.33 }
+        { "name" => "alpha", "total_seconds" => 180, "percent" => 100.0 }
       ],
       active_day.fetch("projects").map { |project| project.slice("name", "total_seconds", "percent") }
     )

--- a/test/controllers/api/hackatime/v1/hackatime_controller_test.rb
+++ b/test/controllers/api/hackatime/v1/hackatime_controller_test.rb
@@ -431,7 +431,7 @@ class Api::Hackatime::V1::HackatimeControllerTest < ActionDispatch::IntegrationT
     )
     user.heartbeats.create!(
       category: "coding", entity: "app/third.rb", project: "beta",
-      source_type: :test_entry, time: (start_time + 2.minutes).to_f, type: "file"
+      source_type: :test_entry, time: (start_time + 5.minutes).to_f, type: "file"
     )
 
     get "/api/hackatime/v1/users/current/summaries",
@@ -443,20 +443,20 @@ class Api::Hackatime::V1::HackatimeControllerTest < ActionDispatch::IntegrationT
     assert_equal [ "2026-08-10", "2026-08-11" ], payload.fetch("data").map { |day| day.dig("range", "date") }
 
     active_day = payload.fetch("data").first
-    assert_equal 120, active_day.dig("grand_total", "total_seconds")
+    assert_equal 180, active_day.dig("grand_total", "total_seconds")
     assert_equal 100, active_day.dig("grand_total", "ai_input_tokens")
     assert_equal 20, active_day.dig("grand_total", "ai_output_tokens")
     assert_equal [ { "name" => "gpt/5.6", "lines" => 5 } ], active_day.dig("grand_total", "ai_model_breakdown")
     assert_equal(
       [
-        { "name" => "alpha", "total_seconds" => 60, "percent" => 50.0 },
-        { "name" => "beta", "total_seconds" => 60, "percent" => 50.0 }
+        { "name" => "beta", "total_seconds" => 120, "percent" => 66.67 },
+        { "name" => "alpha", "total_seconds" => 60, "percent" => 33.33 }
       ],
       active_day.fetch("projects").map { |project| project.slice("name", "total_seconds", "percent") }
     )
 
     assert_equal 0, payload.fetch("data").second.dig("grand_total", "total_seconds")
-    assert_equal 120, payload.dig("cumulative_total", "seconds")
+    assert_equal 180, payload.dig("cumulative_total", "seconds")
   end
 
   test "summaries reject missing or invalid date ranges" do


### PR DESCRIPTION
## Summary of the problem

Hackatime's WakaTime-compatible API returned 404 responses for the current user profile and daily summary routes required by clients using a custom instance. This caused correctly configured clients to report that the provider was unavailable.

## Describe your changes

- Add authenticated current user profile and daily summary endpoints under `/api/hackatime/v1`
- Build timezone-aware summaries with empty days, project breakdowns and AI counters

## Screenshots / Media

N/A