### PR TITLE
Remap swapped macOS WakaTime Zed heartbeats

### DIFF
--- a/app/lib/heartbeat_payload_remapper.rb
+++ b/app/lib/heartbeat_payload_remapper.rb
@@ -1,0 +1,56 @@
+class HeartbeatPayloadRemapper
+  ZED_PROJECT_FIRST_VERSION = Gem::Version.new("0.162.0")
+  MACOS_WAKATIME_ZED_FIX_VERSION = Gem::Version.new("5.28.5-alpha.1")
+  AUTHORITATIVE_LANGUAGE_EXTENSIONS = %w[.luau].freeze
+
+  def self.remap_fields(attributes, user_agent: attributes[:user_agent])
+    attributes = attributes.dup
+    remap_macos_wakatime_zed_fields!(attributes, user_agent:)
+    attributes
+  end
+
+  def self.remap_language(attributes)
+    attributes = attributes.dup
+    attributes[:language] = authoritative_language(attributes[:entity]) ||
+      legacy_language(attributes[:language], entity: attributes[:entity])
+    attributes
+  end
+
+  # Kept for import deduplication against hashes stored before authoritative
+  # language corrections were introduced.
+  def self.legacy_language(raw, entity:)
+    blank_or_unknown?(raw) ? LanguageUtils.detect_from_entity(entity) : raw
+  end
+
+  def self.remap_macos_wakatime_zed_fields!(attributes, user_agent:)
+    return unless attributes[:type] == "app"
+
+    zed_version = product_version(user_agent, "Zed")
+    macos_wakatime_version = product_version(user_agent, "macos-wakatime")
+    return unless zed_version && macos_wakatime_version
+    return unless zed_version >= ZED_PROJECT_FIRST_VERSION
+    return unless macos_wakatime_version < MACOS_WAKATIME_ZED_FIX_VERSION
+
+    attributes[:entity], attributes[:project] = attributes[:project], attributes[:entity]
+  end
+  private_class_method :remap_macos_wakatime_zed_fields!
+
+  def self.authoritative_language(entity)
+    return if entity.blank?
+    return unless AUTHORITATIVE_LANGUAGE_EXTENSIONS.include?(File.extname(entity).downcase)
+
+    LanguageUtils.detect_from_extension(entity)
+  end
+  private_class_method :authoritative_language
+
+  def self.blank_or_unknown?(raw) = raw.blank? || raw.to_s.strip.casecmp("unknown").zero?
+  private_class_method :blank_or_unknown?
+
+  def self.product_version(user_agent, product)
+    version = user_agent.to_s.match(/(?:\A|\s)#{Regexp.escape(product)}\/([^\s]+)/i)&.captures&.first
+    Gem::Version.new(version&.split("+")&.first)
+  rescue ArgumentError
+    nil
+  end
+  private_class_method :product_version
+end

--- a/app/lib/language_utils.rb
+++ b/app/lib/language_utils.rb
@@ -1,12 +1,6 @@
 module LanguageUtils
   DEFAULT_COLOR = "#888888"
 
-  # Some extensions are silly and report the wrong language for a given entity path.
-  # But, we know better!
-  # This means that we can just override the language when we think it's incorrect, and Hackatime
-  # will be accurate Most Of The Time(tm). Without this, it's the opposite!
-  AUTHORITATIVE_EXTENSIONS = %w[.luau].freeze
-
   def self.data
     @data ||= begin
       base = YAML.load_file(Rails.root.join("config/languages.yml"))
@@ -52,7 +46,6 @@ module LanguageUtils
     alias_map[key] || data.keys.find { |name| name.downcase == key }
   end
 
-  def self.blank_or_unknown?(raw) = raw.blank? || raw.to_s.strip.casecmp("unknown").zero?
   def self.detect_from_filename(entity) = entity.present? ? filename_map[File.basename(entity).downcase] : nil
 
   def self.detect_from_extension(entity)
@@ -62,24 +55,6 @@ module LanguageUtils
   end
 
   def self.detect_from_entity(entity) = detect_from_filename(entity) || detect_from_extension(entity)
-
-  def self.authoritative_language(entity)
-    return nil if entity.blank?
-    return nil unless AUTHORITATIVE_EXTENSIONS.include?(File.extname(entity).downcase)
-    detect_from_extension(entity)
-  end
-
-  def self.fill_missing_language(raw, entity:)
-    authoritative_language(entity) || legacy_fill_missing_language(raw, entity:)
-  end
-
-  # The pre-override fill, without AUTHORITATIVE_EXTENSIONS. Kept so the import
-  # dedup path can reproduce fields hashes stored before the override existed;
-  # routing those through the override would compute hashes that never existed
-  # and re-importing an old dump would mint duplicate heartbeats.
-  def self.legacy_fill_missing_language(raw, entity:)
-    blank_or_unknown?(raw) ? detect_from_entity(entity) : raw
-  end
 
   # Canonical display name: "js" → "JavaScript", "cpp" → "C++"
   def self.display_name(raw) = raw.blank? ? "Unknown" : (find_name(raw) || raw)

--- a/app/services/heartbeat_ingest.rb
+++ b/app/services/heartbeat_ingest.rb
@@ -5,9 +5,6 @@ class HeartbeatIngest
   LAST_BRANCH_SENTINEL = "<<LAST_BRANCH>>"
   LAST_PROJECT_SENTINEL = "<<LAST_PROJECT>>"
 
-  ZED_PROJECT_FIRST_VERSION = Gem::Version.new("0.162.0")
-  MACOS_WAKATIME_ZED_FIX_VERSION = Gem::Version.new("5.28.5-alpha.1")
-
   # Sane epoch-seconds window: 2001-09-09 .. 2033-05-18. Values outside are
   # client bugs (uptime-like numbers, literal years, ms/µs/ns-scaled epochs).
   EPOCH_SANE_MIN = 1_000_000_000
@@ -103,14 +100,12 @@ class HeartbeatIngest
     attrs = strip_null_bytes(heartbeat.to_h.with_indifferent_access)
     attrs[:time] = normalize_heartbeat_time(attrs[:time])
     attrs[:user_agent] = attrs[:user_agent].presence || attrs.delete(:plugin).presence || @request_context[:user_agent].presence
-    remap_macos_wakatime_zed_heartbeat!(attrs)
+    attrs = HeartbeatPayloadRemapper.remap_fields(attrs)
     source_type = attrs[:entity] == "test.txt" ? :test_entry : :direct_entry
     attrs[:project] = sanitize_project(attrs[:project])
 
     resolve_placeholders!(attrs, placeholder_state)
-
-    inferred = LanguageUtils.fill_missing_language(attrs[:language], entity: attrs[:entity])
-    attrs[:language] = inferred if inferred.present?
+    attrs = HeartbeatPayloadRemapper.remap_language(attrs)
 
     attrs[:category] = default_category(attrs[:category], type: attrs[:type])
     parsed_ua = WakatimeUserAgentParser.parse(attrs[:user_agent], category: attrs[:category])
@@ -220,7 +215,7 @@ class HeartbeatIngest
     source_heartbeat = hb.dup
     user_agent_info = (@user_agents_by_id[hb[:user_agent_id].to_s] || {}).with_indifferent_access
     resolved_user_agent = hb[:user_agent].presence || user_agent_info[:value].presence || hb[:user_agent_id].presence
-    remap_macos_wakatime_zed_heartbeat!(hb, user_agent: resolved_user_agent)
+    hb = HeartbeatPayloadRemapper.remap_fields(hb, user_agent: resolved_user_agent)
     parsed_user_agent = parse_user_agent(resolved_user_agent, category: hb[:category])
     derived_ai_editor = parsed_user_agent[:editor].presence if parsed_user_agent[:ai_model].present?
 
@@ -256,7 +251,7 @@ class HeartbeatIngest
       source_type: Heartbeat.source_types.fetch("wakapi_import")
     }
     resolve_placeholders!(attrs, placeholder_state)
-    attrs[:language] = LanguageUtils.fill_missing_language(attrs[:language], entity: attrs[:entity])
+    attrs = HeartbeatPayloadRemapper.remap_language(attrs)
     attrs[:category] = default_category(attrs[:category], type: attrs[:type])
     model_attributes = validated_model_attributes(attrs)
     normalized = model_attributes
@@ -312,7 +307,7 @@ class HeartbeatIngest
       type: hb[:type],
       category: hb[:category] || "coding",
       project: hb[:project],
-      language: LanguageUtils.legacy_fill_missing_language(hb[:language], entity: hb[:entity]),
+      language: HeartbeatPayloadRemapper.legacy_language(hb[:language], entity: hb[:entity]),
       editor: hb[:editor].presence || user_agent_info[:editor].presence || legacy_user_agent[:editor].presence,
       operating_system: hb[:operating_system].presence || user_agent_info[:os].presence || legacy_user_agent[:os].presence,
       machine: hb[:machine].presence || hb[:machine_name_id].presence,
@@ -435,25 +430,6 @@ class HeartbeatIngest
     return "browsing" if %w[domain url].include?(type)
 
     "coding"
-  end
-
-  def remap_macos_wakatime_zed_heartbeat!(heartbeat, user_agent: heartbeat[:user_agent])
-    return unless heartbeat[:type] == "app"
-
-    zed_version = product_version(user_agent, "Zed")
-    macos_wakatime_version = product_version(user_agent, "macos-wakatime")
-    return unless zed_version && macos_wakatime_version
-    return unless zed_version >= ZED_PROJECT_FIRST_VERSION
-    return unless macos_wakatime_version < MACOS_WAKATIME_ZED_FIX_VERSION
-
-    heartbeat[:entity], heartbeat[:project] = heartbeat[:project], heartbeat[:entity]
-  end
-
-  def product_version(user_agent, product)
-    version = user_agent.to_s.match(/(?:\A|\s)#{Regexp.escape(product)}\/([^\s]+)/i)&.captures&.first
-    Gem::Version.new(version&.split("+")&.first)
-  rescue ArgumentError
-    nil
   end
 
   # `<<LAST_PROJECT>>` stays persisted by design, but language and branch need

--- a/app/services/heartbeat_ingest.rb
+++ b/app/services/heartbeat_ingest.rb
@@ -5,6 +5,9 @@ class HeartbeatIngest
   LAST_BRANCH_SENTINEL = "<<LAST_BRANCH>>"
   LAST_PROJECT_SENTINEL = "<<LAST_PROJECT>>"
 
+  ZED_PROJECT_FIRST_VERSION = Gem::Version.new("0.162.0")
+  MACOS_WAKATIME_ZED_FIX_VERSION = Gem::Version.new("5.28.5-alpha.1")
+
   # Sane epoch-seconds window: 2001-09-09 .. 2033-05-18. Values outside are
   # client bugs (uptime-like numbers, literal years, ms/µs/ns-scaled epochs).
   EPOCH_SANE_MIN = 1_000_000_000
@@ -99,6 +102,8 @@ class HeartbeatIngest
   def normalize_direct_heartbeat(heartbeat, placeholder_state:)
     attrs = strip_null_bytes(heartbeat.to_h.with_indifferent_access)
     attrs[:time] = normalize_heartbeat_time(attrs[:time])
+    attrs[:user_agent] = attrs[:user_agent].presence || attrs.delete(:plugin).presence || @request_context[:user_agent].presence
+    remap_macos_wakatime_zed_heartbeat!(attrs)
     source_type = attrs[:entity] == "test.txt" ? :test_entry : :direct_entry
     attrs[:project] = sanitize_project(attrs[:project])
 
@@ -108,7 +113,6 @@ class HeartbeatIngest
     attrs[:language] = inferred if inferred.present?
 
     attrs[:category] = default_category(attrs[:category], type: attrs[:type])
-    attrs[:user_agent] = attrs[:user_agent].presence || attrs.delete(:plugin).presence || @request_context[:user_agent].presence
     parsed_ua = WakatimeUserAgentParser.parse(attrs[:user_agent], category: attrs[:category])
 
     attrs.merge(
@@ -213,8 +217,10 @@ class HeartbeatIngest
 
   def normalize_imported_heartbeat(heartbeat, placeholder_state: { contexts: {}, last_project: nil })
     hb = heartbeat.respond_to?(:with_indifferent_access) ? heartbeat.with_indifferent_access : heartbeat.to_h.with_indifferent_access
+    source_heartbeat = hb.dup
     user_agent_info = (@user_agents_by_id[hb[:user_agent_id].to_s] || {}).with_indifferent_access
     resolved_user_agent = hb[:user_agent].presence || user_agent_info[:value].presence || hb[:user_agent_id].presence
+    remap_macos_wakatime_zed_heartbeat!(hb, user_agent: resolved_user_agent)
     parsed_user_agent = parse_user_agent(resolved_user_agent, category: hb[:category])
     derived_ai_editor = parsed_user_agent[:editor].presence if parsed_user_agent[:ai_model].present?
 
@@ -256,9 +262,9 @@ class HeartbeatIngest
     normalized = model_attributes
       .except("id", "fields_hash", "created_at", "updated_at", "time_epoch")
       .symbolize_keys
-    normalized[:fields_hash] = import_fields_hash(model_attributes, source: hb)
+    normalized[:fields_hash] = import_fields_hash(model_attributes, source: source_heartbeat)
     normalized[:legacy_fields_hash] = legacy_import_fields_hash(
-      hb,
+      source_heartbeat,
       user_agent_info:,
       resolved_user_agent:,
       normalized_time: normalized[:time]
@@ -429,6 +435,25 @@ class HeartbeatIngest
     return "browsing" if %w[domain url].include?(type)
 
     "coding"
+  end
+
+  def remap_macos_wakatime_zed_heartbeat!(heartbeat, user_agent: heartbeat[:user_agent])
+    return unless heartbeat[:type] == "app"
+
+    zed_version = product_version(user_agent, "Zed")
+    macos_wakatime_version = product_version(user_agent, "macos-wakatime")
+    return unless zed_version && macos_wakatime_version
+    return unless zed_version >= ZED_PROJECT_FIRST_VERSION
+    return unless macos_wakatime_version < MACOS_WAKATIME_ZED_FIX_VERSION
+
+    heartbeat[:entity], heartbeat[:project] = heartbeat[:project], heartbeat[:entity]
+  end
+
+  def product_version(user_agent, product)
+    version = user_agent.to_s.match(/(?:\A|\s)#{Regexp.escape(product)}\/([^\s]+)/i)&.captures&.first
+    Gem::Version.new(version&.split("+")&.first)
+  rescue ArgumentError
+    nil
   end
 
   # `<<LAST_PROJECT>>` stays persisted by design, but language and branch need

--- a/test/lib/heartbeat_payload_remapper_test.rb
+++ b/test/lib/heartbeat_payload_remapper_test.rb
@@ -1,0 +1,56 @@
+require "test_helper"
+
+class HeartbeatPayloadRemapperTest < Minitest::Test
+  def test_remaps_fields_swapped_by_affected_macos_wakatime_versions
+    attributes = {
+      entity: "hackatime",
+      project: "heartbeat_ingest.rb",
+      type: "app",
+      user_agent: "wakatime/v1.100.1 (darwin-arm64) Zed/0.198.5 macos-wakatime/5.28.4-alpha.1"
+    }
+
+    remapped = HeartbeatPayloadRemapper.remap_fields(attributes)
+    remapped = HeartbeatPayloadRemapper.remap_language(remapped)
+
+    assert_equal "heartbeat_ingest.rb", remapped[:entity]
+    assert_equal "hackatime", remapped[:project]
+    assert_equal "Ruby", remapped[:language]
+    assert_equal "hackatime", attributes[:entity]
+  end
+
+  def test_preserves_fields_from_unaffected_macos_wakatime_versions
+    old_zed = {
+      entity: "heartbeat_ingest.rb",
+      project: "hackatime",
+      type: "app",
+      user_agent: "wakatime/v1.100.1 (darwin-arm64) Zed/0.161.2 macos-wakatime/5.28.4-alpha.1"
+    }
+    fixed_client = old_zed.merge(
+      user_agent: "wakatime/v1.100.1 (darwin-arm64) Zed/0.198.5 macos-wakatime/5.28.5-alpha.1"
+    )
+
+    assert_equal [ "heartbeat_ingest.rb", "hackatime" ],
+      HeartbeatPayloadRemapper.remap_fields(old_zed).values_at(:entity, :project)
+    assert_equal [ "heartbeat_ingest.rb", "hackatime" ],
+      HeartbeatPayloadRemapper.remap_fields(fixed_client).values_at(:entity, :project)
+  end
+
+  def test_authoritative_extension_overrides_client_reported_language
+    assert_equal "Luau", remap_language("Lua", "/a/main.luau")
+    assert_equal "Luau", remap_language("PLAIN_TEXT", "/a/main.luau")
+    assert_equal "Luau", remap_language("luau", "/a/MAIN.LUAU")
+    assert_equal "Luau", remap_language(nil, "/a/main.luau")
+  end
+
+  def test_non_authoritative_extensions_still_trust_the_client
+    assert_equal "Lua", remap_language("Lua", "/a/main.lua")
+    assert_equal "C++", remap_language("C++", "/a/foo.h")
+    assert_nil remap_language(nil, "/a/noext")
+  end
+
+  private
+
+  def remap_language(language, entity)
+    HeartbeatPayloadRemapper.remap_language(language:, entity:)[:language]
+  end
+end

--- a/test/lib/language_utils_test.rb
+++ b/test/lib/language_utils_test.rb
@@ -30,17 +30,4 @@ class LanguageUtilsTest < Minitest::Test
   def test_custom_language_without_extension_conflict
     assert_equal "Lapse", LanguageUtils.find_name("Lapse")
   end
-
-  def test_authoritative_extension_overrides_client_reported_language
-    assert_equal "Luau", LanguageUtils.fill_missing_language("Lua", entity: "/a/main.luau")
-    assert_equal "Luau", LanguageUtils.fill_missing_language("PLAIN_TEXT", entity: "/a/main.luau")
-    assert_equal "Luau", LanguageUtils.fill_missing_language("luau", entity: "/a/MAIN.LUAU")
-    assert_equal "Luau", LanguageUtils.fill_missing_language(nil, entity: "/a/main.luau")
-  end
-
-  def test_non_authoritative_extensions_still_trust_the_client
-    assert_equal "Lua", LanguageUtils.fill_missing_language("Lua", entity: "/a/main.lua")
-    assert_equal "C++", LanguageUtils.fill_missing_language("C++", entity: "/a/foo.h")
-    assert_nil LanguageUtils.fill_missing_language(nil, entity: "/a/noext")
-  end
 end

--- a/test/services/heartbeat_ingest_test.rb
+++ b/test/services/heartbeat_ingest_test.rb
@@ -85,6 +85,56 @@ class HeartbeatIngestTest < ActiveSupport::TestCase
     assert_equal "body-machine", heartbeat.machine
   end
 
+  test "direct heartbeat ingest remaps filenames swapped by macos-wakatime for newer Zed versions" do
+    user = User.create!(timezone: "UTC")
+
+    HeartbeatIngest.call(
+      user: user,
+      mode: :direct,
+      heartbeats: [ {
+        entity: "hackatime",
+        project: "heartbeat_ingest.rb",
+        time: Time.current.to_f,
+        type: "app",
+        user_agent: "wakatime/v1.100.1 (darwin-arm64) Zed/0.198.5 macos-wakatime/5.28.4-alpha.1"
+      } ]
+    )
+
+    heartbeat = user.heartbeats.sole
+    assert_equal "heartbeat_ingest.rb", heartbeat.entity
+    assert_equal "hackatime", heartbeat.project
+    assert_equal "Ruby", heartbeat.language
+  end
+
+  test "direct heartbeat ingest preserves filenames from unaffected macos-wakatime versions" do
+    user = User.create!(timezone: "UTC")
+    now = Time.current.to_f
+
+    HeartbeatIngest.call(
+      user: user,
+      mode: :direct,
+      heartbeats: [
+        {
+          entity: "heartbeat_ingest.rb",
+          project: "hackatime",
+          time: now - 1,
+          type: "app",
+          user_agent: "wakatime/v1.100.1 (darwin-arm64) Zed/0.161.2 macos-wakatime/5.28.4-alpha.1"
+        },
+        {
+          entity: "heartbeat_ingest.rb",
+          project: "hackatime",
+          time: now,
+          type: "app",
+          user_agent: "wakatime/v1.100.1 (darwin-arm64) Zed/0.198.5 macos-wakatime/5.28.5-alpha.1"
+        }
+      ]
+    )
+
+    assert_equal [ [ "heartbeat_ingest.rb", "hackatime" ] ] * 2,
+      user.heartbeats.order(:time).pluck(:entity, :project)
+  end
+
   test "direct heartbeat ingest classifies uncategorized browser heartbeats as browsing" do
     user = User.create!(timezone: "UTC")
 
@@ -516,6 +566,27 @@ class HeartbeatIngestTest < ActiveSupport::TestCase
     heartbeat = user.heartbeats.sole
     assert_equal "coding", heartbeat.category
     assert_equal "hackatime", heartbeat.project
+  end
+
+  test "import heartbeat ingest remaps filenames swapped by macos-wakatime" do
+    user = User.create!(timezone: "UTC")
+
+    HeartbeatIngest.call(
+      user: user,
+      mode: :import,
+      heartbeats: [ {
+        entity: "hackatime",
+        project: "heartbeat_ingest.rb",
+        time: 1_700_000_000.0,
+        type: "app",
+        user_agent: "wakatime/v1.100.1 (darwin-arm64) Zed/0.198.5+stable macos-wakatime/5.28.4"
+      } ]
+    )
+
+    heartbeat = user.heartbeats.sole
+    assert_equal "heartbeat_ingest.rb", heartbeat.entity
+    assert_equal "hackatime", heartbeat.project
+    assert_equal "Ruby", heartbeat.language
   end
 
   test "import heartbeat ingest recognizes a pre-normalization fields hash" do

--- a/test/services/heartbeat_ingest_test.rb
+++ b/test/services/heartbeat_ingest_test.rb
@@ -622,7 +622,7 @@ class HeartbeatIngestTest < ActiveSupport::TestCase
       time: 1_700_000_000.0,
       type: "file"
     }
-    # Stored before AUTHORITATIVE_EXTENSIONS existed, so its hash was computed
+    # Stored before authoritative language remapping existed, so its hash was computed
     # with the client-reported "Lua" rather than the corrected "Luau".
     create_legacy_imported_heartbeat(user, raw)
 


### PR DESCRIPTION
## Summary of the problem

macos-wakatime versions before 5.28.5-alpha.1 swapped Zed project names and filenames after Zed 0.162.0 changed its title format.

Closes #1586

## Describe your changes

Remap affected direct and imported heartbeats using the Zed and macos-wakatime versions in their plugin metadata. Keep unaffected versions unchanged and infer language from the corrected filename.

Move heartbeat-specific field and language corrections into a dedicated payload remapper so ingestion remains focused on orchestration and persistence.

## Screenshots / Media

No visual changes.