### PR TITLE
Scope authenticated rate limits by credential

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,5 +1,7 @@
 # config/initializers/rack_attack.rb
 
+require "digest"
+
 class Rack::Attack
   Rack::Attack.enabled = true
 
@@ -44,7 +46,10 @@ class Rack::Attack
   end
 
   Rack::Attack.throttle("general", limit: 300, period: 1.minute) do |req|
-    req.ip unless req.path.start_with?("/assets")
+    unless req.path.start_with?("/assets")
+      authorization = req.get_header("HTTP_AUTHORIZATION")
+      authorization.present? ? Digest::SHA256.hexdigest(authorization) : req.ip
+    end
   end
 
   Rack::Attack.throttle("posts by ip", limit: 60, period: 5.minutes) do |req|

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -27,17 +27,20 @@ class Rack::Attack
     req.path =~ %r{\A/api/hackatime/v1/users/[^/]+/heartbeats(?:\.bulk)?\z}
   end
 
-  def self.authenticated_user_id(req)
+  def self.authenticated_credential_id(req)
     source, token = credential_from(req)
     token = normalize_credential(token)
     return if token.blank?
 
-    user_id = ApiKey.where(token: token).pick(:user_id)
-    user_id ||= AdminApiKey.active.find_by(token: token)&.user_id if source == :bearer
-    return user_id if user_id || source != :bearer
+    api_key_id = ApiKey.where(token: token).pick(:id)
+    return "api_key:#{api_key_id}" if api_key_id
+    return if source != :bearer
+
+    admin_api_key_id = AdminApiKey.active.find_by(token: token)&.id
+    return "admin_api_key:#{admin_api_key_id}" if admin_api_key_id
 
     oauth_token = Doorkeeper::AccessToken.by_token(token)
-    oauth_token.resource_owner_id if oauth_token&.accessible?
+    "oauth_token:#{oauth_token.id}" if oauth_token&.accessible?
   end
 
   def self.credential_from(req)
@@ -79,8 +82,7 @@ class Rack::Attack
 
   Rack::Attack.throttle("general", limit: 300, period: 1.minute) do |req|
     unless req.path.start_with?("/assets")
-      user_id = authenticated_user_id(req)
-      user_id ? "user:#{user_id}" : "ip:#{req.ip}"
+      authenticated_credential_id(req) || "ip:#{req.ip}"
     end
   end
 

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -28,27 +28,50 @@ class Rack::Attack
   end
 
   def self.authenticated_credential_id(req)
-    source, token = credential_from(req)
+    sources, api_keys, oauth, oauth_scopes = credential_policy(req.path)
+    return unless sources
+
+    source, token = credential_from(req, sources)
     token = normalize_credential(token)
     return if token.blank?
 
-    api_key_id = ApiKey.where(token: token).pick(:id)
-    return "api_key:#{api_key_id}" if api_key_id
-    return if source != :bearer
-
-    admin_api_key_id = AdminApiKey.active.find_by(token: token)&.id
-    return "admin_api_key:#{admin_api_key_id}" if admin_api_key_id
+    if api_keys
+      api_key_id = ApiKey.where(token: token).pick(:id)
+      return "api_key:#{api_key_id}" if api_key_id
+    end
+    return unless source == :bearer && oauth
 
     oauth_token = Doorkeeper::AccessToken.by_token(token)
-    "oauth_token:#{oauth_token.id}" if oauth_token&.accessible?
+    oauth_valid = oauth_scopes ? oauth_token&.acceptable?(oauth_scopes) : oauth_token&.accessible?
+    "oauth_token:#{oauth_token.id}" if oauth_valid
   end
 
-  def self.credential_from(req)
-    scheme, token = req.get_header("HTTP_AUTHORIZATION").to_s.split(/\s+/, 2)
-    return [ :bearer, token ] if scheme&.casecmp?("Bearer")
-    return [ :basic, Base64.strict_decode64(token.to_s) ] if scheme&.casecmp?("Basic")
+  def self.credential_policy(path)
+    normalized_path = path.chomp("/")
 
-    [ :query, req.GET["api_key"] ]
+    case normalized_path
+    when "/api/v1/authenticated/me"
+      [ [ :bearer ], false, true, [ "profile" ] ]
+    when "/api/v1/authenticated/hours", "/api/v1/authenticated/streak",
+         "/api/v1/authenticated/projects", "/api/v1/authenticated/heartbeats/latest"
+      [ [ :bearer ], false, true, [ "read" ] ]
+    when "/api/v1/authenticated/api_keys"
+      [ [ :bearer ], false, true, nil ]
+    when %r{\A/api/hackatime/v1/}
+      [ %i[bearer basic query], true, false, nil ]
+    when "/api/v1/my/heartbeats", "/api/v1/my/heartbeats/most_recent"
+      [ %i[bearer basic], true, true, [ "read" ] ]
+    end
+  end
+
+  def self.credential_from(req, sources)
+    scheme, token = req.get_header("HTTP_AUTHORIZATION").to_s.split(/\s+/, 2)
+    return [ :bearer, token ] if sources.include?(:bearer) && scheme&.casecmp?("Bearer")
+    if sources.include?(:basic) && scheme&.casecmp?("Basic")
+      return [ :basic, Base64.strict_decode64(token.to_s) ]
+    end
+
+    [ :query, req.GET["api_key"] ] if sources.include?(:query)
   rescue ArgumentError
     nil
   end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,6 +1,6 @@
 # config/initializers/rack_attack.rb
 
-require "digest"
+require "base64"
 
 class Rack::Attack
   Rack::Attack.enabled = true
@@ -27,6 +27,38 @@ class Rack::Attack
     req.path =~ %r{\A/api/hackatime/v1/users/[^/]+/heartbeats(?:\.bulk)?\z}
   end
 
+  def self.authenticated_user_id(req)
+    source, token = credential_from(req)
+    token = normalize_credential(token)
+    return if token.blank?
+
+    user_id = ApiKey.where(token: token).pick(:user_id)
+    user_id ||= AdminApiKey.active.find_by(token: token)&.user_id if source == :bearer
+    return user_id if user_id || source != :bearer
+
+    oauth_token = Doorkeeper::AccessToken.by_token(token)
+    oauth_token.resource_owner_id if oauth_token&.accessible?
+  end
+
+  def self.credential_from(req)
+    scheme, token = req.get_header("HTTP_AUTHORIZATION").to_s.split(/\s+/, 2)
+    return [ :bearer, token ] if scheme&.casecmp?("Bearer")
+    return [ :basic, Base64.strict_decode64(token.to_s) ] if scheme&.casecmp?("Basic")
+
+    [ :query, req.GET["api_key"] ]
+  rescue ArgumentError
+    nil
+  end
+
+  def self.normalize_credential(token)
+    token = token.to_s
+    return if token.encoding == Encoding::UTF_8 && !token.valid_encoding?
+
+    token.encode(Encoding::UTF_8)
+  rescue Encoding::InvalidByteSequenceError, Encoding::UndefinedConversionError
+    nil
+  end
+
   # Always allow requests from bogon ips
   # (blocklist & throttles are skipped)
   Rack::Attack.safelist("allow from bogon ips") do |req|
@@ -47,8 +79,8 @@ class Rack::Attack
 
   Rack::Attack.throttle("general", limit: 300, period: 1.minute) do |req|
     unless req.path.start_with?("/assets")
-      authorization = req.get_header("HTTP_AUTHORIZATION")
-      authorization.present? ? Digest::SHA256.hexdigest(authorization) : req.ip
+      user_id = authenticated_user_id(req)
+      user_id ? "user:#{user_id}" : "ip:#{req.ip}"
     end
   end
 

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -25,14 +25,14 @@ class Rack::Attack
     req.path =~ %r{\A/api/hackatime/v1/users/[^/]+/heartbeats(?:\.bulk)?\z}
   end
 
-  def self.oauth_credential_id(req)
+  def self.oauth_user_id(req)
     return unless req.path.start_with?("/api/v1/authenticated/")
 
     scheme, token = req.get_header("HTTP_AUTHORIZATION").to_s.split(/\s+/, 2)
     return unless scheme&.casecmp?("Bearer") && token.present?
 
     oauth_token = Doorkeeper::AccessToken.by_token(token)
-    "oauth_token:#{oauth_token.id}" if oauth_token&.accessible?
+    "user:#{oauth_token.resource_owner_id}" if oauth_token&.accessible? && oauth_token.resource_owner_id
   end
 
   # Always allow requests from bogon ips
@@ -55,7 +55,7 @@ class Rack::Attack
 
   Rack::Attack.throttle("general", limit: 300, period: 1.minute) do |req|
     unless req.path.start_with?("/assets")
-      oauth_credential_id(req) || req.ip
+      oauth_user_id(req) || req.ip
     end
   end
 

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,7 +1,5 @@
 # config/initializers/rack_attack.rb
 
-require "base64"
-
 class Rack::Attack
   Rack::Attack.enabled = true
 
@@ -27,62 +25,14 @@ class Rack::Attack
     req.path =~ %r{\A/api/hackatime/v1/users/[^/]+/heartbeats(?:\.bulk)?\z}
   end
 
-  def self.authenticated_credential_id(req)
-    sources, api_keys, oauth, oauth_scopes = credential_policy(req.path)
-    return unless sources
+  def self.oauth_credential_id(req)
+    return unless req.path.start_with?("/api/v1/authenticated/")
 
-    source, token = credential_from(req, sources)
-    token = normalize_credential(token)
-    return if token.blank?
-
-    if api_keys
-      api_key_id = ApiKey.where(token: token).pick(:id)
-      return "api_key:#{api_key_id}" if api_key_id
-    end
-    return unless source == :bearer && oauth
+    scheme, token = req.get_header("HTTP_AUTHORIZATION").to_s.split(/\s+/, 2)
+    return unless scheme&.casecmp?("Bearer") && token.present?
 
     oauth_token = Doorkeeper::AccessToken.by_token(token)
-    oauth_valid = oauth_scopes ? oauth_token&.acceptable?(oauth_scopes) : oauth_token&.accessible?
-    "oauth_token:#{oauth_token.id}" if oauth_valid
-  end
-
-  def self.credential_policy(path)
-    normalized_path = path.chomp("/")
-
-    case normalized_path
-    when "/api/v1/authenticated/me"
-      [ [ :bearer ], false, true, [ "profile" ] ]
-    when "/api/v1/authenticated/hours", "/api/v1/authenticated/streak",
-         "/api/v1/authenticated/projects", "/api/v1/authenticated/heartbeats/latest"
-      [ [ :bearer ], false, true, [ "read" ] ]
-    when "/api/v1/authenticated/api_keys"
-      [ [ :bearer ], false, true, nil ]
-    when %r{\A/api/hackatime/v1/}
-      [ %i[bearer basic query], true, false, nil ]
-    when "/api/v1/my/heartbeats", "/api/v1/my/heartbeats/most_recent"
-      [ %i[bearer basic], true, true, [ "read" ] ]
-    end
-  end
-
-  def self.credential_from(req, sources)
-    scheme, token = req.get_header("HTTP_AUTHORIZATION").to_s.split(/\s+/, 2)
-    return [ :bearer, token ] if sources.include?(:bearer) && scheme&.casecmp?("Bearer")
-    if sources.include?(:basic) && scheme&.casecmp?("Basic")
-      return [ :basic, Base64.strict_decode64(token.to_s) ]
-    end
-
-    [ :query, req.GET["api_key"] ] if sources.include?(:query)
-  rescue ArgumentError
-    nil
-  end
-
-  def self.normalize_credential(token)
-    token = token.to_s
-    return if token.encoding == Encoding::UTF_8 && !token.valid_encoding?
-
-    token.encode(Encoding::UTF_8)
-  rescue Encoding::InvalidByteSequenceError, Encoding::UndefinedConversionError
-    nil
+    "oauth_token:#{oauth_token.id}" if oauth_token&.accessible?
   end
 
   # Always allow requests from bogon ips
@@ -105,7 +55,7 @@ class Rack::Attack
 
   Rack::Attack.throttle("general", limit: 300, period: 1.minute) do |req|
     unless req.path.start_with?("/assets")
-      authenticated_credential_id(req) || "ip:#{req.ip}"
+      oauth_credential_id(req) || req.ip
     end
   end
 

--- a/test/lib/rack_attack_test.rb
+++ b/test/lib/rack_attack_test.rb
@@ -3,8 +3,8 @@ require "test_helper"
 class RackAttackTest < ActiveSupport::TestCase
   test "general throttle separates valid bearer credentials for the same user" do
     user = create(:user)
-    first_token = create(:oauth_access_token, resource_owner_id: user.id)
-    second_token = create(:oauth_access_token, resource_owner_id: user.id)
+    first_token = create(:oauth_access_token, resource_owner_id: user.id, scopes: "read")
+    second_token = create(:oauth_access_token, resource_owner_id: user.id, scopes: "read")
 
     assert_equal(
       "oauth_token:#{first_token.id}",
@@ -21,15 +21,32 @@ class RackAttackTest < ActiveSupport::TestCase
     first_key = create(:api_key, user: user)
     second_key = create(:api_key, user: user)
 
-    assert_equal "api_key:#{first_key.id}", discriminator_for(query: first_key.token)
-    assert_equal "api_key:#{second_key.id}", discriminator_for(query: second_key.token)
+    path = "/api/hackatime/v1/users/current/heartbeats"
+    assert_equal "api_key:#{first_key.id}", discriminator_for(path:, query: first_key.token)
+    assert_equal "api_key:#{second_key.id}", discriminator_for(path:, query: second_key.token)
   end
 
   test "general throttle recognises valid basic credentials" do
     key = create(:api_key)
     authorization = "Basic #{Base64.strict_encode64(key.token)}"
 
-    assert_equal "api_key:#{key.id}", discriminator_for(authorization: authorization)
+    path = "/api/hackatime/v1/users/current/heartbeats"
+    assert_equal "api_key:#{key.id}", discriminator_for(path:, authorization: authorization)
+  end
+
+  test "general throttle groups credentials sent over unsupported transports by IP" do
+    key = create(:api_key)
+    basic = "Basic #{Base64.strict_encode64(key.token)}"
+
+    assert_equal "ip:198.51.100.20", discriminator_for(query: key.token)
+    assert_equal "ip:198.51.100.20", discriminator_for(authorization: basic)
+  end
+
+  test "general throttle groups credentials invalid for the endpoint by IP" do
+    oauth_token = create(:oauth_access_token, scopes: "profile")
+    authorization = "Bearer #{oauth_token.token}"
+
+    assert_equal "ip:198.51.100.20", discriminator_for(authorization: authorization)
   end
 
   test "general throttle groups invalid credentials by IP" do

--- a/test/lib/rack_attack_test.rb
+++ b/test/lib/rack_attack_test.rb
@@ -1,0 +1,59 @@
+require "test_helper"
+
+class RackAttackTest < ActiveSupport::TestCase
+  test "general throttle separates valid bearer credentials by user" do
+    first_token = create(:oauth_access_token)
+    second_token = create(:oauth_access_token)
+
+    assert_equal(
+      "user:#{first_token.resource_owner_id}",
+      discriminator_for(authorization: "Bearer #{first_token.token}")
+    )
+    assert_equal(
+      "user:#{second_token.resource_owner_id}",
+      discriminator_for(authorization: "Bearer #{second_token.token}")
+    )
+  end
+
+  test "general throttle separates valid query credentials by user" do
+    first_key = create(:api_key)
+    second_key = create(:api_key)
+
+    assert_equal "user:#{first_key.user_id}", discriminator_for(query: first_key.token)
+    assert_equal "user:#{second_key.user_id}", discriminator_for(query: second_key.token)
+  end
+
+  test "general throttle recognises valid basic credentials" do
+    key = create(:api_key)
+    authorization = "Basic #{Base64.strict_encode64(key.token)}"
+
+    assert_equal "user:#{key.user_id}", discriminator_for(authorization: authorization)
+  end
+
+  test "general throttle groups invalid credentials by IP" do
+    first = discriminator_for(authorization: "Bearer invalid-one")
+    second = discriminator_for(authorization: "Bearer invalid-two")
+
+    assert_equal "ip:198.51.100.20", first
+    assert_equal first, second
+  end
+
+  test "general throttle groups anonymous requests by IP" do
+    assert_equal "ip:198.51.100.20", discriminator_for
+  end
+
+  test "general throttle excludes assets" do
+    assert_nil discriminator_for(path: "/assets/application.js")
+  end
+
+  private
+
+  def discriminator_for(path: "/api/v1/authenticated/projects", authorization: nil, query: nil)
+    path = "#{path}?api_key=#{query}" if query
+    env = Rack::MockRequest.env_for(path, "REMOTE_ADDR" => "198.51.100.20")
+    env["HTTP_AUTHORIZATION"] = authorization if authorization
+    request = Rack::Attack::Request.new(env)
+
+    Rack::Attack.throttles.fetch("general").block.call(request)
+  end
+end

--- a/test/lib/rack_attack_test.rb
+++ b/test/lib/rack_attack_test.rb
@@ -1,33 +1,35 @@
 require "test_helper"
 
 class RackAttackTest < ActiveSupport::TestCase
-  test "general throttle separates valid bearer credentials by user" do
-    first_token = create(:oauth_access_token)
-    second_token = create(:oauth_access_token)
+  test "general throttle separates valid bearer credentials for the same user" do
+    user = create(:user)
+    first_token = create(:oauth_access_token, resource_owner_id: user.id)
+    second_token = create(:oauth_access_token, resource_owner_id: user.id)
 
     assert_equal(
-      "user:#{first_token.resource_owner_id}",
+      "oauth_token:#{first_token.id}",
       discriminator_for(authorization: "Bearer #{first_token.token}")
     )
     assert_equal(
-      "user:#{second_token.resource_owner_id}",
+      "oauth_token:#{second_token.id}",
       discriminator_for(authorization: "Bearer #{second_token.token}")
     )
   end
 
-  test "general throttle separates valid query credentials by user" do
-    first_key = create(:api_key)
-    second_key = create(:api_key)
+  test "general throttle separates valid query credentials for the same user" do
+    user = create(:user)
+    first_key = create(:api_key, user: user)
+    second_key = create(:api_key, user: user)
 
-    assert_equal "user:#{first_key.user_id}", discriminator_for(query: first_key.token)
-    assert_equal "user:#{second_key.user_id}", discriminator_for(query: second_key.token)
+    assert_equal "api_key:#{first_key.id}", discriminator_for(query: first_key.token)
+    assert_equal "api_key:#{second_key.id}", discriminator_for(query: second_key.token)
   end
 
   test "general throttle recognises valid basic credentials" do
     key = create(:api_key)
     authorization = "Basic #{Base64.strict_encode64(key.token)}"
 
-    assert_equal "user:#{key.user_id}", discriminator_for(authorization: authorization)
+    assert_equal "api_key:#{key.id}", discriminator_for(authorization: authorization)
   end
 
   test "general throttle groups invalid credentials by IP" do

--- a/test/lib/rack_attack_test.rb
+++ b/test/lib/rack_attack_test.rb
@@ -1,19 +1,26 @@
 require "test_helper"
 
 class RackAttackTest < ActiveSupport::TestCase
-  test "general throttle separates valid OAuth credentials for the same user" do
+  test "general throttle groups valid OAuth credentials by user" do
     user = create(:user)
     first_token = create(:oauth_access_token, resource_owner_id: user.id)
     second_token = create(:oauth_access_token, resource_owner_id: user.id)
 
-    assert_equal(
-      "oauth_token:#{first_token.id}",
-      discriminator_for(authorization: "Bearer #{first_token.token}")
-    )
-    assert_equal(
-      "oauth_token:#{second_token.id}",
-      discriminator_for(authorization: "Bearer #{second_token.token}")
-    )
+    first = discriminator_for(authorization: "Bearer #{first_token.token}")
+    second = discriminator_for(authorization: "Bearer #{second_token.token}")
+
+    assert_equal "user:#{user.id}", first
+    assert_equal first, second
+  end
+
+  test "general throttle separates OAuth credentials for different users" do
+    first_token = create(:oauth_access_token)
+    second_token = create(:oauth_access_token)
+
+    first = discriminator_for(authorization: "Bearer #{first_token.token}")
+    second = discriminator_for(authorization: "Bearer #{second_token.token}")
+
+    assert_not_equal first, second
   end
 
   test "general throttle groups invalid credentials by IP" do

--- a/test/lib/rack_attack_test.rb
+++ b/test/lib/rack_attack_test.rb
@@ -1,10 +1,10 @@
 require "test_helper"
 
 class RackAttackTest < ActiveSupport::TestCase
-  test "general throttle separates valid bearer credentials for the same user" do
+  test "general throttle separates valid OAuth credentials for the same user" do
     user = create(:user)
-    first_token = create(:oauth_access_token, resource_owner_id: user.id, scopes: "read")
-    second_token = create(:oauth_access_token, resource_owner_id: user.id, scopes: "read")
+    first_token = create(:oauth_access_token, resource_owner_id: user.id)
+    second_token = create(:oauth_access_token, resource_owner_id: user.id)
 
     assert_equal(
       "oauth_token:#{first_token.id}",
@@ -16,49 +16,16 @@ class RackAttackTest < ActiveSupport::TestCase
     )
   end
 
-  test "general throttle separates valid query credentials for the same user" do
-    user = create(:user)
-    first_key = create(:api_key, user: user)
-    second_key = create(:api_key, user: user)
-
-    path = "/api/hackatime/v1/users/current/heartbeats"
-    assert_equal "api_key:#{first_key.id}", discriminator_for(path:, query: first_key.token)
-    assert_equal "api_key:#{second_key.id}", discriminator_for(path:, query: second_key.token)
-  end
-
-  test "general throttle recognises valid basic credentials" do
-    key = create(:api_key)
-    authorization = "Basic #{Base64.strict_encode64(key.token)}"
-
-    path = "/api/hackatime/v1/users/current/heartbeats"
-    assert_equal "api_key:#{key.id}", discriminator_for(path:, authorization: authorization)
-  end
-
-  test "general throttle groups credentials sent over unsupported transports by IP" do
-    key = create(:api_key)
-    basic = "Basic #{Base64.strict_encode64(key.token)}"
-
-    assert_equal "ip:198.51.100.20", discriminator_for(query: key.token)
-    assert_equal "ip:198.51.100.20", discriminator_for(authorization: basic)
-  end
-
-  test "general throttle groups credentials invalid for the endpoint by IP" do
-    oauth_token = create(:oauth_access_token, scopes: "profile")
-    authorization = "Bearer #{oauth_token.token}"
-
-    assert_equal "ip:198.51.100.20", discriminator_for(authorization: authorization)
-  end
-
   test "general throttle groups invalid credentials by IP" do
     first = discriminator_for(authorization: "Bearer invalid-one")
     second = discriminator_for(authorization: "Bearer invalid-two")
 
-    assert_equal "ip:198.51.100.20", first
+    assert_equal "198.51.100.20", first
     assert_equal first, second
   end
 
   test "general throttle groups anonymous requests by IP" do
-    assert_equal "ip:198.51.100.20", discriminator_for
+    assert_equal "198.51.100.20", discriminator_for
   end
 
   test "general throttle excludes assets" do
@@ -67,8 +34,7 @@ class RackAttackTest < ActiveSupport::TestCase
 
   private
 
-  def discriminator_for(path: "/api/v1/authenticated/projects", authorization: nil, query: nil)
-    path = "#{path}?api_key=#{query}" if query
+  def discriminator_for(path: "/api/v1/authenticated/projects", authorization: nil)
     env = Rack::MockRequest.env_for(path, "REMOTE_ADDR" => "198.51.100.20")
     env["HTTP_AUTHORIZATION"] = authorization if authorization
     request = Rack::Attack::Request.new(env)


### PR DESCRIPTION
## Summary of the problem

OAuth integrations sharing an IP address also share the general rate limit bucket, allowing one integration to rate limit requests made for unrelated Hackatime users.

## Describe your changes

Give each authenticated Hackatime user under the OAuth API namespace a general throttle bucket shared across their OAuth tokens. Invalid, anonymous and all other requests remain scoped by IP address.

## Screenshots / Media

Not applicable.
