### PR TITLE
Install libvips in Rails Docker build stages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -110,6 +110,13 @@ RUN --mount=type=cache,target=/root/.bundle/cache \
 # layers. Rails and Blume consume those dependencies through read-only mounts.
 FROM ruby-base AS application-source
 
+# image_processing 2.0 loads Ruby Vips during Rails boot, so the stages that
+# boot Rails below (route helpers, asset precompilation) need libvips too.
+ENV LD_LIBRARY_PATH="/usr/local/lib"
+
+COPY --from=libvips /libvips/libvips-cpp.so /usr/local/lib/libvips-cpp.so
+RUN ln -s libvips-cpp.so /usr/local/lib/libvips.so.42
+
 COPY --from=javascript-dependencies /rails/vendor/fonts /rails/vendor/fonts
 COPY --exclude=blume.config.ts --exclude=docs . .
 


### PR DESCRIPTION
## Summary of the problem
- docker_build workflow has been failing on main since the dependency update in 6eb4b42c
- That commit bumped `image_processing` from 1.2 to 2.0, which loads Ruby Vips during Rails boot rather than lazily 
- The Dockerfile stages that boot Rails (route helper generation and asset precompilation) build from application-source, which has no libvips, so the build fails with `Could not open library 'vips.so.42'`. 2081b8cb fixed the CI runners but not the image build.

## Describe your changes
Copy the libvips library to the Rails Docker stages

## Screenshots / Media
N/A