### PR TITLE
Fix admin API rate limit scope

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -39,8 +39,8 @@ class Rack::Attack
     !req.cloudflare?
   end
 
-  Rack::Attack.throttle("admin abooze", limit: 5, period: 1.second) do |req|
-    req.path.start_with?("/api/admin/")
+  Rack::Attack.throttle("admin abooze", limit: 300, period: 1.minute) do |req|
+    req.ip if req.path.start_with?("/api/admin/")
   end
 
   Rack::Attack.throttle("general", limit: 300, period: 1.minute) do |req|


### PR DESCRIPTION
## Summary of the problem

The admin API throttle used one shared rate limit bucket, allowing one consumer to rate limit every other admin API consumer.

## Describe your changes

Scope the admin API throttle by client IP and allow 300 requests per minute for each client.

## Screenshots / Media

Not applicable.
