### PR TITLE
Fix timezone handling in quantised activity

### DIFF
--- a/app/controllers/api/admin/v1/admin_controller.rb
+++ b/app/controllers/api/admin/v1/admin_controller.rb
@@ -41,36 +41,45 @@ module Api
           return render_error("invalid parameters") if year.nil? || month.nil? || month < 1 || month > 12
 
           begin
-            start_epoch = Time.utc(year, month, 1).to_i
-            end_epoch = month == 12 ? Time.utc(year + 1, 1, 1).to_i : Time.utc(year, month + 1, 1).to_i
+            timezone = Time.find_zone!(user.timezone)
+            start_date = Date.new(year, month, 1)
+            end_date = start_date.next_month
+            start_epoch = timezone.local(start_date.year, start_date.month, start_date.day).to_i
+            end_epoch = timezone.local(end_date.year, end_date.month, end_date.day).to_i
           rescue Date::Error
             return render_error("invalid date")
           end
 
           quantized_query = <<-SQL
-            WITH base_heartbeats AS (
+            WITH query_parameters(timezone) AS (VALUES (?)),
+            base_heartbeats AS (
                 SELECT
                     "time",
                     lineno,
                     cursorpos,
-                    date_trunc('day', to_timestamp("time")) as day_start
+                    to_timestamp("time") AT TIME ZONE query_parameters.timezone AS local_time
                 FROM heartbeats
+                CROSS JOIN query_parameters
                 WHERE user_id = ?
                 AND deleted_at IS NULL
-                AND "time" >= ? AND "time" <= ?
+                AND "time" >= ? AND "time" < ?
                 LIMIT 1000000
+            ),
+            bucketed_heartbeats AS (
+                SELECT *, date_trunc('day', local_time) AS day_start
+                FROM base_heartbeats
             ),
             daily_stats AS (
                 SELECT
                     *,
                     GREATEST(1, MAX(lineno) OVER (PARTITION BY day_start)) as max_lineno,
                     GREATEST(1, MAX(cursorpos) OVER (PARTITION BY day_start)) as max_cursorpos
-                FROM base_heartbeats
+                FROM bucketed_heartbeats
             ),
             quantized_heartbeats AS (
                 SELECT
                     *,
-                    ROUND(2 + (("time" - extract(epoch from day_start)) / 86400) * (396)) as qx,
+                    ROUND(2 + (extract(epoch from (local_time - day_start)) / 86400) * (396)) as qx,
                     ROUND(2 + (1 - CAST(lineno AS decimal) / max_lineno) * (96)) as qy_lineno,
                     ROUND(2 + (1 - CAST(cursorpos AS decimal) / max_cursorpos) * (96)) as qy_cursorpos
                 FROM daily_stats
@@ -102,12 +111,21 @@ module Api
           SQL
 
           daily_totals_query = <<-SQL
-            WITH heartbeats_with_gaps AS (
+            WITH query_parameters(timezone) AS (VALUES (?)),
+            base_heartbeats AS (
               SELECT
-                date_trunc('day', to_timestamp("time"))::date as day,
-                "time" - LAG("time", 1, "time") OVER (PARTITION BY date_trunc('day', to_timestamp("time")) ORDER BY "time", id) as gap
+                id,
+                "time",
+                to_timestamp("time") AT TIME ZONE query_parameters.timezone AS local_time
               FROM heartbeats
-              WHERE user_id = ? AND deleted_at IS NULL AND time >= ? AND time <= ?
+              CROSS JOIN query_parameters
+              WHERE user_id = ? AND deleted_at IS NULL AND time >= ? AND time < ?
+            ),
+            heartbeats_with_gaps AS (
+              SELECT
+                date_trunc('day', local_time)::date as day,
+                "time" - LAG("time", 1, "time") OVER (PARTITION BY date_trunc('day', local_time) ORDER BY "time", id) as gap
+              FROM base_heartbeats
             )
             SELECT day, SUM(LEAST(gap, 120)) as total_seconds
             FROM heartbeats_with_gaps
@@ -116,19 +134,20 @@ module Api
           SQL
 
           conn = ActiveRecord::Base.connection
-          quantized_result = conn.execute(ActiveRecord::Base.sanitize_sql([ quantized_query, user.id, start_epoch, end_epoch ]))
-          daily_totals_result = conn.execute(ActiveRecord::Base.sanitize_sql([ daily_totals_query, user.id, start_epoch, end_epoch ]))
+          query_parameters = [ user.timezone, user.id, start_epoch, end_epoch ]
+          quantized_result = conn.execute(ActiveRecord::Base.sanitize_sql([ quantized_query, *query_parameters ]))
+          daily_totals_result = conn.execute(ActiveRecord::Base.sanitize_sql([ daily_totals_query, *query_parameters ]))
 
           daily_totals = daily_totals_result.each_with_object({}) { |row, h| h[row["day"]] = row["total_seconds"] }
 
           points_by_day = quantized_result.each_with_object({}) do |row, hash|
-            day = Time.at(row["time"]).to_date
+            day = Time.at(row["time"]).in_time_zone(timezone).to_date
             (hash[day] ||= []) << { time: row["time"], lineno: row["lineno"], cursorpos: row["cursorpos"] }
           end
 
-          days = (start_epoch...end_epoch).step(86400).map do |epoch|
-            day = Time.at(epoch).to_date
-            { date_timestamp_s: epoch, total_seconds: daily_totals[day] || 0, points: points_by_day[day] || [] }
+          days = (start_date...end_date).map do |date|
+            date_epoch = timezone.local(date.year, date.month, date.day).to_i
+            { date_timestamp_s: date_epoch, total_seconds: daily_totals[date] || 0, points: points_by_day[date] || [] }
           end
 
           render json: { days: days }

--- a/spec/requests/api/admin/v1/admin_misc_spec.rb
+++ b/spec/requests/api/admin/v1/admin_misc_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Api::Admin::V1::AdminMisc', type: :request, openapi_spec: 'admin
               items: {
                 type: :object,
                 properties: {
-                  date_timestamp_s: { type: :integer, example: 1704067200, description: 'Start-of-day epoch (seconds, UTC)' },
+                  date_timestamp_s: { type: :integer, example: 1704067200, description: "Epoch for the start of the target user's local day" },
                   total_seconds: { type: :number, example: 7200.0, description: 'Total coding seconds for the day' },
                   points: {
                     type: :array,

--- a/swagger/admin/swagger.yaml
+++ b/swagger/admin/swagger.yaml
@@ -54,7 +54,8 @@ paths:
                         date_timestamp_s:
                           type: integer
                           example: 1704067200
-                          description: Start-of-day epoch (seconds, UTC)
+                          description: Epoch for the start of the target user's local
+                            day
                         total_seconds:
                           type: number
                           example: 7200.0

--- a/test/controllers/api/admin/v1/admin_controller_test.rb
+++ b/test/controllers/api/admin/v1/admin_controller_test.rb
@@ -1,6 +1,51 @@
 require "test_helper"
 
 class Api::Admin::V1::AdminControllerTest < ActionDispatch::IntegrationTest
+  test "quantized visualization uses the target user's calendar days across DST and month boundaries" do
+    admin = create(:user, :superadmin)
+    key = create(:admin_api_key, user: admin, name: "test")
+    user = create(:user, timezone: "America/Los_Angeles")
+    timezone = ActiveSupport::TimeZone[user.timezone]
+
+    outside_start = timezone.local(2024, 2, 29, 23, 59, 30).to_i
+    march_start = timezone.local(2024, 3, 1, 0, 0, 30).to_i
+    before_local_midnight = timezone.local(2024, 3, 9, 23, 59, 30).to_i
+    after_local_midnight = timezone.local(2024, 3, 10, 0, 0, 30).to_i
+    before_dst_jump = timezone.local(2024, 3, 10, 1, 59, 30).to_i
+    after_dst_jump = timezone.local(2024, 3, 10, 3, 0, 30).to_i
+    march_end = timezone.local(2024, 3, 31, 23, 59, 30).to_i
+    outside_end = timezone.local(2024, 4, 1, 0, 0, 30).to_i
+
+    [
+      outside_start,
+      march_start,
+      before_local_midnight,
+      after_local_midnight,
+      before_dst_jump,
+      after_dst_jump,
+      march_end,
+      outside_end
+    ].each { |time| create(:heartbeat, user: user, time: time) }
+
+    get "/api/admin/v1/users/#{user.id}/visualization/quantized",
+      params: { year: 2024, month: 3 }, headers: auth_headers(key)
+
+    assert_response :success
+    days = response.parsed_body.fetch("days")
+    assert_equal 31, days.length
+    assert_equal timezone.local(2024, 3, 1).to_i, days.first.fetch("date_timestamp_s")
+    assert_equal timezone.local(2024, 3, 31).to_i, days.last.fetch("date_timestamp_s")
+    assert_equal 23.hours.to_i,
+      days[10].fetch("date_timestamp_s") - days[9].fetch("date_timestamp_s")
+
+    assert_equal [ march_start ], days[0].fetch("points").pluck("time")
+    assert_equal [ before_local_midnight ], days[8].fetch("points").pluck("time")
+    assert_equal [ after_local_midnight, before_dst_jump, after_dst_jump ],
+      days[9].fetch("points").pluck("time")
+    assert_equal 180, days[9].fetch("total_seconds")
+    assert_equal [ march_end ], days[30].fetch("points").pluck("time")
+  end
+
   test "user heartbeats returns ja4 fingerprint and name" do
     admin = create(:user, :superadmin)
     key = create(:admin_api_key, user: admin, name: "test")


### PR DESCRIPTION
## Summary of the problem

The quantised activity endpoint used UTC month bounds and day buckets for every user. This misplaced activity near local month boundaries and produced incorrect calendar days across daylight saving transitions.

## Describe your changes

Use the target user's validated timezone for local month bounds, SQL day grouping and quantisation. Group returned points by the same local date and build the response by calendar date while preserving the existing duration cap and response shape.

## Screenshots / Media

Not applicable. This changes the JSON activity calculation only.
