### PR TITLE
Move leaderboard shadowbans to admin navigation

### DIFF
--- a/app/controllers/inertia_controller.rb
+++ b/app/controllers/inertia_controller.rb
@@ -87,20 +87,20 @@ class InertiaController < ApplicationController
   ADMIN_NAV_LINKS = [
     [ :admin_timeline_path, "Review Timeline" ],
     [ :admin_trust_level_audit_logs_path, "Trust Level Logs", "/admin/trust_level_audit_logs" ],
-    [ :admin_admin_api_keys_path, "Admin API Keys", "/admin/admin_api_keys" ]
+    [ :admin_admin_api_keys_path, "Admin API Keys", "/admin/admin_api_keys" ],
+    [ :admin_leaderboard_shadowbans_path, "Leaderboard Shadowbans", "/admin/leaderboard_shadowbans" ]
   ].freeze
+  VIEWER_NAV_LINKS = ADMIN_NAV_LINKS.take_while { |path_method,| path_method != :admin_leaderboard_shadowbans_path }.freeze
 
   def inertia_admin_links
     return [] unless current_user&.admin_level.in?(%w[admin superadmin ultraadmin])
 
-    links = build_nav_from(ADMIN_NAV_LINKS)
-    links << inertia_leaderboard_shadowbans_link if current_user.admin_level == "admin"
-    links
+    build_nav_from(ADMIN_NAV_LINKS)
   end
 
   def inertia_viewer_links
     return [] unless current_user&.admin_level == "viewer"
-    build_nav_from(ADMIN_NAV_LINKS)
+    build_nav_from(VIEWER_NAV_LINKS)
   end
 
   def inertia_superadmin_links
@@ -110,13 +110,8 @@ class InertiaController < ApplicationController
     [
       inertia_link("Admin Management", admin_admin_users_path, active: helpers.current_page?(admin_admin_users_path)),
       inertia_link("Account Deletions", admin_deletion_requests_path, active: helpers.current_page?(admin_deletion_requests_path), badge: pending_count.positive? ? pending_count : nil),
-      inertia_link("All OAuth Apps", admin_oauth_applications_path, active: helpers.current_page?(admin_oauth_applications_path) || request.path.start_with?("/admin/oauth_applications")),
-      inertia_leaderboard_shadowbans_link
+      inertia_link("All OAuth Apps", admin_oauth_applications_path, active: helpers.current_page?(admin_oauth_applications_path) || request.path.start_with?("/admin/oauth_applications"))
     ]
-  end
-
-  def inertia_leaderboard_shadowbans_link
-    inertia_link("Leaderboard Shadowbans", admin_leaderboard_shadowbans_path, active: helpers.current_page?(admin_leaderboard_shadowbans_path) || request.path.start_with?("/admin/leaderboard_shadowbans"), tool: "admin-tool")
   end
 
   def inertia_ultraadmin_links

--- a/test/controllers/admin/admin_users_controller_test.rb
+++ b/test/controllers/admin/admin_users_controller_test.rb
@@ -29,11 +29,14 @@ class Admin::AdminUsersControllerTest < ActionDispatch::IntegrationTest
   test "translated admin navigation uses Inertia links" do
     get admin_admin_users_path
 
-    links = inertia_page.dig("props", "layout", "nav").values_at("admin_links", "superadmin_links").flatten
+    nav = inertia_page.dig("props", "layout", "nav")
+    admin_links = nav.fetch("admin_links")
+    superadmin_links = nav.fetch("superadmin_links")
+    links = admin_links + superadmin_links
 
-    assert_equal [ "Review Timeline", "Trust Level Logs", "Admin API Keys", "Admin Management", "Account Deletions", "All OAuth Apps", "Leaderboard Shadowbans" ], links.pluck("label")
+    assert_equal [ "Review Timeline", "Trust Level Logs", "Admin API Keys", "Leaderboard Shadowbans" ], admin_links.pluck("label")
+    assert_equal [ "Admin Management", "Account Deletions", "All OAuth Apps" ], superadmin_links.pluck("label")
     assert links.all? { |link| link.fetch("inertia") }
-    assert_equal "admin-tool", links.last.fetch("tool")
   end
 
   test "search reload returns only authorised search results" do


### PR DESCRIPTION
## Summary of the problem

Leaderboard Shadowbans appeared in the superadmin navigation group rather than the admin group.

Closes #1580

## Describe your changes

Places Leaderboard Shadowbans directly after Admin API Keys in the admin navigation while keeping it unavailable to viewer-level admins.

## Screenshots / Media

Not applicable.