### PR TITLE
Standardise browser authentication for settings

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -82,9 +82,9 @@ class ApplicationController < ActionController::Base
     { "url" => url }
   end
 
-  def authenticate_user!
+  def authenticate_user!(continue_path: request.fullpath)
     unless user_signed_in?
-      redirect_to signin_path(continue: request.fullpath), alert: "Please sign in first!"
+      redirect_to signin_path(continue: continue_path), alert: "Please sign in first!"
     end
   end
 

--- a/app/controllers/settings/base_controller.rb
+++ b/app/controllers/settings/base_controller.rb
@@ -48,6 +48,11 @@ class Settings::BaseController < InertiaController
       .transform_values { |builder| builder.call }
   end
 
+  def authenticate_user!
+    continue_path = request.get? || request.head? ? request.fullpath : url_for(action: :show, only_path: true)
+    super(continue_path: continue_path)
+  end
+
   def set_user
     @user = current_user
   end

--- a/app/controllers/settings/base_controller.rb
+++ b/app/controllers/settings/base_controller.rb
@@ -1,6 +1,7 @@
 class Settings::BaseController < InertiaController
   layout "inertia"
 
+  before_action :authenticate_user!
   before_action :set_user
 
   def show = render_settings_page
@@ -49,6 +50,5 @@ class Settings::BaseController < InertiaController
 
   def set_user
     @user = current_user
-    redirect_to root_path, alert: "You need to log in!" if @user.nil?
   end
 end

--- a/test/controllers/settings_appearance_controller_test.rb
+++ b/test/controllers/settings_appearance_controller_test.rb
@@ -1,6 +1,26 @@
 require "test_helper"
 
 class SettingsAppearanceControllerTest < ActionDispatch::IntegrationTest
+  test "show redirects guests to sign in with the original URL" do
+    settings_path = my_settings_appearance_path(source: "profile")
+
+    get settings_path
+
+    assert_response :redirect
+    assert_redirected_to signin_path(continue: settings_path)
+  end
+
+  test "show renders appearance settings for an authenticated user" do
+    user = create(:user)
+    sign_in_as(user)
+
+    get my_settings_appearance_path
+
+    assert_response :success
+    assert_inertia_component "Users/Settings/Appearance"
+    assert_equal user.theme, inertia.props.dig("user", "theme")
+  end
+
   test "theme update persists selected theme and clears Inertia history" do
     user = create(:user)
     sign_in_as(user)

--- a/test/controllers/settings_appearance_controller_test.rb
+++ b/test/controllers/settings_appearance_controller_test.rb
@@ -21,6 +21,17 @@ class SettingsAppearanceControllerTest < ActionDispatch::IntegrationTest
     assert_equal user.theme, inertia.props.dig("user", "theme")
   end
 
+  test "expired session mutation continues to the GET settings page" do
+    user = create(:user)
+    sign_in_as(user)
+    reset!
+
+    patch my_settings_appearance_theme_path, params: { user: { theme: "nord" } }
+
+    assert_response :redirect
+    assert_redirected_to signin_path(continue: my_settings_appearance_path)
+  end
+
   test "theme update persists selected theme and clears Inertia history" do
     user = create(:user)
     sign_in_as(user)


### PR DESCRIPTION
## Summary of the problem
Settings pages used a local guest guard that redirected to the home page, discarding the requested destination and bypassing the shared sign-in continuation flow.

## Describe your changes
Settings now authenticate through the shared browser callback before assigning the current user. This retains `@user` for settings subclasses and lets Rails halt the callback chain after redirecting a guest. Request coverage protects both the continuation URL and authenticated rendering.

## Screenshots / Media
Not applicable. There are no visual changes.
