### PR TITLE
Override language when entity shows irrefutable evidence

### DIFF
--- a/app/lib/language_utils.rb
+++ b/app/lib/language_utils.rb
@@ -1,6 +1,12 @@
 module LanguageUtils
   DEFAULT_COLOR = "#888888"
 
+  # Some extensions are silly and report the wrong language for a given entity path.
+  # But, we know better!
+  # This means that we can just override the language when we think it's incorrect, and Hackatime
+  # will be accurate Most Of The Time(tm). Without this, it's the opposite!
+  AUTHORITATIVE_EXTENSIONS = %w[.luau].freeze
+
   def self.data
     @data ||= begin
       base = YAML.load_file(Rails.root.join("config/languages.yml"))
@@ -56,7 +62,16 @@ module LanguageUtils
   end
 
   def self.detect_from_entity(entity) = detect_from_filename(entity) || detect_from_extension(entity)
-  def self.fill_missing_language(raw, entity:) = blank_or_unknown?(raw) ? detect_from_entity(entity) : raw
+
+  def self.authoritative_language(entity)
+    return nil if entity.blank?
+    return nil unless AUTHORITATIVE_EXTENSIONS.include?(File.extname(entity).downcase)
+    detect_from_extension(entity)
+  end
+
+  def self.fill_missing_language(raw, entity:)
+    authoritative_language(entity) || (blank_or_unknown?(raw) ? detect_from_entity(entity) : raw)
+  end
 
   # Canonical display name: "js" → "JavaScript", "cpp" → "C++"
   def self.display_name(raw) = raw.blank? ? "Unknown" : (find_name(raw) || raw)

--- a/app/lib/language_utils.rb
+++ b/app/lib/language_utils.rb
@@ -70,7 +70,15 @@ module LanguageUtils
   end
 
   def self.fill_missing_language(raw, entity:)
-    authoritative_language(entity) || (blank_or_unknown?(raw) ? detect_from_entity(entity) : raw)
+    authoritative_language(entity) || legacy_fill_missing_language(raw, entity:)
+  end
+
+  # The pre-override fill, without AUTHORITATIVE_EXTENSIONS. Kept so the import
+  # dedup path can reproduce fields hashes stored before the override existed;
+  # routing those through the override would compute hashes that never existed
+  # and re-importing an old dump would mint duplicate heartbeats.
+  def self.legacy_fill_missing_language(raw, entity:)
+    blank_or_unknown?(raw) ? detect_from_entity(entity) : raw
   end
 
   # Canonical display name: "js" → "JavaScript", "cpp" → "C++"

--- a/app/services/heartbeat_ingest.rb
+++ b/app/services/heartbeat_ingest.rb
@@ -104,10 +104,8 @@ class HeartbeatIngest
 
     resolve_placeholders!(attrs, placeholder_state)
 
-    if attrs[:language].blank? || attrs[:language] == "Unknown"
-      inferred = LanguageUtils.detect_from_extension(attrs[:entity])
-      attrs[:language] = inferred if inferred
-    end
+    inferred = LanguageUtils.fill_missing_language(attrs[:language], entity: attrs[:entity])
+    attrs[:language] = inferred if inferred.present?
 
     attrs[:category] = default_category(attrs[:category], type: attrs[:type])
     attrs[:user_agent] = attrs[:user_agent].presence || attrs.delete(:plugin).presence || @request_context[:user_agent].presence

--- a/app/services/heartbeat_ingest.rb
+++ b/app/services/heartbeat_ingest.rb
@@ -306,7 +306,7 @@ class HeartbeatIngest
       type: hb[:type],
       category: hb[:category] || "coding",
       project: hb[:project],
-      language: LanguageUtils.fill_missing_language(hb[:language], entity: hb[:entity]),
+      language: LanguageUtils.legacy_fill_missing_language(hb[:language], entity: hb[:entity]),
       editor: hb[:editor].presence || user_agent_info[:editor].presence || legacy_user_agent[:editor].presence,
       operating_system: hb[:operating_system].presence || user_agent_info[:os].presence || legacy_user_agent[:os].presence,
       machine: hb[:machine].presence || hb[:machine_name_id].presence,

--- a/test/lib/language_utils_test.rb
+++ b/test/lib/language_utils_test.rb
@@ -30,4 +30,17 @@ class LanguageUtilsTest < Minitest::Test
   def test_custom_language_without_extension_conflict
     assert_equal "Lapse", LanguageUtils.find_name("Lapse")
   end
+
+  def test_authoritative_extension_overrides_client_reported_language
+    assert_equal "Luau", LanguageUtils.fill_missing_language("Lua", entity: "/a/main.luau")
+    assert_equal "Luau", LanguageUtils.fill_missing_language("PLAIN_TEXT", entity: "/a/main.luau")
+    assert_equal "Luau", LanguageUtils.fill_missing_language("luau", entity: "/a/MAIN.LUAU")
+    assert_equal "Luau", LanguageUtils.fill_missing_language(nil, entity: "/a/main.luau")
+  end
+
+  def test_non_authoritative_extensions_still_trust_the_client
+    assert_equal "Lua", LanguageUtils.fill_missing_language("Lua", entity: "/a/main.lua")
+    assert_equal "C++", LanguageUtils.fill_missing_language("C++", entity: "/a/foo.h")
+    assert_nil LanguageUtils.fill_missing_language(nil, entity: "/a/noext")
+  end
 end

--- a/test/services/heartbeat_ingest_test.rb
+++ b/test/services/heartbeat_ingest_test.rb
@@ -541,6 +541,28 @@ class HeartbeatIngestTest < ActiveSupport::TestCase
     end
   end
 
+  test "import heartbeat ingest recognizes legacy hashes stored before the language override" do
+    user = User.create!(timezone: "UTC")
+    raw = {
+      category: "coding",
+      entity: "/home/dev/main.luau",
+      language: "Lua",
+      project: "vm",
+      time: 1_700_000_000.0,
+      type: "file"
+    }
+    # Stored before AUTHORITATIVE_EXTENSIONS existed, so its hash was computed
+    # with the client-reported "Lua" rather than the corrected "Luau".
+    create_legacy_imported_heartbeat(user, raw)
+
+    assert_no_difference("user.heartbeats.count") do
+      result = HeartbeatIngest.call(user: user, mode: :import, heartbeats: [ raw ])
+
+      assert_equal 0, result.persisted_count
+      assert_equal 1, result.duplicate_count
+    end
+  end
+
   test "import heartbeat ingest recognizes legacy hashes containing placeholders" do
     user = User.create!(timezone: "UTC")
     raw = {


### PR DESCRIPTION
## Summary of the problem
Some extensions report the wrong language for a given filepath (e.g Lua for a `.luau` file)

## Describe your changes
Hardcode an authoritative extension list and override the language if we think it's wrong!

## Screenshots / Media
N/A