### PR TITLE
Return 401 for failed internal API authentication

### DIFF
--- a/app/controllers/api/internal/application_controller.rb
+++ b/app/controllers/api/internal/application_controller.rb
@@ -8,17 +8,22 @@ module Api
       private
 
       def authenticate!
-        res = authenticate_with_http_token do |token, _|
+        authenticated = authenticate_with_http_token do |token, _|
           next false if token.blank?
+
           token_hash = ::Digest::SHA256.digest(token)
-          ENV["INTERNAL_API_KEYS"]&.split(",")&.any? do |expected|
+          expected_api_keys.any? do |expected|
             next false if expected.blank?
+
             ActiveSupport::SecurityUtils.secure_compare(token_hash, ::Digest::SHA256.digest(expected))
           end
         end
-        unless res
-          redirect_to "https://www.youtube.com/watch?v=dQw4w9WgXcQ", allow_other_host: true
-        end
+
+        head :unauthorized unless authenticated
+      end
+
+      def expected_api_keys
+        ENV["INTERNAL_API_KEYS"].to_s.split(",")
       end
     end
   end

--- a/app/controllers/api/internal/revocations_controller.rb
+++ b/app/controllers/api/internal/revocations_controller.rb
@@ -57,13 +57,8 @@ module Api
         render json: { success: false, error: message }, status: :unprocessable_entity
       end
 
-      private def authenticate!
-        res = authenticate_with_http_token do |token, _|
-          ActiveSupport::SecurityUtils.secure_compare(token, ENV["HKA_REVOCATION_KEY"])
-        end
-        unless res
-          redirect_to "https://www.youtube.com/watch?v=dQw4w9WgXcQ", allow_other_host: true
-        end
+      def expected_api_keys
+        [ ENV["HKA_REVOCATION_KEY"] ]
       end
     end
   end

--- a/spec/requests/api/internal/internal_spec.rb
+++ b/spec/requests/api/internal/internal_spec.rb
@@ -72,8 +72,8 @@ RSpec.describe 'Api::Internal', type: :request, openapi_spec: 'admin/swagger.yam
         run_test!
       end
 
-      response(302, 'redirect on failed authentication — When the provided token does not match HKA_REVOCATION_KEY (or is missing), the controller does not return 401; it issues a 302 redirect to an external URL.') do
-        let(:Authorization) { "Bearer wrong_revocation_key" }
+      response(401, 'unauthorized') do
+        let(:Authorization) { "Bearer wrong" }
         let(:payload) { { token: SecureRandom.uuid_v4 } }
 
         before do

--- a/swagger/admin/swagger.yaml
+++ b/swagger/admin/swagger.yaml
@@ -3414,10 +3414,8 @@ paths:
                 required:
                 - success
                 - error
-        '302':
-          description: redirect on failed authentication — When the provided token
-            does not match HKA_REVOCATION_KEY (or is missing), the controller does
-            not return 401; it issues a 302 redirect to an external URL.
+        '401':
+          description: unauthorized
       requestBody:
         content:
           application/json:

--- a/test/controllers/api/internal/revocations_controller_test.rb
+++ b/test/controllers/api/internal/revocations_controller_test.rb
@@ -86,11 +86,29 @@ class Api::Internal::RevocationsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Token is invalid or already revoked", response.parsed_body["error"]
   end
 
+  test "returns unauthorized when the revocation key is missing" do
+    ENV.delete("HKA_REVOCATION_KEY")
+
+    post "/api/internal/revoke", params: { token: SecureRandom.uuid_v4 }, headers: auth_headers("present-token"), as: :json
+
+    assert_response :unauthorized
+    assert_empty response.body
+    assert_nil response.location
+  end
+
+  test "returns unauthorized when the bearer token has a different length" do
+    post "/api/internal/revoke", params: { token: SecureRandom.uuid_v4 }, headers: auth_headers("short"), as: :json
+
+    assert_response :unauthorized
+    assert_empty response.body
+    assert_nil response.location
+  end
+
   private
 
-  def auth_headers
+  def auth_headers(token = ENV.fetch("HKA_REVOCATION_KEY"))
     {
-      "Authorization" => ActionController::HttpAuthentication::Token.encode_credentials(ENV.fetch("HKA_REVOCATION_KEY"))
+      "Authorization" => ActionController::HttpAuthentication::Token.encode_credentials(token)
     }
   end
 end


### PR DESCRIPTION
## Summary of the problem

The revocation endpoint handled its credential separately from the internal API authentication policy. A missing secret could raise an exception and failed authentication redirected callers to an external page.

## Describe your changes

Centralises blank handling and digest comparison in the internal API base controller while allowing each controller to supply its expected keys. The revocation controller now supplies `HKA_REVOCATION_KEY` and failed authentication returns an empty 401 response. The successful revocation response remains unchanged and the documented failure response is now 401.

## Screenshots / Media

Not applicable because there are no visual changes.