### PR TITLE
Move unique stats duration calculation to Heartbeatable

### DIFF
--- a/app/controllers/api/v1/stats_controller.rb
+++ b/app/controllers/api/v1/stats_controller.rb
@@ -97,7 +97,7 @@ class Api::V1::StatsController < ApplicationController
     if params[:features]&.include?("projects") && params[:filter_by_project].present?
       heartbeats = @user.heartbeats.coding_only.with_valid_timestamps
                                    .where(time: start_date..end_date, project: filter_by_projects)
-      summary[:unique_total_seconds] = unique_heartbeat_seconds(heartbeats)
+      summary[:unique_total_seconds] = heartbeats.duration_seconds_excluding_gaps_over_timeout
     end
 
     trust_level = @user.public_trust_level
@@ -200,18 +200,6 @@ class Api::V1::StatsController < ApplicationController
   def project_stats_query(include_archived: false)
     @project_stats_queries ||= {}
     @project_stats_queries[include_archived] ||= ProjectStatsQuery.new(user: @user, params: params, include_archived: include_archived)
-  end
-
-  def unique_heartbeat_seconds(heartbeats)
-    timestamps = heartbeats.order(:time, :id).pluck(:time)
-    return 0 if timestamps.empty?
-
-    total_seconds = 0
-    timestamps.each_cons(2) do |prev_time, curr_time|
-      gap = curr_time - prev_time
-      total_seconds += gap if gap > 0 && gap <= 2.minutes
-    end
-    total_seconds.to_i
   end
 
   def parse_date_param(param_name, default:, boundary:)

--- a/app/models/concerns/heartbeatable.rb
+++ b/app/models/concerns/heartbeatable.rb
@@ -250,6 +250,20 @@ module Heartbeatable
       connection.select_all(sql).each_with_object({}) { |row, hash| hash[row["bucket"]] = row["duration"].to_i }
     end
 
+    def duration_seconds_excluding_gaps_over_timeout(scope = all)
+      scope = scope.with_valid_timestamps
+      heartbeat_gaps = scope.select("LAG(time) OVER (ORDER BY time, #{quoted_table_name}.id) as duration_start, time as duration_end").where.not(time: nil)
+      timeout = heartbeat_timeout_duration.to_i
+
+      connection.select_value(<<~SQL.squish).to_f.to_i
+        SELECT COALESCE(SUM(duration_end - duration_start), 0)
+        FROM (#{heartbeat_gaps.to_sql}) AS durations
+        WHERE duration_start IS NOT NULL
+          AND duration_end > duration_start
+          AND duration_end - duration_start <= #{timeout}
+      SQL
+    end
+
     def duration_seconds(scope = all)
       scope = scope.with_valid_timestamps
 

--- a/test/controllers/api/v1/stats_controller_test.rb
+++ b/test/controllers/api/v1/stats_controller_test.rb
@@ -29,6 +29,60 @@ class Api::V1::StatsControllerTest < ActionDispatch::IntegrationTest
     assert_equal summary_total, total_only
   end
 
+  test "user_stats unique_total_seconds matches filtered coding duration at timeout and date boundaries" do
+    user = create(:user, username: "stats_user_#{SecureRandom.hex(3)}")
+    start_time = Time.utc(2025, 12, 15, 10, 0, 0)
+    end_time = start_time + 301.seconds
+
+    create_heartbeat(user:, time: (start_time - 60.seconds).to_f, project: "alpha", category: "coding")
+    create_heartbeat(user:, time: start_time.to_f, project: "alpha", category: "coding")
+    create_heartbeat(user:, time: (start_time + 120.seconds).to_f, project: "alpha", category: "coding")
+    create_heartbeat(user:, time: (start_time + 180.seconds).to_f, project: "alpha", category: "browsing")
+    create_heartbeat(user:, time: (start_time + 180.seconds).to_f, project: "other", category: "coding")
+    create_heartbeat(user:, time: (start_time + 241.seconds).to_f, project: "beta", category: "coding")
+    create_heartbeat(user:, time: end_time.to_f, project: "beta", category: "coding")
+
+    get "/api/v1/users/#{user.username}/stats", params: {
+      features: "projects",
+      filter_by_project: "alpha,beta",
+      start_date: start_time.iso8601(3),
+      end_date: end_time.iso8601(3)
+    }
+
+    assert_response :success
+    scope = user.heartbeats.coding_only.with_valid_timestamps
+                .where(time: start_time..end_time, project: %w[alpha beta])
+    authoritative_duration = scope.duration_seconds_excluding_gaps_over_timeout
+
+    assert_equal 180, authoritative_duration
+    assert_equal authoritative_duration, JSON.parse(response.body).dig("data", "unique_total_seconds")
+  end
+
+  test "user_stats unique_total_seconds ignores invalid timestamps in test mode" do
+    user = create(:user, username: "stats_user_#{SecureRandom.hex(3)}")
+    start_time = Time.at(-60).utc
+    end_time = Time.at(180).utc
+
+    create_heartbeat(user:, time: -60.0, project: "alpha", category: "coding")
+    create_heartbeat(user:, time: 0.0, project: "alpha", category: "coding")
+    create_heartbeat(user:, time: 120.0, project: "alpha", category: "coding")
+
+    get "/api/v1/users/#{user.username}/stats", params: {
+      features: "projects",
+      filter_by_project: "alpha",
+      start_date: start_time.iso8601,
+      end_date: end_time.iso8601,
+      test_param: "true"
+    }
+
+    assert_response :success
+    scope = user.heartbeats.coding_only.with_valid_timestamps.where(time: start_time..end_time, project: "alpha")
+    authoritative_duration = scope.duration_seconds_excluding_gaps_over_timeout
+
+    assert_equal 120, authoritative_duration
+    assert_equal authoritative_duration, JSON.parse(response.body).dig("data", "unique_total_seconds")
+  end
+
   test "user_stats with project filter does not load heartbeat records" do
     user = create(:user, username: "stats_user_#{SecureRandom.hex(3)}")
     create_heartbeat(user:, time: Time.utc(2025, 12, 15, 10, 0, 0).to_f, project: "Galactic_war", category: "coding")


### PR DESCRIPTION
## Summary of the problem

`StatsController#user_stats` calculated `unique_total_seconds` with controller-local timestamp ordering and timeout handling even though Heartbeatable owns heartbeat duration semantics.

## Describe your changes

Moved the distinct over-timeout gap calculation into a narrowly named Heartbeatable relation method and made the endpoint delegate to it. The established coding-only, valid timestamp and project filter behaviour is preserved, including exact timeout and date boundary handling. Added endpoint regression coverage against the authoritative relation result, including `test_param` mode.

## Screenshots / Media

Not applicable. There are no visual changes.