### PR TITLE
Let admins read stats for users who have opted out of public lookup

### DIFF
--- a/app/controllers/api/summary_controller.rb
+++ b/app/controllers/api/summary_controller.rb
@@ -1,5 +1,7 @@
 module Api
   class SummaryController < ApplicationController
+    include PublicStatsAccess
+
     skip_before_action :verify_authenticity_token
     before_action :set_user
 
@@ -47,7 +49,7 @@ module Api
 
       @user = User.lookup_by_identifier(identifier)
       return render_not_found_json("User not found") unless @user
-      render_forbidden("User has disabled public stats") unless @user.allow_public_stats_lookup
+      render_forbidden("User has disabled public stats") unless @user.allow_public_stats_lookup || admin_stats_access?
     end
 
     def determine_date_range(interval, range, from_date, to_date)

--- a/app/controllers/api/v1/badges_controller.rb
+++ b/app/controllers/api/v1/badges_controller.rb
@@ -1,6 +1,8 @@
 module Api
   module V1
     class BadgesController < ApplicationController
+      include PublicStatsAccess
+
       skip_before_action :verify_authenticity_token
 
       # GET /api/v1/badge/:user_id/*project
@@ -11,7 +13,7 @@ module Api
       def show
         user = find_user(params[:user_id])
         return render_not_found_json("User not found") unless user
-        return render_forbidden("User has disabled public stats") unless user.allow_public_stats_lookup
+        return render_forbidden("User has disabled public stats") unless user.allow_public_stats_lookup || admin_stats_access?
 
         project_name = resolve_project_name(user, params[:project])
         return render_not_found_json("Project not found") unless project_name

--- a/app/controllers/api/v1/stats_controller.rb
+++ b/app/controllers/api/v1/stats_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::StatsController < ApplicationController
+  include PublicStatsAccess
+
   USER_LOOKUP_ACTIONS = [ :user_stats, :user_spans, :user_projects, :user_project, :user_projects_details ].freeze
 
   before_action :authenticate_stats_api_key!, only: [ :show ], unless: -> { Rails.env.development? }
@@ -180,6 +182,7 @@ class Api::V1::StatsController < ApplicationController
     return render_not_found_json("User not found") unless @user
     return if @user.allow_public_stats_lookup
     return if current_user == @user || @api_caller_user == @user
+    return if admin_stats_access?
     render_forbidden("user has disabled public stats")
   end
 

--- a/app/controllers/concerns/public_stats_access.rb
+++ b/app/controllers/concerns/public_stats_access.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# Lets admins read a user's stats on the public stats endpoints even when that
+# user has turned off `allow_public_stats_lookup`.
+#
+# These endpoints are anonymously accessible, so the admin credential is only
+# ever read from the `Authorization: Bearer` header. It is deliberately never
+# read from `?api_key=` (which several of these endpoints accept for ordinary
+# user keys) so a privileged token cannot end up in a URL, log line or referrer.
+#
+# This intentionally does NOT assign `@current_user`. `ApplicationController#current_user`
+# memoises into that ivar, so assigning it would silently authenticate the whole
+# request as the admin for every other `current_user` check in the request cycle.
+module PublicStatsAccess
+  extend ActiveSupport::Concern
+
+  private
+
+  # True when the caller may bypass the target's public stats preference.
+  def admin_stats_access?
+    return true if current_user&.can_view_private_stats?
+
+    admin_stats_viewer.present?
+  end
+
+  # The admin User behind the request's bearer token, or nil.
+  def admin_stats_viewer
+    return @admin_stats_viewer if defined?(@admin_stats_viewer)
+
+    @admin_stats_viewer = resolve_admin_stats_viewer
+  end
+
+  def resolve_admin_stats_viewer
+    scheme, token = request.headers["Authorization"].to_s.split(/\s+/, 2)
+    return nil unless scheme&.casecmp?("Bearer") && token.present?
+
+    admin_viewer_from_api_key(token) || admin_viewer_from_oauth(token)
+  end
+
+  def admin_viewer_from_api_key(token)
+    key = AdminApiKey.active.includes(:user).find_by(token: token)
+    return nil unless key
+
+    user = key.user
+    # Mirrors AdminApiKeyAuthentication: a key whose owner lost admin is dead.
+    return user if user&.can_view_private_stats?
+
+    key.revoke!
+    nil
+  end
+
+  def admin_viewer_from_oauth(token)
+    access_token = Doorkeeper::AccessToken.by_token(token)
+    return nil unless access_token&.acceptable?([ OauthApplication::ADMIN_SCOPE ])
+
+    application = access_token.application
+    return nil unless application&.admin_scope? && application.confidential? && application.verified?
+
+    user = User.find_by(id: access_token.resource_owner_id)
+    user if user&.can_view_private_stats?
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -111,6 +111,8 @@ class User < ApplicationRecord
   def can_convict_users? = admin_level_superadmin? || admin_level_ultraadmin?
   def can_leaderboard_shadowban_users? = admin_level.in?(%w[admin superadmin ultraadmin])
   def can_view_query_stats? = admin_level.in?(%w[viewer admin superadmin ultraadmin])
+  # Read another user's stats even when they've turned off public stats lookup.
+  def can_view_private_stats? = admin_level.in?(%w[viewer admin superadmin ultraadmin])
   def admin_level_rank = ADMIN_LEVEL_RANK[admin_level.to_s] || 0
 
   def can_impersonate?(target_user)

--- a/spec/requests/api/summary_spec.rb
+++ b/spec/requests/api/summary_spec.rb
@@ -7,7 +7,9 @@ RSpec.describe 'Api::Summary', type: :request do
       description 'Returns a summary of coding activity in a format compatible with WakaTime clients. ' \
                   'This endpoint does NOT authenticate any API token: access is gated solely by the target ' \
                   'user (identified by user_id/user) having allow_public_stats_lookup enabled. No caller ' \
-                  'credentials are required or verified.'
+                  'credentials are required or verified, with one exception: admins may bypass that setting ' \
+                  'by supplying an Admin API Key (or an OAuth token with the `admin` scope) in the ' \
+                  '`Authorization: Bearer` header. Admin credentials are never accepted in the `api_key` query param.'
       produces 'application/json'
 
       parameter name: :start, in: :query, schema: { type: :string, format: :date }, description: 'Start date (YYYY-MM-DD). Requires "end"/"to" to be set as well to form an explicit range.'

--- a/spec/requests/api/v1/badges_spec.rb
+++ b/spec/requests/api/v1/badges_spec.rb
@@ -33,6 +33,10 @@ RSpec.describe 'Api::V1::Badges', type: :request do
         time a user has logged on a project. The endpoint is public (no auth) but
         only works for users who have not disabled public stats lookup.
 
+        Admins may bypass that setting by supplying an Admin API Key (or an OAuth
+        token with the `admin` scope) in the `Authorization: Bearer` header. Admin
+        credentials are never accepted in the `api_key` query param.
+
         `user_id` is matched, in order, against the user's Slack UID, then
         username, then (only when the value is all digits) the internal numeric
         ID. `project` may be a raw project name (e.g. `hackatime`) or an

--- a/spec/requests/api/v1/stats_spec.rb
+++ b/spec/requests/api/v1/stats_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe 'Api::V1::Stats', type: :request do
   path '/api/v1/users/{username}/heartbeats/spans' do
     get('Get user heartbeat spans') do
       tags 'Stats'
-      description 'Returns heartbeat spans for a user, useful for visualizations. Accessible anonymously when the target user has public stats lookup enabled; otherwise the requester must be the user (authenticated via the User API Key).'
+      description 'Returns heartbeat spans for a user, useful for visualizations. Accessible anonymously when the target user has public stats lookup enabled; otherwise the requester must be the user (authenticated via the User API Key). Admins may bypass the target public stats lookup setting by supplying an Admin API Key (or an OAuth token with the `admin` scope) in the `Authorization: Bearer` header. Admin credentials are never accepted in the `api_key` query param.'
       produces 'application/json'
 
       parameter name: :username, in: :path, type: :string, description: 'Username, Slack ID, or User ID. The literal value "my" resolves the user from the Authorization Bearer token.'
@@ -187,7 +187,7 @@ RSpec.describe 'Api::V1::Stats', type: :request do
   path '/api/v1/users/{username}/projects' do
     get('Get user project names') do
       tags 'Stats'
-      description 'Returns a list of project names for a user from the last 30 days. Accessible anonymously when the target user has public stats lookup enabled.'
+      description 'Returns a list of project names for a user from the last 30 days. Accessible anonymously when the target user has public stats lookup enabled. Admins may bypass the target public stats lookup setting by supplying an Admin API Key (or an OAuth token with the `admin` scope) in the `Authorization: Bearer` header. Admin credentials are never accepted in the `api_key` query param.'
       produces 'application/json'
 
       parameter name: :username, in: :path, type: :string, description: 'Username, Slack ID, or User ID'
@@ -226,7 +226,7 @@ RSpec.describe 'Api::V1::Stats', type: :request do
   path '/api/v1/users/{username}/project/{project_name}' do
     get('Get user project details') do
       tags 'Stats'
-      description 'Returns details for a specific project. Accessible anonymously when the target user has public stats lookup enabled.'
+      description 'Returns details for a specific project. Accessible anonymously when the target user has public stats lookup enabled. Admins may bypass the target public stats lookup setting by supplying an Admin API Key (or an OAuth token with the `admin` scope) in the `Authorization: Bearer` header. Admin credentials are never accepted in the `api_key` query param.'
       produces 'application/json'
 
       parameter name: :username, in: :path, type: :string, description: 'Username, Slack ID, or User ID'
@@ -301,7 +301,7 @@ RSpec.describe 'Api::V1::Stats', type: :request do
   path '/api/v1/users/{username}/projects/details' do
     get('Get details for multiple projects') do
       tags 'Stats'
-      description 'Returns details for multiple projects, or all projects in a time range. Accessible anonymously when the target user has public stats lookup enabled.'
+      description 'Returns details for multiple projects, or all projects in a time range. Accessible anonymously when the target user has public stats lookup enabled. Admins may bypass the target public stats lookup setting by supplying an Admin API Key (or an OAuth token with the `admin` scope) in the `Authorization: Bearer` header. Admin credentials are never accepted in the `api_key` query param.'
       produces 'application/json'
 
       parameter name: :username, in: :path, type: :string, description: 'Username, Slack ID, or User ID'
@@ -389,6 +389,8 @@ RSpec.describe 'Api::V1::Stats', type: :request do
         Returns detailed coding stats for a specific user, including languages, projects, and total time.
 
         Authentication is OPTIONAL: the endpoint is publicly accessible (no token) whenever the target user has public stats lookup enabled. When a User API Key is supplied it is used to resolve the special username "my" and to grant access to the caller's own private stats.
+
+        Admins may bypass the target public stats lookup setting by supplying an Admin API Key (or an OAuth token with the `admin` scope) in the `Authorization: Bearer` header. Admin credentials are never accepted in the `api_key` query param.
 
         When total_seconds=true, the response shape is instead { "total_seconds": <number> }.
       DESC

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -870,7 +870,10 @@ paths:
       description: 'Returns a summary of coding activity in a format compatible with
         WakaTime clients. This endpoint does NOT authenticate any API token: access
         is gated solely by the target user (identified by user_id/user) having allow_public_stats_lookup
-        enabled. No caller credentials are required or verified.'
+        enabled. No caller credentials are required or verified, with one exception:
+        admins may bypass that setting by supplying an Admin API Key (or an OAuth
+        token with the `admin` scope) in the `Authorization: Bearer` header. Admin
+        credentials are never accepted in the `api_key` query param.'
       parameters:
       - name: start
         in: query
@@ -1320,6 +1323,10 @@ paths:
         time a user has logged on a project. The endpoint is public (no auth) but
         only works for users who have not disabled public stats lookup.
 
+        Admins may bypass that setting by supplying an Admin API Key (or an OAuth
+        token with the `admin` scope) in the `Authorization: Bearer` header. Admin
+        credentials are never accepted in the `api_key` query param.
+
         `user_id` is matched, in order, against the user's Slack UID, then
         username, then (only when the value is all digits) the internal numeric
         ID. `project` may be a raw project name (e.g. `hackatime`) or an
@@ -1726,9 +1733,13 @@ paths:
       summary: Get user heartbeat spans
       tags:
       - Stats
-      description: Returns heartbeat spans for a user, useful for visualizations.
+      description: 'Returns heartbeat spans for a user, useful for visualizations.
         Accessible anonymously when the target user has public stats lookup enabled;
         otherwise the requester must be the user (authenticated via the User API Key).
+        Admins may bypass the target public stats lookup setting by supplying an Admin
+        API Key (or an OAuth token with the `admin` scope) in the `Authorization:
+        Bearer` header. Admin credentials are never accepted in the `api_key` query
+        param.'
       parameters:
       - name: username
         in: path
@@ -1853,8 +1864,12 @@ paths:
       summary: Get user project names
       tags:
       - Stats
-      description: Returns a list of project names for a user from the last 30 days.
+      description: 'Returns a list of project names for a user from the last 30 days.
         Accessible anonymously when the target user has public stats lookup enabled.
+        Admins may bypass the target public stats lookup setting by supplying an Admin
+        API Key (or an OAuth token with the `admin` scope) in the `Authorization:
+        Bearer` header. Admin credentials are never accepted in the `api_key` query
+        param.'
       parameters:
       - name: username
         in: path
@@ -1893,8 +1908,11 @@ paths:
       summary: Get user project details
       tags:
       - Stats
-      description: Returns details for a specific project. Accessible anonymously
-        when the target user has public stats lookup enabled.
+      description: 'Returns details for a specific project. Accessible anonymously
+        when the target user has public stats lookup enabled. Admins may bypass the
+        target public stats lookup setting by supplying an Admin API Key (or an OAuth
+        token with the `admin` scope) in the `Authorization: Bearer` header. Admin
+        credentials are never accepted in the `api_key` query param.'
       parameters:
       - name: username
         in: path
@@ -2001,9 +2019,12 @@ paths:
       summary: Get details for multiple projects
       tags:
       - Stats
-      description: Returns details for multiple projects, or all projects in a time
+      description: 'Returns details for multiple projects, or all projects in a time
         range. Accessible anonymously when the target user has public stats lookup
-        enabled.
+        enabled. Admins may bypass the target public stats lookup setting by supplying
+        an Admin API Key (or an OAuth token with the `admin` scope) in the `Authorization:
+        Bearer` header. Admin credentials are never accepted in the `api_key` query
+        param.'
       parameters:
       - name: username
         in: path
@@ -2129,6 +2150,8 @@ paths:
         Returns detailed coding stats for a specific user, including languages, projects, and total time.
 
         Authentication is OPTIONAL: the endpoint is publicly accessible (no token) whenever the target user has public stats lookup enabled. When a User API Key is supplied it is used to resolve the special username "my" and to grant access to the caller's own private stats.
+
+        Admins may bypass the target public stats lookup setting by supplying an Admin API Key (or an OAuth token with the `admin` scope) in the `Authorization: Bearer` header. Admin credentials are never accepted in the `api_key` query param.
 
         When total_seconds=true, the response shape is instead { "total_seconds": <number> }.
       security:

--- a/test/integration/admin_public_stats_access_test.rb
+++ b/test/integration/admin_public_stats_access_test.rb
@@ -1,0 +1,87 @@
+require "test_helper"
+
+# Admins may read a user's stats on the public stats endpoints even when that
+# user has turned off allow_public_stats_lookup. These endpoints are anonymously
+# accessible, so the credential handling is security sensitive.
+class AdminPublicStatsAccessTest < ActionDispatch::IntegrationTest
+  setup do
+    @private_user = User.create!(username: "priv_#{SecureRandom.hex(4)}",
+                                 slack_uid: "U#{SecureRandom.hex(5).upcase}",
+                                 timezone: "UTC",
+                                 allow_public_stats_lookup: false)
+    @private_user.email_addresses.create!(email: "target-#{SecureRandom.hex(4)}@example.com")
+
+    @admin = User.create!(username: "adm_#{SecureRandom.hex(4)}", timezone: "UTC", admin_level: :superadmin)
+    @admin.email_addresses.create!(email: "admin-#{SecureRandom.hex(4)}@example.com")
+    @admin_key = AdminApiKey.create!(user: @admin, name: "stats bypass test #{SecureRandom.hex(4)}")
+
+    @plain_user = User.create!(username: "pln_#{SecureRandom.hex(4)}", timezone: "UTC")
+    @plain_user.email_addresses.create!(email: "plain-#{SecureRandom.hex(4)}@example.com")
+    @plain_key = ApiKey.create!(user: @plain_user, name: "plain test key")
+  end
+
+  def stats_path = "/api/v1/users/#{@private_user.slack_uid}/stats"
+  def bearer(token) = { "Authorization" => "Bearer #{token}" }
+
+  test "anonymous callers cannot read a private user's stats" do
+    get stats_path
+    assert_response :forbidden
+  end
+
+  test "an ordinary user API key cannot read a private user's stats" do
+    get stats_path, headers: bearer(@plain_key.token)
+    assert_response :forbidden
+  end
+
+  test "an admin API key can read a private user's stats" do
+    get stats_path, headers: bearer(@admin_key.token)
+    assert_response :success
+    assert JSON.parse(response.body).key?("data")
+  end
+
+  test "an admin API key in the api_key query param is ignored" do
+    get stats_path, params: { api_key: @admin_key.token }
+    assert_response :forbidden
+  end
+
+  test "a revoked admin API key cannot read a private user's stats" do
+    @admin_key.revoke!
+    get stats_path, headers: bearer(@admin_key.token)
+    assert_response :forbidden
+  end
+
+  test "a key whose owner lost admin is rejected and revoked" do
+    @admin.update!(admin_level: :default)
+    get stats_path, headers: bearer(@admin_key.token)
+    assert_response :forbidden
+    assert_not @admin_key.reload.active?
+  end
+
+  test "an admin API key does not authenticate the session as the admin" do
+    get stats_path, headers: bearer(@admin_key.token)
+    assert_response :success
+    assert_nil session[:user_id]
+  end
+
+  test "users who allow public stats lookup are still served anonymously" do
+    @private_user.update!(allow_public_stats_lookup: true)
+    get stats_path
+    assert_response :success
+  end
+
+  test "admin API key bypasses the privacy gate on the summary endpoint" do
+    get "/api/summary", params: { user_id: @private_user.slack_uid, interval: "today" }
+    assert_response :forbidden
+
+    get "/api/summary", params: { user_id: @private_user.slack_uid, interval: "today" }, headers: bearer(@admin_key.token)
+    assert_response :success
+  end
+
+  test "admin API key bypasses the privacy gate on the badge endpoint" do
+    get "/api/v1/badge/#{@private_user.slack_uid}/some-project"
+    assert_response :forbidden
+
+    get "/api/v1/badge/#{@private_user.slack_uid}/some-project", headers: bearer(@admin_key.token)
+    assert_not_equal 403, response.status
+  end
+end


### PR DESCRIPTION
## Summary of the problem

An admin could not read coding time for a user who had turned off `allow_public_stats_lookup`. `GET /api/v1/users/:username/stats` returned 403 regardless of who was asking, and passing an admin API key made no difference because the public stats controller only recognises user API keys and user OAuth tokens.

The admin API namespace was not a workaround either. `/api/admin/v1/user/projects` is also not very full featured (and I want to deprecate it at some point...)

## Screenshots / Media

Not applicable, no visual changes.
