### PR TITLE
Use static Tailwind classes for settings code blocks

### DIFF
--- a/app/javascript/pages/Users/Settings/components/CodeBlock.svelte
+++ b/app/javascript/pages/Users/Settings/components/CodeBlock.svelte
@@ -1,10 +1,19 @@
 <script lang="ts">
+  const sizeClasses = {
+    xs: "text-xs",
+    sm: "text-sm",
+  } as const;
+
   let {
     text,
     size = "xs",
     class: className = "",
-  }: { text: string; size?: "xs" | "sm"; class?: string } = $props();
+  }: {
+    text: string;
+    size?: keyof typeof sizeClasses;
+    class?: string;
+  } = $props();
 </script>
 
 <pre
-  class={`overflow-x-auto rounded-md border border-surface-200 bg-darker p-4 text-${size} text-surface-content ${className}`}>{text}</pre>
+  class={`overflow-x-auto rounded-md border border-surface-200 bg-darker p-4 ${sizeClasses[size]} text-surface-content ${className}`}>{text}</pre>


### PR DESCRIPTION
## Summary of the problem

The settings code block built its text size as `text-${size}`. Tailwind cannot detect these dynamic class names, so the generated styles depended on unrelated source files containing each size.

## Describe your changes

Map the typed `xs` and `sm` size options to static `text-xs` and `text-sm` classes so Tailwind discovers both without changing rendered output.

## Screenshots / Media

Not applicable. There is no visual change.
