### PR TITLE
Fix leaderboard loading layout shift

### DIFF
--- a/app/javascript/pages/Leaderboards/Index.svelte
+++ b/app/javascript/pages/Leaderboards/Index.svelte
@@ -128,6 +128,11 @@
             class="h-9 w-full rounded-full border border-surface-200 bg-darkless pl-9 pr-3 text-sm text-surface-content placeholder:text-muted focus:border-primary/60 focus:outline-none focus:ring-2 focus:ring-primary/30 transition-colors"
           />
         </div>
+      {:else if leaderboard && entries === undefined}
+        <div
+          aria-hidden="true"
+          class="h-9 w-full rounded-full bg-darkless sm:w-64 sm:shrink-0 animate-pulse"
+        ></div>
       {/if}
     </div>
   </div>
@@ -138,9 +143,11 @@
         {#snippet fallback()}
           <div class="divide-y divide-gray-800">
             {#each Array(20) as _}
-              <div class="flex items-center p-2 animate-pulse">
-                <div class="w-12 h-6 bg-darkless rounded shrink-0"></div>
-                <div class="w-8 h-8 bg-darkless rounded-full mx-4"></div>
+              <div class="flex h-16 items-center p-2 sm:p-3 animate-pulse">
+                <div class="w-8 sm:w-12 h-6 bg-darkless rounded shrink-0"></div>
+                <div
+                  class="w-8 h-8 bg-darkless rounded-full mx-1 sm:mx-4"
+                ></div>
                 <div class="flex-1">
                   <div class="h-4 w-32 bg-darkless rounded"></div>
                 </div>

--- a/app/javascript/pages/Leaderboards/Index.svelte
+++ b/app/javascript/pages/Leaderboards/Index.svelte
@@ -143,7 +143,9 @@
         {#snippet fallback()}
           <div class="divide-y divide-gray-800">
             {#each Array(20) as _}
-              <div class="flex h-16 items-center p-2 sm:p-3 animate-pulse">
+              <div
+                class="flex h-16 items-center gap-2 p-2 sm:gap-0 sm:p-3 animate-pulse"
+              >
                 <div class="w-8 sm:w-12 h-6 bg-darkless rounded shrink-0"></div>
                 <div
                   class="w-8 h-8 bg-darkless rounded-full mx-1 sm:mx-4"


### PR DESCRIPTION
## Summary of the problem

On leaderboard reload, the deferred entries fallback removed the search control and used different row dimensions. The page content moved when the entries finished loading.

Fixes #1595.

## Describe your changes

Reserve the search control footprint while entries load and align the skeleton row height and responsive spacing with the loaded leaderboard rows.

## Screenshots / Media

The brief loading transition is shown in the linked issue recording.