### PR TITLE
Re-home admin user utility actions

### DIFF
--- a/app/controllers/api/admin/v1/admin_controller.rb
+++ b/app/controllers/api/admin/v1/admin_controller.rb
@@ -2,7 +2,7 @@ module Api
   module Admin
     module V1
       class AdminController < Api::Admin::V1::ApplicationController
-        include Api::Admin::V1::UserUtilities
+        include DateParsing
 
         def check
           u = current_user

--- a/app/controllers/api/admin/v1/application_controller.rb
+++ b/app/controllers/api/admin/v1/application_controller.rb
@@ -2,7 +2,15 @@ module Api
   module Admin
     module V1
       class ApplicationController < Api::Admin::ApplicationController
-        # todo, add shit here or something
+        private
+
+        def find_user_by_id
+          user_id = params[:id] || params[:user_id]
+          return render_error("who?") if user_id.blank?
+          User.find(user_id)
+        rescue ActiveRecord::RecordNotFound
+          render_not_found_json("user not found")
+        end
       end
     end
   end

--- a/app/controllers/api/admin/v1/heartbeats_controller.rb
+++ b/app/controllers/api/admin/v1/heartbeats_controller.rb
@@ -2,8 +2,25 @@ module Api
   module Admin
     module V1
       class HeartbeatsController < Api::Admin::V1::ApplicationController
+        include DateParsing
+
         MAX_LIMIT = 10_000
         DEFAULT_LIMIT = 1_000
+        HEARTBEAT_RESPONSE_COLUMNS = [
+          *%i[id time created_at lineno cursorpos is_write project language entity branch category dependencies editor machine operating_system type project_root_count user_agent line_additions line_deletions ip_address lines source_type],
+          :ja4_id
+        ].freeze
+        HEARTBEAT_FIELD_COLUMNS = {
+          "projects" => "project",
+          "languages" => "language",
+          "entities" => "entity",
+          "branches" => "branch",
+          "categories" => "category",
+          "editors" => "editor",
+          "machines" => "machine",
+          "user_agents" => "user_agent",
+          "ips" => "ip_address"
+        }.freeze
 
         def ip_machine_pairs
           lookback_days = (params[:lookback_days] || 30).to_i.clamp(1, 365)
@@ -87,6 +104,104 @@ module Api
           )
 
           render json: { machines: result.to_a }
+        end
+
+        def get_users_by_ip
+          return render_error("bro dont got the ip") if params[:ip].blank?
+
+          result = Heartbeat.where(ip_address: params[:ip]).select(:ip_address, :user_id, :machine, :user_agent).distinct
+          render json: {
+            users: result.map { |u|
+              {
+                user_id: u.user_id,
+                ip_address: u.ip_address,
+                machine: u.machine,
+                user_agent: u.user_agent
+              }
+            }
+          }
+        end
+
+        def get_users_by_machine
+          return render_error("bro dont got the machine") if params[:machine].blank?
+
+          result = Heartbeat.where(machine: params[:machine]).select(:user_id, :machine).distinct
+          render json: { users: result.map { |u| { user_id: u.user_id, machine: u.machine } } }
+        end
+
+        def user_heartbeats
+          user = find_user_by_id
+          return unless user
+
+          limit = (params[:limit] || 1000).to_i.clamp(1, 5_000)
+          offset = (params[:offset] || 0).to_i.clamp(0, Float::INFINITY)
+
+          query = user.heartbeats
+          query = apply_time_range(query) or return
+          %i[project language entity editor machine].each do |f|
+            query = query.where(f => params[f]) if params[f].present?
+          end
+
+          total_count = query.count
+          source_types = Heartbeat.source_types.invert
+          rows = query.order(time: :asc, id: :asc).limit(limit).offset(offset).pluck(*HEARTBEAT_RESPONSE_COLUMNS)
+          ja4s_by_id = Ja4.where(id: rows.filter_map(&:last).uniq).index_by(&:id)
+          heartbeats = rows.map do |id, time, created_at, lineno, cursorpos, is_write, project, language, entity, branch, category, dependencies, editor, machine, operating_system, type, project_root_count, user_agent, line_additions, line_deletions, ip_address, lines, source_type, ja4_id|
+            {
+              id: id,
+              time: time,
+              created_at: created_at,
+              project: project,
+              branch: branch,
+              category: category,
+              dependencies: dependencies,
+              editor: editor,
+              entity: entity,
+              language: language,
+              machine: machine,
+              operating_system: operating_system,
+              type: type,
+              user_agent: user_agent,
+              line_additions: line_additions,
+              line_deletions: line_deletions,
+              lineno: lineno,
+              lines: lines,
+              cursorpos: cursorpos,
+              project_root_count: project_root_count,
+              is_write: is_write,
+              source_type: source_types[source_type] || source_type,
+              ip_address: ip_address,
+              ja4: ja4s_by_id[ja4_id]&.then { |ja4| { fingerprint: ja4.fingerprint, name: ja4.name } }
+            }
+          end
+
+          render json: {
+            user_id: user.id,
+            heartbeats: heartbeats,
+            total_count: total_count,
+            has_more: (offset + limit) < total_count
+          }
+        end
+
+        def user_heartbeat_values
+          user = find_user_by_id
+          return unless user
+
+          field = params[:field]
+          column_name = HEARTBEAT_FIELD_COLUMNS[field]
+          return render_error("invalid field") unless column_name
+
+          limit = (params[:limit] || 5000).to_i.clamp(1, 5000)
+
+          query = user.heartbeats
+          query = apply_time_range(query) or return
+
+          quoted_column = Heartbeat.connection.quote_column_name(column_name)
+          values = query.where.not(column_name => nil).distinct
+                        .order(Arel.sql("#{quoted_column} ASC"))
+                        .limit(limit).pluck(column_name).reject(&:empty?)
+
+          render json: { user_id: user.id, field: field, values: values, count: values.count }
         end
 
         private

--- a/app/controllers/api/admin/v1/permissions_controller.rb
+++ b/app/controllers/api/admin/v1/permissions_controller.rb
@@ -4,7 +4,8 @@ module Api
       class PermissionsController < Api::Admin::V1::ApplicationController
         include AdminLevelChangeMessages
 
-        before_action :require_superadmin
+        before_action :require_superadmin, only: [ :index, :update ]
+        before_action :can_write!, only: [ :user_convict ]
 
         def index
           users = User.where.not(admin_level: :default).order(admin_level: :asc, username: :asc)
@@ -55,6 +56,46 @@ module Api
           end
         rescue ActiveRecord::RecordNotFound
           render_not_found_json("User not found")
+        end
+
+        def user_convict
+          user = find_user_by_id
+          return unless user
+
+          trust_level = params[:trust_level]
+          reason = params[:reason]
+          notes = params[:notes]
+
+          return render_error("you cant punish a mortal and not justify your actions") if reason.blank?
+          return render_error("read the docs you idiot") unless User.trust_levels.key?(trust_level)
+          return render_error("no perms lmaooo", status: :forbidden) unless current_user.can_change_trust_of?(user, trust_level)
+
+          success = user.set_trust(trust_level, changed_by_user: current_user, reason: reason, notes: notes)
+
+          return render_error("no perms lmaooo") unless success
+
+          render json: {
+            success: true,
+            message: "gotcha, updated to #{trust_level}",
+            user: {
+              id: user.id,
+              username: user.display_name,
+              trust_level: user.trust_level,
+              updated_at: user.updated_at
+            },
+            audit_log: {
+              changed_by: current_user.display_name,
+              reason: reason,
+              notes: notes,
+              timestamp: Time.current
+            }
+          }
+        end
+
+        private
+
+        def can_write!
+          render_forbidden("no perms lmaooo") unless current_user.admin_level.in?(AuthHelpers::ADMIN_LEVELS)
         end
       end
     end

--- a/app/controllers/api/admin/v1/trust_level_audit_logs_controller.rb
+++ b/app/controllers/api/admin/v1/trust_level_audit_logs_controller.rb
@@ -49,6 +49,31 @@ module Api
           render_not_found_json("Audit log not found")
         end
 
+        def trust_logs
+          user = find_user_by_id
+          return unless user
+
+          logs = TrustLevelAuditLog.for_user(user).recent.limit(25)
+          render json: {
+            trust_logs: logs.map { |log|
+              {
+                id: log.id,
+                previous_trust_level: log.previous_trust_level,
+                new_trust_level: log.new_trust_level,
+                changed_by: {
+                  id: log.changed_by.id,
+                  username: log.changed_by.username,
+                  display_name: log.changed_by.display_name,
+                  admin_level: log.changed_by.admin_level
+                },
+                reason: log.reason,
+                notes: log.notes,
+                created_at: log.created_at
+              }
+            }
+          }
+        end
+
         private
 
         def audit_log_json(log, full: false)

--- a/app/controllers/api/admin/v1/users_controller.rb
+++ b/app/controllers/api/admin/v1/users_controller.rb
@@ -1,30 +1,8 @@
 module Api
   module Admin
     module V1
-      module UserUtilities
-        extend ActiveSupport::Concern
+      class UsersController < Api::Admin::V1::ApplicationController
         include DateParsing
-
-        HEARTBEAT_RESPONSE_COLUMNS = [
-          *%i[id time created_at lineno cursorpos is_write project language entity branch category dependencies editor machine operating_system type project_root_count user_agent line_additions line_deletions ip_address lines source_type],
-          :ja4_id
-        ].freeze
-
-        HEARTBEAT_FIELD_COLUMNS = {
-          "projects" => "project",
-          "languages" => "language",
-          "entities" => "entity",
-          "branches" => "branch",
-          "categories" => "category",
-          "editors" => "editor",
-          "machines" => "machine",
-          "user_agents" => "user_agent",
-          "ips" => "ip_address"
-        }.freeze
-
-        included do
-          before_action :can_write!, only: [ :user_convict ]
-        end
 
         def get_user_by_email
           return render_error("bro dont have a email") if params[:email].blank?
@@ -54,29 +32,6 @@ module Api
               }
             }
           }
-        end
-
-        def get_users_by_ip
-          return render_error("bro dont got the ip") if params[:ip].blank?
-
-          result = Heartbeat.where(ip_address: params[:ip]).select(:ip_address, :user_id, :machine, :user_agent).distinct
-          render json: {
-            users: result.map { |u|
-              {
-                user_id: u.user_id,
-                ip_address: u.ip_address,
-                machine: u.machine,
-                user_agent: u.user_agent
-              }
-            }
-          }
-        end
-
-        def get_users_by_machine
-          return render_error("bro dont got the machine") if params[:machine].blank?
-
-          result = Heartbeat.where(machine: params[:machine]).select(:user_id, :machine).distinct
-          render json: { users: result.map { |u| { user_id: u.user_id, machine: u.machine } } }
         end
 
         def user_info
@@ -217,65 +172,6 @@ module Api
           }
         end
 
-        def user_convict
-          user = find_user_by_id
-          return unless user
-
-          trust_level = params[:trust_level]
-          reason = params[:reason]
-          notes = params[:notes]
-
-          return render_error("you cant punish a mortal and not justify your actions") if reason.blank?
-          return render_error("read the docs you idiot") unless User.trust_levels.key?(trust_level)
-          return render_error("no perms lmaooo", status: :forbidden) unless current_user.can_change_trust_of?(user, trust_level)
-
-          success = user.set_trust(trust_level, changed_by_user: current_user, reason: reason, notes: notes)
-
-          return render_error("no perms lmaooo") unless success
-
-          render json: {
-            success: true,
-            message: "gotcha, updated to #{trust_level}",
-            user: {
-              id: user.id,
-              username: user.display_name,
-              trust_level: user.trust_level,
-              updated_at: user.updated_at
-            },
-            audit_log: {
-              changed_by: current_user.display_name,
-              reason: reason,
-              notes: notes,
-              timestamp: Time.current
-            }
-          }
-        end
-
-        def trust_logs
-          user = find_user_by_id
-          return unless user
-
-          logs = TrustLevelAuditLog.for_user(user).recent.limit(25)
-          render json: {
-            trust_logs: logs.map { |log|
-              {
-                id: log.id,
-                previous_trust_level: log.previous_trust_level,
-                new_trust_level: log.new_trust_level,
-                changed_by: {
-                  id: log.changed_by.id,
-                  username: log.changed_by.username,
-                  display_name: log.changed_by.display_name,
-                  admin_level: log.changed_by.admin_level
-                },
-                reason: log.reason,
-                notes: log.notes,
-                created_at: log.created_at
-              }
-            }
-          }
-        end
-
         def user_info_batch
           return render_error("ids parameter required") if params[:ids].blank?
 
@@ -289,95 +185,6 @@ module Api
               methods: %i[display_name avatar_url]
             )
           }
-        end
-
-        def user_heartbeats
-          user = find_user_by_id
-          return unless user
-
-          limit = (params[:limit] || 1000).to_i.clamp(1, 5_000)
-          offset = (params[:offset] || 0).to_i.clamp(0, Float::INFINITY)
-
-          query = user.heartbeats
-          query = apply_time_range(query) or return
-          %i[project language entity editor machine].each do |f|
-            query = query.where(f => params[f]) if params[f].present?
-          end
-
-          total_count = query.count
-          source_types = Heartbeat.source_types.invert
-          rows = query.order(time: :asc, id: :asc).limit(limit).offset(offset).pluck(*HEARTBEAT_RESPONSE_COLUMNS)
-          ja4s_by_id = Ja4.where(id: rows.filter_map(&:last).uniq).index_by(&:id)
-          heartbeats = rows.map do |id, time, created_at, lineno, cursorpos, is_write, project, language, entity, branch, category, dependencies, editor, machine, operating_system, type, project_root_count, user_agent, line_additions, line_deletions, ip_address, lines, source_type, ja4_id|
-            {
-              id: id,
-              time: time,
-              created_at: created_at,
-              project: project,
-              branch: branch,
-              category: category,
-              dependencies: dependencies,
-              editor: editor,
-              entity: entity,
-              language: language,
-              machine: machine,
-              operating_system: operating_system,
-              type: type,
-              user_agent: user_agent,
-              line_additions: line_additions,
-              line_deletions: line_deletions,
-              lineno: lineno,
-              lines: lines,
-              cursorpos: cursorpos,
-              project_root_count: project_root_count,
-              is_write: is_write,
-              source_type: source_types[source_type] || source_type,
-              ip_address: ip_address,
-              ja4: ja4s_by_id[ja4_id]&.then { |ja4| { fingerprint: ja4.fingerprint, name: ja4.name } }
-            }
-          end
-
-          render json: {
-            user_id: user.id,
-            heartbeats: heartbeats,
-            total_count: total_count,
-            has_more: (offset + limit) < total_count
-          }
-        end
-
-        def user_heartbeat_values
-          user = find_user_by_id
-          return unless user
-
-          field = params[:field]
-          column_name = HEARTBEAT_FIELD_COLUMNS[field]
-          return render_error("invalid field") unless column_name
-
-          limit = (params[:limit] || 5000).to_i.clamp(1, 5000)
-
-          query = user.heartbeats
-          query = apply_time_range(query) or return
-
-          quoted_column = Heartbeat.connection.quote_column_name(column_name)
-          values = query.where.not(column_name => nil).distinct
-                        .order(Arel.sql("#{quoted_column} ASC"))
-                        .limit(limit).pluck(column_name).reject(&:empty?)
-
-          render json: { user_id: user.id, field: field, values: values, count: values.count }
-        end
-
-        private
-
-        def can_write!
-          render_forbidden("no perms lmaooo") unless current_user.admin_level.in?(AuthHelpers::ADMIN_LEVELS)
-        end
-
-        def find_user_by_id
-          user_id = params[:id] || params[:user_id]
-          return render_error("who?") if user_id.blank?
-          User.find(user_id)
-        rescue ActiveRecord::RecordNotFound
-          render_not_found_json("user not found")
         end
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -283,19 +283,19 @@ Rails.application.routes.draw do
     namespace :admin do
       namespace :v1 do
         get "check", to: "admin#check"
-        get "user/info", to: "admin#user_info"
-        get "user/info_batch", to: "admin#user_info_batch"
-        get "user/heartbeats", to: "admin#user_heartbeats"
-        get "user/heartbeat_values", to: "admin#user_heartbeat_values"
-        get "user/get_users_by_ip", to: "admin#get_users_by_ip"
-        get "user/get_users_by_machine", to: "admin#get_users_by_machine"
-        get "user/stats", to: "admin#user_stats"
-        get "user/projects", to: "admin#user_projects"
-        get "user/trust_logs", to: "admin#trust_logs"
+        get "user/info", to: "users#user_info"
+        get "user/info_batch", to: "users#user_info_batch"
+        get "user/heartbeats", to: "heartbeats#user_heartbeats"
+        get "user/heartbeat_values", to: "heartbeats#user_heartbeat_values"
+        get "user/get_users_by_ip", to: "heartbeats#get_users_by_ip"
+        get "user/get_users_by_machine", to: "heartbeats#get_users_by_machine"
+        get "user/stats", to: "users#user_stats"
+        get "user/projects", to: "users#user_projects"
+        get "user/trust_logs", to: "trust_level_audit_logs#trust_logs"
         get "banned_users", to: "admin#banned_users"
-        post "user/get_user_by_email", to: "admin#get_user_by_email"
-        post "user/search_fuzzy", to: "admin#search_users_fuzzy"
-        post "user/convict", to: "admin#user_convict"
+        post "user/get_user_by_email", to: "users#get_user_by_email"
+        post "user/search_fuzzy", to: "users#search_users_fuzzy"
+        post "user/convict", to: "permissions#user_convict"
 
         # Admin API Keys management
         resources :admin_api_keys, only: [ :index, :show, :create, :destroy ]

--- a/spec/requests/api/admin/v1/admin_url_contracts_spec.rb
+++ b/spec/requests/api/admin/v1/admin_url_contracts_spec.rb
@@ -1,6 +1,6 @@
 require 'swagger_helper'
 
-RSpec.describe 'Api::Admin::V1::UserUtils', type: :request, openapi_spec: 'admin/swagger.yaml' do
+RSpec.describe 'Api::Admin::V1::AdminUrlContracts', type: :request, openapi_spec: 'admin/swagger.yaml' do
   path '/api/admin/v1/user/info_batch' do
     get('Get user info batch') do
       tags 'Admin Utils'

--- a/test/controllers/api/admin/v1/heartbeats_controller_test.rb
+++ b/test/controllers/api/admin/v1/heartbeats_controller_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class Api::Admin::V1::AdminControllerTest < ActionDispatch::IntegrationTest
+class Api::Admin::V1::HeartbeatsControllerTest < ActionDispatch::IntegrationTest
   test "user heartbeats returns ja4 fingerprint and name" do
     admin = create(:user, :superadmin)
     key = create(:admin_api_key, user: admin, name: "test")

--- a/test/controllers/api/admin/v1/route_ownership_test.rb
+++ b/test/controllers/api/admin/v1/route_ownership_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+
+class Api::Admin::V1::RouteOwnershipTest < ActionDispatch::IntegrationTest
+  test "legacy user utility paths dispatch to resource controllers" do
+    assert_route :get, "/api/admin/v1/user/info", "users", "user_info"
+    assert_route :get, "/api/admin/v1/user/info_batch", "users", "user_info_batch"
+    assert_route :get, "/api/admin/v1/user/stats", "users", "user_stats"
+    assert_route :get, "/api/admin/v1/user/projects", "users", "user_projects"
+    assert_route :post, "/api/admin/v1/user/get_user_by_email", "users", "get_user_by_email"
+    assert_route :post, "/api/admin/v1/user/search_fuzzy", "users", "search_users_fuzzy"
+
+    assert_route :get, "/api/admin/v1/user/heartbeats", "heartbeats", "user_heartbeats"
+    assert_route :get, "/api/admin/v1/user/heartbeat_values", "heartbeats", "user_heartbeat_values"
+    assert_route :get, "/api/admin/v1/user/get_users_by_ip", "heartbeats", "get_users_by_ip"
+    assert_route :get, "/api/admin/v1/user/get_users_by_machine", "heartbeats", "get_users_by_machine"
+
+    assert_route :post, "/api/admin/v1/user/convict", "permissions", "user_convict"
+    assert_route :get, "/api/admin/v1/user/trust_logs", "trust_level_audit_logs", "trust_logs"
+  end
+
+  private
+
+  def assert_route(method, path, controller, action)
+    route = Rails.application.routes.recognize_path(path, method: method)
+    assert_equal({ controller: "api/admin/v1/#{controller}", action: action }, route.slice(:controller, :action))
+  end
+end


### PR DESCRIPTION
## Summary of the problem

`Api::Admin::V1::UserUtilities` mixes unrelated user, heartbeat and trust administration actions into `AdminController`. This obscures resource ownership and leaves a large controller concern acting as an action container.

## Describe your changes

- Route the existing `/api/admin/v1/user/...` URLs to `UsersController`, `HeartbeatsController`, `PermissionsController` and `TrustLevelAuditLogsController` without changing public contracts.
- Keep shared user lookup private on the V1 base controller and preserve current authentication and write checks.
- Remove the concern and protect dispatch ownership with routing coverage.

## Screenshots / Media

Not applicable. There are no visual changes.
