### PR TITLE
Remove STATS_API_KEY code

### DIFF
--- a/app/controllers/api/v1/stats_controller.rb
+++ b/app/controllers/api/v1/stats_controller.rb
@@ -1,7 +1,7 @@
 class Api::V1::StatsController < ApplicationController
   USER_LOOKUP_ACTIONS = [ :user_stats, :user_spans, :user_projects, :user_project, :user_projects_details ].freeze
 
-  before_action :authenticate_stats_api_key!, only: [ :show ], unless: -> { Rails.env.development? }
+  before_action :authenticate_admin_api_key!, only: [ :show ], unless: -> { Rails.env.development? }
   before_action :set_user, only: USER_LOOKUP_ACTIONS
   before_action :ensure_public_stats_allowed!, only: USER_LOOKUP_ACTIONS
 

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::UsersController < ApplicationController
-  before_action -> { authenticate_stats_api_key!(allow_query_param: false) }, unless: -> { Rails.env.development? }
+  before_action :authenticate_admin_api_key!, unless: -> { Rails.env.development? }
 
   def lookup_email
     user = EmailAddress.find_by(email: params[:email])&.user

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -88,28 +88,16 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  # Authenticates stats integrations with an AdminApiKey. STATS_API_KEY remains
-  # available as a temporary fallback while the Flipper flag is enabled.
-  def authenticate_stats_api_key!(allow_query_param: true, message: "Unauthorized")
+  def authenticate_admin_api_key!(message: "Unauthorized")
     authorization = request.headers["Authorization"]
-    if authorization.nil?
-      return if allow_query_param && valid_legacy_stats_api_key?(params[:api_key])
-    elsif authorization.match?(/\ABearer +\S+\z/i)
+    if authorization&.match?(/\ABearer +\S+\z/i)
       scheme, header_token = authorization_credentials
       if bearer_scheme?(scheme)
         return if auth_admin_api_key(header_token)
-        return if valid_legacy_stats_api_key?(header_token)
       end
     end
 
     render_unauthorized(message)
-  end
-
-  def valid_legacy_stats_api_key?(token)
-    return false unless Flipper.enabled?(:allow_legacy_stats_api_key)
-
-    expected = ENV["STATS_API_KEY"]
-    token.present? && expected.present? && ActiveSupport::SecurityUtils.secure_compare(token, expected)
   end
 
   def enforce_lockout

--- a/spec/requests/api/v1/stats_spec.rb
+++ b/spec/requests/api/v1/stats_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe 'Api::V1::Stats', type: :request do
   path '/api/v1/stats' do
     get('Get total coding time') do
       tags 'Stats'
-      description 'Returns the total coding time for all users, optionally filtered by user or date range. Requires an active Admin API Key supplied via the Bearer header. Admin API Keys are never accepted in the api_key query param. During migration, STATS_API_KEY is accepted via the Bearer header or api_key query param only when the allow_legacy_stats_api_key Flipper flag is enabled. Authentication is skipped entirely in development.'
-      security [ { Bearer: [] }, { LegacyStatsApiKey: [] } ]
+      description 'Returns the total coding time for all users, optionally filtered by user or date range. Requires an active Admin API Key supplied via the Bearer header.'
+      security [ { Bearer: [] } ]
       produces 'text/plain'
 
       parameter name: :start_date, in: :query, schema: { type: :string, format: :date }, description: 'Start date (YYYY-MM-DD), defaults to 10 years ago'

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Api::V1::Users', type: :request do
   path '/api/v1/users/lookup_email/{email}' do
     get('Lookup user by email') do
       tags 'Users'
-      description 'Find a user ID by their email address. Useful for integrations that need to map emails to Hackatime users. Requires an active Admin API Key supplied via the Authorization Bearer header (the api_key query param is NOT accepted for this endpoint). During migration, STATS_API_KEY is also accepted when the allow_legacy_stats_api_key Flipper flag is enabled.'
+      description 'Find a user ID by their email address. Useful for integrations that need to map emails to Hackatime users. Requires an active Admin API Key supplied via the Authorization Bearer header.'
       security [ Bearer: [] ]
       produces 'application/json'
 
@@ -49,7 +49,7 @@ RSpec.describe 'Api::V1::Users', type: :request do
   path '/api/v1/users/lookup_slack_uid/{slack_uid}' do
     get('Lookup user by Slack UID') do
       tags 'Users'
-      description 'Find a user ID by their Slack User ID. Requires an active Admin API Key supplied via the Authorization Bearer header (the api_key query param is NOT accepted for this endpoint). During migration, STATS_API_KEY is also accepted when the allow_legacy_stats_api_key Flipper flag is enabled.'
+      description 'Find a user ID by their Slack User ID. Requires an active Admin API Key supplied via the Authorization Bearer header'
       security [ Bearer: [] ]
       produces 'application/json'
 

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -333,12 +333,6 @@ RSpec.configure do |config|
             name: 'api_key',
             in: :query,
             description: 'User API Key from settings'
-          },
-          LegacyStatsApiKey: {
-            type: :apiKey,
-            name: 'api_key',
-            in: :query,
-            description: 'Legacy STATS_API_KEY, accepted only while the allow_legacy_stats_api_key feature flag is enabled'
           }
         },
         schemas: public_schemas

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -1636,13 +1636,9 @@ paths:
       - Stats
       description: Returns the total coding time for all users, optionally filtered
         by user or date range. Requires an active Admin API Key supplied via the Bearer
-        header. Admin API Keys are never accepted in the api_key query param. During
-        migration, STATS_API_KEY is accepted via the Bearer header or api_key query
-        param only when the allow_legacy_stats_api_key Flipper flag is enabled. Authentication
-        is skipped entirely in development.
+        header.
       security:
       - Bearer: []
-      - LegacyStatsApiKey: []
       parameters:
       - name: start_date
         in: query
@@ -2262,9 +2258,7 @@ paths:
       - Users
       description: Find a user ID by their email address. Useful for integrations
         that need to map emails to Hackatime users. Requires an active Admin API Key
-        supplied via the Authorization Bearer header (the api_key query param is NOT
-        accepted for this endpoint). During migration, STATS_API_KEY is also accepted
-        when the allow_legacy_stats_api_key Flipper flag is enabled.
+        supplied via the Authorization Bearer header.
       security:
       - Bearer: []
       parameters:
@@ -2314,9 +2308,7 @@ paths:
       tags:
       - Users
       description: Find a user ID by their Slack User ID. Requires an active Admin
-        API Key supplied via the Authorization Bearer header (the api_key query param
-        is NOT accepted for this endpoint). During migration, STATS_API_KEY is also
-        accepted when the allow_legacy_stats_api_key Flipper flag is enabled.
+        API Key supplied via the Authorization Bearer header
       security:
       - Bearer: []
       parameters:
@@ -2382,12 +2374,6 @@ components:
       name: api_key
       in: query
       description: User API Key from settings
-    LegacyStatsApiKey:
-      type: apiKey
-      name: api_key
-      in: query
-      description: Legacy STATS_API_KEY, accepted only while the allow_legacy_stats_api_key
-        feature flag is enabled
   schemas:
     Error:
       type: object

--- a/test/controllers/api/v1/stats_controller_test.rb
+++ b/test/controllers/api/v1/stats_controller_test.rb
@@ -210,48 +210,6 @@ class Api::V1::StatsControllerTest < ActionDispatch::IntegrationTest
     assert_response :unauthorized
   end
 
-  test "aggregate stats accepts STATS_API_KEY only while legacy flag is enabled" do
-    previous_stats_api_key = ENV["STATS_API_KEY"]
-    legacy_key = "legacy-stats-#{SecureRandom.hex(8)}"
-    ENV["STATS_API_KEY"] = legacy_key
-    Flipper.disable(:allow_legacy_stats_api_key)
-
-    get "/api/v1/stats", headers: { "Authorization" => "Bearer #{legacy_key}" }
-    assert_response :unauthorized
-    get "/api/v1/stats", params: { api_key: legacy_key }
-    assert_response :unauthorized
-
-    Flipper.enable(:allow_legacy_stats_api_key)
-    get "/api/v1/stats", headers: { "Authorization" => "Bearer #{legacy_key}" }
-    assert_response :success
-    get "/api/v1/stats", headers: { "Authorization" => "bearer #{legacy_key}" }
-    assert_response :success
-    get "/api/v1/stats", params: { api_key: legacy_key }
-    assert_response :success
-
-    [ "Basic #{legacy_key}", "Token #{legacy_key}", legacy_key, "Bearer\t#{legacy_key}" ].each do |authorization|
-      get "/api/v1/stats", headers: { "Authorization" => authorization }
-      assert_response :unauthorized
-    end
-
-    [ "", " ", "Token malformed" ].each do |authorization|
-      get "/api/v1/stats",
-        params: { api_key: legacy_key },
-        headers: { "Authorization" => authorization }
-      assert_response :unauthorized
-    end
-
-    get "/api/v1/users/lookup_email/nobody@example.com", params: { api_key: legacy_key }
-    assert_response :unauthorized
-
-    admin_api_key = create_admin_api_key
-    get "/api/v1/stats", params: { api_key: admin_api_key.token }
-    assert_response :unauthorized
-  ensure
-    Flipper.disable(:allow_legacy_stats_api_key)
-    ENV["STATS_API_KEY"] = previous_stats_api_key
-  end
-
   private
 
   def create_admin_api_key


### PR DESCRIPTION
## Summary of the problem
STATS_API_KEY has officially been retired, so we don't need to keep the code around anymore.

## Describe your changes
Removes STATS_API_KEY's code.

## Screenshots / Media
<!-- If there are any visual changes, please attach images, videos, or gifs. -->
