### PR TITLE
Use one canonical Hackatime API key across setup surfaces

### DIFF
--- a/app/controllers/api/v1/authenticated/api_keys_controller.rb
+++ b/app/controllers/api/v1/authenticated/api_keys_controller.rb
@@ -9,7 +9,7 @@ module Api
         private
 
         def api_key
-          @api_key ||= current_user.api_keys.first || current_user.api_keys.create!
+          @api_key ||= current_user.hackatime_api_key(create_if_missing: true)
         end
       end
     end

--- a/app/controllers/api_keys_controller.rb
+++ b/app/controllers/api_keys_controller.rb
@@ -4,7 +4,7 @@ class ApiKeysController < InertiaController
   before_action :authenticate_user!
 
   def show
-    api_key = current_user.api_keys.first || current_user.api_keys.create!(name: "Hackatime key")
+    api_key = current_user.hackatime_api_key(create_if_missing: true)
 
     render inertia: "ApiKey/Show", props: {
       api_key: api_key.token

--- a/app/controllers/settings/setup_controller.rb
+++ b/app/controllers/settings/setup_controller.rb
@@ -2,7 +2,7 @@ class Settings::SetupController < Settings::BaseController
   private
 
   def page_props
-    api_key_token = @user.api_keys.last&.token
+    api_key_token = @user.hackatime_api_key&.token
 
     {
       config_file: {

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -17,7 +17,7 @@ class UsersController < InertiaController
     session[:return_data]&.delete("skip_setup_flow")
 
     render inertia: "Setup/Index", props: {
-      current_user_api_key: ensure_api_key.token,
+      current_user_api_key: current_user.hackatime_api_key(create_if_missing: true).token,
       setup_os: detect_setup_os(request.user_agent).to_s,
       skip_setup_flow: skip_setup_flow,
       return_url: session.dig(:return_data, "url"),
@@ -64,10 +64,6 @@ class UsersController < InertiaController
   def current_theme = SETUP_THEME
   def current_theme_color_scheme = User.theme_metadata(SETUP_THEME).fetch(:color_scheme, "light")
   def current_theme_color = User.theme_metadata(SETUP_THEME).fetch(:theme_color, "#aa586f")
-
-  def ensure_api_key
-    current_user&.api_keys&.last || current_user.api_keys.create!(name: "Wakatime API Key")
-  end
 
   def ensure_current_user_for_setup
     redirect_to signin_path(continue: request.fullpath), alert: "Please sign in to set up your editor." if current_user.nil?

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -1,4 +1,6 @@
 class ApiKey < ApplicationRecord
+  DEFAULT_NAME = "Hackatime key".freeze
+
   belongs_to :user
 
   validates :token, presence: true, uniqueness: true
@@ -11,6 +13,6 @@ class ApiKey < ApplicationRecord
   # WakaTime compatibility: vscode-wakatime expects a UUID v4 token.
   def generate_token!
     self.token ||= SecureRandom.uuid_v4
-    self.name ||= "Hackatime key"
+    self.name ||= DEFAULT_NAME
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -357,7 +357,11 @@ class User < ApplicationRecord
     api_key = api_keys.find_by(name: ApiKey::DEFAULT_NAME) || api_keys.order(:id).first
     return api_key if api_key || !create_if_missing
 
-    api_keys.create!(name: ApiKey::DEFAULT_NAME)
+    with_lock do
+      api_keys.find_by(name: ApiKey::DEFAULT_NAME) ||
+        api_keys.order(:id).first ||
+        api_keys.create!(name: ApiKey::DEFAULT_NAME)
+    end
   end
 
   def rotate_api_keys!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -353,8 +353,15 @@ class User < ApplicationRecord
 
   def create_email_signin_token(continue_param: nil) = sign_in_tokens.create!(auth_type: :email, continue_param: continue_param)
 
+  def hackatime_api_key(create_if_missing: false)
+    api_key = api_keys.find_by(name: ApiKey::DEFAULT_NAME) || api_keys.order(:id).first
+    return api_key if api_key || !create_if_missing
+
+    api_keys.create!(name: ApiKey::DEFAULT_NAME)
+  end
+
   def rotate_api_keys!
-    api_keys.transaction { api_keys.destroy_all; api_keys.create!(name: "Hackatime key") }
+    api_keys.transaction { api_keys.destroy_all; api_keys.create!(name: ApiKey::DEFAULT_NAME) }
   end
 
   def rotate_single_api_key!(api_key)

--- a/test/controllers/api_key_selection_controller_test.rb
+++ b/test/controllers/api_key_selection_controller_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class ApiKeySelectionControllerTest < ActionDispatch::IntegrationTest
+  test "user-facing controllers return the same canonical key when multiple exist" do
+    user = create(:user, :with_email)
+    create(:api_key, user: user, name: "Desktop")
+    canonical_key = create(:api_key, user: user, name: "Hackatime key")
+    create(:api_key, user: user, name: "Laptop")
+    sign_in_as(user)
+
+    get api_key_path
+    api_key_page_token = inertia.props["api_key"]
+
+    get setup_path
+    setup_guide_token = inertia.props["current_user_api_key"]
+
+    get my_settings_setup_path
+    settings_token = inertia.props.dig("config_file", "api_key")
+
+    access_token = create(:oauth_access_token,
+      application: create(:oauth_application, owner: user),
+      resource_owner_id: user.id
+    )
+    get "/api/v1/authenticated/api_keys", headers: {
+      "Authorization" => "Bearer #{access_token.token}"
+    }
+    api_token = response.parsed_body["token"]
+
+    assert_equal [ canonical_key.token ] * 4,
+      [ api_key_page_token, setup_guide_token, settings_token, api_token ]
+    assert_equal 3, user.api_keys.count
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,5 +1,6 @@
 require "test_helper"
 require "webmock/minitest"
+require "timeout"
 
 WebMock.disable_net_connect!(allow_localhost: true)
 
@@ -403,5 +404,62 @@ class UserTest < ActiveSupport::TestCase
     yield
   ensure
     Rails.cache = original_cache
+  end
+end
+
+class UserApiKeyConcurrencyTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  self.use_transactional_tests = false
+
+  setup { clear_enqueued_jobs }
+  teardown { clear_enqueued_jobs }
+
+  test "concurrent first key callers resolve one canonical key" do
+    user = create(:user)
+    first_created = Queue.new
+    release_first = Queue.new
+
+    first_caller = Thread.new do
+      User.transaction do
+        api_key = User.find(user.id).hackatime_api_key(create_if_missing: true)
+        first_created << true
+        release_first.pop
+        api_key
+      end
+    end
+    first_created.pop
+
+    second_backend_pid = Queue.new
+    second_caller = Thread.new do
+      ActiveRecord::Base.connection_pool.with_connection do |connection|
+        second_backend_pid << connection.select_value("SELECT pg_backend_pid()")
+        User.find(user.id).hackatime_api_key(create_if_missing: true)
+      end
+    end
+    backend_pid = second_backend_pid.pop
+    Timeout.timeout(5) do
+      loop do
+        wait_event_type = ActiveRecord::Base.connection.select_value(<<~SQL.squish)
+          SELECT wait_event_type FROM pg_stat_activity WHERE pid = #{Integer(backend_pid)}
+        SQL
+        break if wait_event_type == "Lock"
+        sleep 0.01
+      end
+    end
+    release_first << true
+
+    resolved_keys = [ first_caller.value, second_caller.value ]
+    persisted_key = ApiKey.find_by!(user: user)
+
+    assert_equal 1, ApiKey.where(user: user).count
+    assert_equal [ persisted_key.id ], resolved_keys.map(&:id).uniq
+  ensure
+    release_first << true if defined?(release_first)
+    first_caller&.join(5)
+    second_caller&.join(5)
+    ApiKey.where(user_id: user&.id).delete_all
+    Mailkick::Subscription.where(subscriber: user).delete_all if user
+    User.where(id: user&.id).delete_all
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -79,6 +79,37 @@ class UserTest < ActiveSupport::TestCase
     assert_equal [ new_api_key.id ], user.api_keys.reload.pluck(:id)
   end
 
+  test "hackatime_api_key prefers the default named key without removing extra keys" do
+    user = create(:user)
+    create(:api_key, user: user, name: "Desktop")
+    default_key = create(:api_key, user: user, name: "Hackatime key")
+    create(:api_key, user: user, name: "Laptop")
+
+    assert_equal default_key, user.hackatime_api_key
+    assert_equal 3, user.api_keys.count
+  end
+
+  test "hackatime_api_key falls back to the lowest id without creating another key" do
+    user = create(:user)
+    oldest_key = create(:api_key, user: user, name: "Desktop")
+    create(:api_key, user: user, name: "Laptop")
+
+    assert_equal oldest_key, user.hackatime_api_key(create_if_missing: true)
+    assert_equal 2, user.api_keys.count
+  end
+
+  test "hackatime_api_key creates the default key only when requested" do
+    user = create(:user)
+
+    assert_nil user.hackatime_api_key
+    assert_equal 0, user.api_keys.count
+
+    api_key = user.hackatime_api_key(create_if_missing: true)
+
+    assert_equal "Hackatime key", api_key.name
+    assert_equal [ api_key.id ], user.api_keys.reload.pluck(:id)
+  end
+
   test "flipper id uses the user id" do
     user = create(:user)
 

--- a/test/system/settings/setup_settings_test.rb
+++ b/test/system/settings/setup_settings_test.rb
@@ -19,4 +19,13 @@ class SetupSettingsTest < ApplicationSystemTestCase
 
     assert_text "WakaTime Config File"
   end
+
+  test "setup settings preserves the no-key message without creating a key" do
+    @user.api_keys.destroy_all
+
+    visit my_settings_setup_path
+
+    assert_text "No API key is available yet. Rotate your API key from Privacy & Security to generate one."
+    assert_equal 0, @user.api_keys.count
+  end
 end

--- a/test/system/setup_test.rb
+++ b/test/system/setup_test.rb
@@ -59,4 +59,22 @@ class SetupTest < ApplicationSystemTestCase
     click_on "I'm done!"
     assert_text "Fair Play Policy"
   end
+
+  test "API key surfaces show the same canonical key when multiple exist" do
+    create(:api_key, user: @user, name: "Desktop")
+    canonical_key = create(:api_key, user: @user, name: "Hackatime key")
+    create(:api_key, user: @user, name: "Laptop")
+
+    visit api_key_path
+    assert_field with: canonical_key.token
+
+    visit setup_path
+    click_on "Yes, I have an editor installed"
+    click_on "Terminal (automatic)"
+    assert_text canonical_key.token
+
+    visit my_settings_setup_path
+    assert_text canonical_key.token
+    assert_equal 3, @user.api_keys.count
+  end
 end


### PR DESCRIPTION
## Summary of the problem

Users with more than one API key could see different tokens on the API key page, setup guide, settings config and OAuth endpoint because each surface chose the first or last key independently. Concurrent first-key requests could also race and return a server error.

## Describe your changes

Centralises key selection on the user model. It prefers an existing `Hackatime key`, then the lowest key ID, creating the default only when a surface requires a key and none exists. Lazy creation rechecks under a user row lock so concurrent callers resolve the same key. Settings keeps its no-key state and extra named keys remain intact.

## Screenshots / Media

Not applicable. There are no visual changes.