### PR TITLE
Use shared Button component across Inertia pages

### DIFF
--- a/app/javascript/components/UserPicker.svelte
+++ b/app/javascript/components/UserPicker.svelte
@@ -14,6 +14,7 @@
 <script lang="ts">
   import { Debounced } from "runed";
   import Search from "hcicons-svelte/search";
+  import Button from "./Button.svelte";
   import { formatUtcDate } from "../utils";
 
   type Accent = "primary" | "green" | "red";
@@ -233,13 +234,14 @@
             {/if}
           </div>
         </div>
-        <button
+        <Button
+          unstyled
           type="button"
           class="shrink-0 cursor-pointer text-sm text-muted hover:text-red"
           onclick={() => (selected = null)}
         >
           Clear
-        </button>
+        </Button>
       </div>
     </div>
   {:else}

--- a/app/javascript/pages/Admin/Timeline.svelte
+++ b/app/javascript/pages/Admin/Timeline.svelte
@@ -366,7 +366,8 @@
                 >
                   No users found
                 </div>{/if}
-              {#each results as user}<button
+              {#each results as user}<Button
+                  unstyled
                   type="button"
                   onmousedown={(event) => event.preventDefault()}
                   onclick={() => selectUser(user)}
@@ -380,7 +381,7 @@
                     class="ml-auto rounded-full bg-surface-100 px-2 py-1 text-xs text-muted"
                     >#{user.id}</span
                   >
-                </button>{/each}
+                </Button>{/each}
             </div>{/if}
         </div>
         <Button
@@ -416,13 +417,14 @@
               />{/if}<span class="mr-2">{user.display_name}</span><span
               class="rounded-md px-2 py-0.5 text-xs">#{user.id}</span
             >
-            {#if user.id !== current_user.id}<button
+            {#if user.id !== current_user.id}<Button
+                unstyled
                 type="button"
                 aria-label="Remove user"
                 onclick={() =>
                   (selected = selected.filter(({ id }) => id !== user.id))}
                 class="ml-2 text-lg leading-none text-muted hover:text-surface-content"
-                >×</button
+                >×</Button
               >{/if}
           </span>{/each}
       </div>
@@ -488,11 +490,12 @@
                     class="text-xs text-green underline">Git</a
                   >{/if}<span class="text-sm"
                   >{trustEmoji(column.user.trust_level)}</span
-                >{#if canMutate && column.user.id !== current_user.id}<button
+                >{#if canMutate && column.user.id !== current_user.id}<Button
+                    unstyled
                     type="button"
                     onclick={() => setTrust(column)}
                     class="text-xs text-muted hover:text-surface-content"
-                    title="Set trust level">🔨</button
+                    title="Set trust level">🔨</Button
                   >{/if}
               </div>
               <div

--- a/app/javascript/pages/Setup/Index.svelte
+++ b/app/javascript/pages/Setup/Index.svelte
@@ -2,6 +2,7 @@
   import { page, router } from "@inertiajs/svelte";
   import { untrack } from "svelte";
   import { Icon, ArrowLeft } from "svelte-hero-icons";
+  import Button from "../../components/Button.svelte";
   import TwoChoiceLayout from "./components/TwoChoiceLayout.svelte";
   import TwoChoiceCard from "./components/TwoChoiceCard.svelte";
   import LinkScreen from "./LinkScreen.svelte";
@@ -75,14 +76,15 @@
 ></div>
 
 {#if step !== initialStep}
-  <button
+  <Button
+    unstyled
     type="button"
     onclick={() => window.history.back()}
     class="fixed top-4 left-4 z-10 flex items-center gap-1.5 rounded-lg px-3 py-2 text-sm font-medium text-secondary transition-colors hover:text-surface-content sm:top-6 sm:left-6"
   >
     <Icon src={ArrowLeft} size="18" />
     Back
-  </button>
+  </Button>
 {/if}
 
 <div class="mx-auto max-w-3xl py-6 sm:py-10">

--- a/app/javascript/pages/Setup/TerminalCommand.svelte
+++ b/app/javascript/pages/Setup/TerminalCommand.svelte
@@ -83,9 +83,14 @@
       class="flex gap-1 rounded-xl border border-surface-300 bg-surface-100 p-1"
     >
       {#each OS_TABS as tab (tab.key)}
-        <button class={toggleClass(tab.key)} onclick={() => (os = tab.key)}>
+        <Button
+          unstyled
+          type="button"
+          class={toggleClass(tab.key)}
+          onclick={() => (os = tab.key)}
+        >
           {tab.label}
-        </button>
+        </Button>
       {/each}
     </div>
 

--- a/app/javascript/pages/Setup/VsCodeSteps.svelte
+++ b/app/javascript/pages/Setup/VsCodeSteps.svelte
@@ -64,7 +64,8 @@
         >
           {step.title}
         </h2>
-        <button
+        <Button
+          unstyled
           type="button"
           onclick={() => openZoom(i)}
           aria-label={`Zoom in: ${step.title}`}
@@ -79,7 +80,7 @@
             decoding="async"
             class="max-h-full max-w-full object-contain transition-transform duration-200 group-hover:scale-[1.02]"
           />
-        </button>
+        </Button>
       </div>
     {/each}
   </div>

--- a/app/javascript/pages/Setup/components/SetupCodeBlock.svelte
+++ b/app/javascript/pages/Setup/components/SetupCodeBlock.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import Button from "../../../components/Button.svelte";
+
   interface Props {
     code: string;
   }
@@ -21,11 +23,12 @@
     class="overflow-x-auto p-4 pr-24 font-mono text-sm break-all whitespace-pre-wrap text-cyan"><code
       >{code}</code
     ></pre>
-  <button
+  <Button
+    unstyled
     type="button"
     onclick={copy}
     class="absolute top-3 right-3 rounded-lg border border-darkless bg-dark px-3 py-1.5 text-sm font-medium text-secondary hover:text-surface-content"
   >
     {copied ? "Copied!" : "Copy"}
-  </button>
+  </Button>
 </div>

--- a/app/javascript/pages/Setup/components/TwoChoiceCard.svelte
+++ b/app/javascript/pages/Setup/components/TwoChoiceCard.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import Button from "../../../components/Button.svelte";
+
   interface Props {
     label: string;
     sublabel?: string;
@@ -8,7 +10,8 @@
   let { label, sublabel, onclick }: Props = $props();
 </script>
 
-<button
+<Button
+  unstyled
   type="button"
   {onclick}
   class="flex min-h-32 flex-col items-center justify-center gap-2 rounded-2xl border-2 border-primary bg-primary/5 p-6 shadow-lg shadow-primary/10 transition-[transform,background-color] duration-200 ease-[cubic-bezier(0.34,1.56,0.64,1)] hover:-translate-y-1 hover:bg-primary/10 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary active:translate-y-0 active:scale-[0.97] motion-reduce:transition-none motion-reduce:hover:translate-y-0 motion-reduce:active:scale-100 sm:min-h-36 cursor-pointer"
@@ -19,4 +22,4 @@
       >{sublabel}</span
     >
   {/if}
-</button>
+</Button>


### PR DESCRIPTION
## Summary of the problem
Several Inertia Svelte pages and components still used raw HTML buttons instead of the shared `Button` component required by project conventions.

## Describe your changes
Replaces nine raw buttons in `UserPicker`, Admin Timeline and Setup with the shared component. Each replacement uses `unstyled` so bespoke classes and appearance remain intact while preserving explicit button types, event behaviour, semantics and accessibility attributes.

## Screenshots / Media
Not included because appearance is unchanged.