### PR TITLE
Centralise the Inertia layout declaration

### DIFF
--- a/app/controllers/admin/account_merger_controller.rb
+++ b/app/controllers/admin/account_merger_controller.rb
@@ -1,6 +1,4 @@
 class Admin::AccountMergerController < InertiaController
-  layout "inertia"
-
   before_action :require_ultraadmin!
 
   def show = render(inertia: "Admin/AccountMerger")

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,8 +1,6 @@
 class Admin::BaseController < InertiaController
   ADMIN_NAV_LEVELS = %w[admin superadmin viewer ultraadmin].freeze
 
-  layout "inertia"
-
   before_action :authenticate_admin!
 
   private

--- a/app/controllers/admin/leaderboard_shadowbans_controller.rb
+++ b/app/controllers/admin/leaderboard_shadowbans_controller.rb
@@ -1,6 +1,4 @@
 class Admin::LeaderboardShadowbansController < InertiaController
-  layout "inertia"
-
   before_action :require_shadowban_admin!
 
   def index

--- a/app/controllers/api_keys_controller.rb
+++ b/app/controllers/api_keys_controller.rb
@@ -1,6 +1,4 @@
 class ApiKeysController < InertiaController
-  layout "inertia", only: [ :show ]
-
   before_action :authenticate_user!
 
   def show

--- a/app/controllers/deletion_requests_controller.rb
+++ b/app/controllers/deletion_requests_controller.rb
@@ -1,6 +1,4 @@
 class DeletionRequestsController < InertiaController
-  layout "inertia", only: [ :show ]
-
   before_action :require_login
   before_action :check_can_request, only: [ :create ]
 

--- a/app/controllers/doorkeeper/applications_controller.rb
+++ b/app/controllers/doorkeeper/applications_controller.rb
@@ -2,8 +2,6 @@
 
 module Doorkeeper
   class ApplicationsController < InertiaController
-    layout "inertia"
-
     before_action :authenticate_oauth_owner!
     before_action :set_application, only: %i[show edit update destroy rotate_secret]
 

--- a/app/controllers/extensions_controller.rb
+++ b/app/controllers/extensions_controller.rb
@@ -1,6 +1,4 @@
 class ExtensionsController < InertiaController
-  layout "inertia"
-
   def index
     render inertia: "Extensions/Index"
   end

--- a/app/controllers/inertia_controller.rb
+++ b/app/controllers/inertia_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class InertiaController < ApplicationController
+  layout "inertia"
+
   inertia_share layout: -> { inertia_layout_props }
 
   private

--- a/app/controllers/leaderboards_controller.rb
+++ b/app/controllers/leaderboards_controller.rb
@@ -1,6 +1,4 @@
 class LeaderboardsController < InertiaController
-  layout "inertia"
-
   def index
     period_type = validated_period_type
     country = load_country_context

--- a/app/controllers/my/project_repo_mappings_controller.rb
+++ b/app/controllers/my/project_repo_mappings_controller.rb
@@ -1,6 +1,4 @@
 class My::ProjectRepoMappingsController < InertiaController
-  layout "inertia", only: [ :index, :show ]
-
   before_action :ensure_current_user
   before_action :require_github_oauth, only: [ :update ]
   before_action :set_project_repo_mapping_for_edit, only: [ :update ]

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,6 +1,4 @@
 class ProfilesController < InertiaController
-  layout "inertia"
-
   before_action :find_user
 
   SOCIAL_LINKS = [

--- a/app/controllers/settings/base_controller.rb
+++ b/app/controllers/settings/base_controller.rb
@@ -1,6 +1,4 @@
 class Settings::BaseController < InertiaController
-  layout "inertia"
-
   before_action :set_user
 
   def show = render_settings_page

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,8 +1,6 @@
 class StaticPagesController < InertiaController
   include DashboardData
 
-  layout "inertia", only: %i[index wakatime_alternative]
-
   def index
     if current_user
       flavor_texts = FlavorText.motto + FlavorText.conditional_mottos(current_user)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,8 +1,6 @@
 class UsersController < InertiaController
   SETUP_THEME = "rose_pine_dawn".freeze
 
-  layout "inertia", only: %i[setup]
-
   before_action :ensure_current_user_for_setup, only: %i[setup]
   before_action :set_setup_meta, only: %i[setup]
   before_action :require_admin, only: [ :update_trust_level ]

--- a/test/controllers/inertia_controller_test.rb
+++ b/test/controllers/inertia_controller_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+class InertiaControllerTest < ActionDispatch::IntegrationTest
+  test "pure descendants inherit the Inertia layout" do
+    get extensions_path
+
+    assert_response :success
+    assert_inertia_component "Extensions/Index"
+    assert_select "html[data-theme]"
+    assert_select "[data-page]"
+  end
+
+  test "mixed descendants apply the layout only to Inertia responses" do
+    get signin_path
+
+    assert_response :success
+    assert_inertia_component "Auth/SignIn"
+    assert_select "html[data-theme]"
+    assert_select "[data-page]"
+
+    get currently_hacking_count_static_pages_path
+
+    assert_response :success
+    assert_equal "application/json", response.media_type
+    assert response.parsed_body.key?("count")
+    assert_not response.body.start_with?("<!DOCTYPE html>")
+  end
+end


### PR DESCRIPTION
## Summary of the problem

Controllers in the Inertia hierarchy repeat the same Rails layout declaration. Scoped declarations on mixed controllers make ownership less clear even though non-rendering actions do not apply layouts.

## Describe your changes

Declare the layout once in `InertiaController` and remove inherited duplicates. Keep declarations on controllers outside the hierarchy. Add request coverage for a pure descendant and a mixed descendant's Inertia and JSON responses.

## Screenshots / Media

Not applicable. No visual changes.