### PR TITLE
Queue Slack status updates after preference changes

### DIFF
--- a/app/controllers/settings/slack_github_controller.rb
+++ b/app/controllers/settings/slack_github_controller.rb
@@ -1,7 +1,7 @@
 class Settings::SlackGithubController < Settings::BaseController
   def update
     if @user.update(slack_github_params)
-      @user.update_slack_status if @user.uses_slack_status?
+      UserSlackStatusUpdateJob.perform_later(@user.id) if @user.uses_slack_status?
       redirect_to my_settings_slack_github_path, notice: "Settings updated successfully"
     else
       flash.now[:error] = @user.errors.full_messages.to_sentence.presence || "Failed to update settings"

--- a/app/jobs/user_slack_status_update_job.rb
+++ b/app/jobs/user_slack_status_update_job.rb
@@ -1,15 +1,7 @@
 class UserSlackStatusUpdateJob < ApplicationJob
   queue_as :latency_10s
 
-  BATCH_SIZE = 25
-
-  def perform
-    User.where(uses_slack_status: true).find_each(batch_size: BATCH_SIZE) do |user|
-      begin
-        user.update_slack_status
-      rescue => e
-        report_error(e, message: "Failed to update Slack status for user #{user.slack_uid}")
-      end
-    end
+  def perform(user_id)
+    User.find_by(id: user_id)&.update_slack_status
   end
 end

--- a/app/jobs/user_slack_status_update_job.rb
+++ b/app/jobs/user_slack_status_update_job.rb
@@ -1,8 +1,10 @@
 class UserSlackStatusUpdateJob < ApplicationJob
   queue_as :latency_10s
 
-  retry_on HTTP::TimeoutError, HTTP::ConnectionError, JSON::ParserError,
-    wait: :polynomially_longer, attempts: 3 do |job, error|
+  MAX_ATTEMPTS = 3
+
+  retry_on HTTP::TimeoutError, HTTP::ConnectionError, JSON::ParserError, SlackIntegration::ServerError,
+    wait: :polynomially_longer, attempts: MAX_ATTEMPTS do |job, error|
       user_id = job.arguments.first
       job.report_error(
         error,
@@ -13,5 +15,15 @@ class UserSlackStatusUpdateJob < ApplicationJob
 
   def perform(user_id)
     User.find_by(id: user_id)&.update_slack_status
+  rescue SlackIntegration::RateLimitedError => e
+    if executions < MAX_ATTEMPTS
+      retry_job(wait: e.retry_after.seconds)
+    else
+      report_error(
+        e,
+        message: "Failed to update Slack status for user #{user_id}",
+        extra: { user_id: }
+      )
+    end
   end
 end

--- a/app/jobs/user_slack_status_update_job.rb
+++ b/app/jobs/user_slack_status_update_job.rb
@@ -15,6 +15,8 @@ class UserSlackStatusUpdateJob < ApplicationJob
 
   def perform(user_id)
     User.find_by(id: user_id)&.update_slack_status
+  rescue SlackIntegration::ServerError
+    raise
   rescue SlackIntegration::RateLimitedError => e
     if executions < MAX_ATTEMPTS
       retry_job(wait: e.retry_after.seconds)
@@ -25,5 +27,12 @@ class UserSlackStatusUpdateJob < ApplicationJob
         extra: { user_id: }
       )
     end
+  rescue SlackIntegration::ApiError => e
+    report_error(
+      e,
+      message: "Failed to update Slack status for user #{user_id}",
+      extra: { user_id: }
+    )
+    raise
   end
 end

--- a/app/jobs/user_slack_status_update_job.rb
+++ b/app/jobs/user_slack_status_update_job.rb
@@ -1,6 +1,16 @@
 class UserSlackStatusUpdateJob < ApplicationJob
   queue_as :latency_10s
 
+  retry_on HTTP::TimeoutError, HTTP::ConnectionError, JSON::ParserError,
+    wait: :polynomially_longer, attempts: 3 do |job, error|
+      user_id = job.arguments.first
+      job.report_error(
+        error,
+        message: "Failed to update Slack status for user #{user_id}",
+        extra: { user_id: }
+      )
+    end
+
   def perform(user_id)
     User.find_by(id: user_id)&.update_slack_status
   end

--- a/app/models/concerns/slack_integration.rb
+++ b/app/models/concerns/slack_integration.rb
@@ -8,6 +8,8 @@ module SlackIntegration
     end
   end
 
+  class ServerError < ApiError; end
+
   class RateLimitedError < StandardError
     attr_reader :retry_after
 
@@ -69,7 +71,7 @@ module SlackIntegration
     current_status_response = HTTP.auth("Bearer #{slack_access_token}")
       .get("https://slack.com/api/users.profile.get")
 
-    current_status = JSON.parse(current_status_response.body.to_s)
+    current_status = parse_slack_status_response!(current_status_response)
 
     custom_status_regex = /spent on \w+ today$/
     status_present = current_status.dig("profile", "status_text").present?
@@ -93,7 +95,7 @@ module SlackIntegration
     status_emoji = ":#{status_emoji}:"
     status_text = "#{current_project_duration_formatted} spent on #{current_project} today"
 
-    HTTP.auth("Bearer #{slack_access_token}")
+    update_status_response = HTTP.auth("Bearer #{slack_access_token}")
       .post("https://slack.com/api/users.profile.set", form: {
         profile: {
           status_text:,
@@ -101,5 +103,19 @@ module SlackIntegration
           status_expiration: (Time.now + 10.minutes).to_i
         }
       })
+    parse_slack_status_response!(update_status_response)
+  end
+
+  private
+
+  def parse_slack_status_response!(response)
+    status = response.status.code
+    raise RateLimitedError, response.headers["Retry-After"] if status == 429
+    raise ServerError.new("server error", status:) if status >= 500
+
+    data = JSON.parse(response.body.to_s)
+    raise ApiError.new(data["error"] || "unexpected response", status:) unless response.status.success? && data["ok"]
+
+    data
   end
 end

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -23,10 +23,6 @@ Rails.application.configure do
     end
 
   config.good_job.cron = {
-    # update_slack_status: {
-    #   cron: "*/5 * * * *",
-    #   class: "UserSlackStatusUpdateJob"
-    # },
     daily_leaderboard_update: {
       cron: "* * * * *",
       class: "LeaderboardUpdateJob",

--- a/test/controllers/settings_slack_github_controller_test.rb
+++ b/test/controllers/settings_slack_github_controller_test.rb
@@ -1,0 +1,46 @@
+require "test_helper"
+require "webmock/minitest"
+
+WebMock.disable_net_connect!(allow_localhost: true)
+
+class SettingsSlackGithubControllerTest < ActionDispatch::IntegrationTest
+  include ActiveJob::TestHelper
+
+  setup do
+    @original_queue_adapter = ActiveJob::Base.queue_adapter
+    ActiveJob::Base.queue_adapter = :test
+    clear_enqueued_jobs
+    clear_performed_jobs
+  end
+
+  teardown do
+    ActiveJob::Base.queue_adapter = @original_queue_adapter
+  end
+
+  test "update enables Slack status and enqueues the user without contacting Slack" do
+    user = create(:user, slack_access_token: "slack-token", uses_slack_status: false)
+    sign_in_as(user)
+
+    assert_enqueued_with(job: UserSlackStatusUpdateJob, args: [ user.id ]) do
+      patch my_settings_slack_github_update_path, params: { user: { uses_slack_status: "1" } }
+    end
+
+    assert_response :redirect
+    assert_redirected_to my_settings_slack_github_path
+    assert user.reload.uses_slack_status?
+    assert_not_requested :any, %r{\Ahttps://slack\.com/}
+  end
+
+  test "update does not enqueue Slack status work when the preference update fails" do
+    user = create(:user, uses_slack_status: false)
+    user.update_column(:country_code, "not-a-country")
+    sign_in_as(user)
+
+    assert_no_enqueued_jobs only: UserSlackStatusUpdateJob do
+      patch my_settings_slack_github_update_path, params: { user: { uses_slack_status: "1" } }
+    end
+
+    assert_response :unprocessable_entity
+    assert_not user.reload.uses_slack_status?
+  end
+end

--- a/test/jobs/user_slack_status_update_job_test.rb
+++ b/test/jobs/user_slack_status_update_job_test.rb
@@ -4,6 +4,19 @@ require "webmock/minitest"
 WebMock.disable_net_connect!(allow_localhost: true)
 
 class UserSlackStatusUpdateJobTest < ActiveJob::TestCase
+  include ActiveJob::TestHelper
+
+  setup do
+    @original_queue_adapter = ActiveJob::Base.queue_adapter
+    ActiveJob::Base.queue_adapter = :test
+  end
+
+  teardown do
+    ActiveJob::Base.queue_adapter = @original_queue_adapter
+    clear_enqueued_jobs
+    clear_performed_jobs
+  end
+
   test "updates only the requested user" do
     user = create(:user, slack_access_token: "requested-token", uses_slack_status: true)
     create(:user, slack_access_token: "other-token", uses_slack_status: true)
@@ -14,6 +27,22 @@ class UserSlackStatusUpdateJobTest < ActiveJob::TestCase
     UserSlackStatusUpdateJob.perform_now(user.id)
 
     assert_requested request, times: 1
+  end
+
+  test "retries a transient Slack connection failure" do
+    user = create(:user, slack_access_token: "requested-token", uses_slack_status: true)
+    request = stub_request(:get, "https://slack.com/api/users.profile.get")
+      .to_raise(HTTP::ConnectionError.new("Slack unavailable"))
+      .then
+      .to_return(body: { profile: { status_text: "In a meeting" } }.to_json)
+
+    assert_enqueued_with(job: UserSlackStatusUpdateJob, args: [ user.id ]) do
+      UserSlackStatusUpdateJob.perform_now(user.id)
+    end
+
+    perform_enqueued_jobs(only: UserSlackStatusUpdateJob)
+
+    assert_requested request, times: 2
   end
 
   test "does nothing when the user no longer exists" do

--- a/test/jobs/user_slack_status_update_job_test.rb
+++ b/test/jobs/user_slack_status_update_job_test.rb
@@ -22,7 +22,7 @@ class UserSlackStatusUpdateJobTest < ActiveJob::TestCase
     create(:user, slack_access_token: "other-token", uses_slack_status: true)
     request = stub_request(:get, "https://slack.com/api/users.profile.get")
       .with(headers: { "Authorization" => "Bearer requested-token" })
-      .to_return(body: { profile: { status_text: "In a meeting" } }.to_json)
+      .to_return(body: { ok: true, profile: { status_text: "In a meeting" } }.to_json)
 
     UserSlackStatusUpdateJob.perform_now(user.id)
 
@@ -34,10 +34,48 @@ class UserSlackStatusUpdateJobTest < ActiveJob::TestCase
     request = stub_request(:get, "https://slack.com/api/users.profile.get")
       .to_raise(HTTP::ConnectionError.new("Slack unavailable"))
       .then
-      .to_return(body: { profile: { status_text: "In a meeting" } }.to_json)
+      .to_return(body: { ok: true, profile: { status_text: "In a meeting" } }.to_json)
 
     assert_enqueued_with(job: UserSlackStatusUpdateJob, args: [ user.id ]) do
       UserSlackStatusUpdateJob.perform_now(user.id)
+    end
+
+    perform_enqueued_jobs(only: UserSlackStatusUpdateJob)
+
+    assert_requested request, times: 2
+  end
+
+  test "retries a transient Slack server error" do
+    user = create(:user, slack_access_token: "requested-token", uses_slack_status: true)
+    request = stub_request(:get, "https://slack.com/api/users.profile.get")
+      .to_return(status: 503, body: { ok: false, error: "service_unavailable" }.to_json)
+      .then
+      .to_return(body: { ok: true, profile: { status_text: "In a meeting" } }.to_json)
+
+    assert_enqueued_with(job: UserSlackStatusUpdateJob, args: [ user.id ]) do
+      UserSlackStatusUpdateJob.perform_now(user.id)
+    end
+
+    perform_enqueued_jobs(only: UserSlackStatusUpdateJob)
+
+    assert_requested request, times: 2
+  end
+
+  test "retries a Slack rate limit after the requested delay" do
+    user = create(:user, slack_access_token: "requested-token", uses_slack_status: true)
+    request = stub_request(:get, "https://slack.com/api/users.profile.get")
+      .to_return(
+        status: 429,
+        headers: { "Retry-After" => "60" },
+        body: { ok: false, error: "ratelimited" }.to_json
+      )
+      .then
+      .to_return(body: { ok: true, profile: { status_text: "In a meeting" } }.to_json)
+
+    travel_to Time.current.change(usec: 0) do
+      assert_enqueued_with(job: UserSlackStatusUpdateJob, args: [ user.id ], at: 60.seconds.from_now) do
+        UserSlackStatusUpdateJob.perform_now(user.id)
+      end
     end
 
     perform_enqueued_jobs(only: UserSlackStatusUpdateJob)

--- a/test/jobs/user_slack_status_update_job_test.rb
+++ b/test/jobs/user_slack_status_update_job_test.rb
@@ -1,0 +1,26 @@
+require "test_helper"
+require "webmock/minitest"
+
+WebMock.disable_net_connect!(allow_localhost: true)
+
+class UserSlackStatusUpdateJobTest < ActiveJob::TestCase
+  test "updates only the requested user" do
+    user = create(:user, slack_access_token: "requested-token", uses_slack_status: true)
+    create(:user, slack_access_token: "other-token", uses_slack_status: true)
+    request = stub_request(:get, "https://slack.com/api/users.profile.get")
+      .with(headers: { "Authorization" => "Bearer requested-token" })
+      .to_return(body: { profile: { status_text: "In a meeting" } }.to_json)
+
+    UserSlackStatusUpdateJob.perform_now(user.id)
+
+    assert_requested request, times: 1
+  end
+
+  test "does nothing when the user no longer exists" do
+    missing_user_id = User.maximum(:id).to_i + 1
+
+    UserSlackStatusUpdateJob.perform_now(missing_user_id)
+
+    assert_not_requested :any, %r{\Ahttps://slack\.com/}
+  end
+end

--- a/test/jobs/user_slack_status_update_job_test.rb
+++ b/test/jobs/user_slack_status_update_job_test.rb
@@ -83,6 +83,26 @@ class UserSlackStatusUpdateJobTest < ActiveJob::TestCase
     assert_requested request, times: 2
   end
 
+  test "reports a non-retryable Slack API error with user context without retrying" do
+    user = create(:user, slack_access_token: "requested-token", uses_slack_status: true)
+    stub_request(:get, "https://slack.com/api/users.profile.get")
+      .to_return(body: { ok: false, error: "missing_scope" }.to_json)
+    log_output = StringIO.new
+    previous_logger = Rails.logger
+    Rails.logger = ActiveSupport::Logger.new(log_output)
+
+    assert_no_enqueued_jobs only: UserSlackStatusUpdateJob do
+      error = assert_raises(SlackIntegration::ApiError) do
+        UserSlackStatusUpdateJob.perform_now(user.id)
+      end
+      assert_includes error.message, "missing_scope"
+    end
+
+    assert_includes log_output.string, "Failed to update Slack status for user #{user.id}"
+  ensure
+    Rails.logger = previous_logger if previous_logger
+  end
+
   test "does nothing when the user no longer exists" do
     missing_user_id = User.maximum(:id).to_i + 1
 


### PR DESCRIPTION
## Summary of the problem

Updating Slack status sync made Slack API requests in the settings request after the preference had already been saved. A Slack failure could therefore return an error after persisting the change.

## Describe your changes

Enqueue the Slack status update for the changed user only after the preference saves. The job targets one user, safely skips deleted users and retries transient Slack connection, timeout and response parsing failures three times before reporting with user context. The unused batch cron contract is removed.

## Screenshots / Media

Not applicable. No visual changes.