### PR TITLE
Extract account merge transaction into a service

### DIFF
--- a/app/controllers/admin/account_merger_controller.rb
+++ b/app/controllers/admin/account_merger_controller.rb
@@ -35,20 +35,31 @@ class Admin::AccountMergerController < InertiaController
       return merge_error("The NEWER user (right side) must have been created after the OLDER user (left side). #{newer_user.display_name} was created #{newer_user.created_at.to_date} which is before #{older_user.display_name} created #{older_user.created_at.to_date}.")
     end
 
-    merge_results = AccountMergeService.call(older_user:, newer_user:)
+    begin
+      merge_results = AccountMergeService.call(older_user:, newer_user:)
+    rescue AccountMergeService::MergeError => error
+      report_merge_failure(error, older_user:, newer_user:)
+      return merge_error("Merge failed and was rolled back. Check the application logs for details.")
+    rescue StandardError => error
+      report_merge_failure(error, older_user:, newer_user:)
+      raise
+    end
+
     redirect_to admin_account_merger_path, notice: "Merge complete! #{merge_results}"
-  rescue StandardError => e
-    report_error(
-      e,
-      message: "Account merge failed and was rolled back for older user ##{older_id} and newer user ##{newer_id}: #{e.class}: #{e.message}",
-      extra: { older_user_id: older_id, newer_user_id: newer_id }
-    )
-    redirect_to admin_account_merger_path, alert: "Merge failed and was rolled back. Check the application logs for details."
   end
 
   private
 
   def merge_error(message) = redirect_to(admin_account_merger_path, alert: message)
+
+  def report_merge_failure(exception, older_user:, newer_user:)
+    diagnostic = exception.cause || exception
+    report_error(
+      exception,
+      message: "Account merge failed and was rolled back for older user ##{older_user.id} and newer user ##{newer_user.id}: #{diagnostic.class}: #{diagnostic.message}",
+      extra: { older_user_id: older_user.id, newer_user_id: newer_user.id }
+    )
+  end
 
   def format_user(user)
     {

--- a/app/controllers/admin/account_merger_controller.rb
+++ b/app/controllers/admin/account_merger_controller.rb
@@ -35,11 +35,15 @@ class Admin::AccountMergerController < InertiaController
       return merge_error("The NEWER user (right side) must have been created after the OLDER user (left side). #{newer_user.display_name} was created #{newer_user.created_at.to_date} which is before #{older_user.display_name} created #{older_user.created_at.to_date}.")
     end
 
-    merge_results = perform_merge(older_user, newer_user)
+    merge_results = AccountMergeService.call(older_user:, newer_user:)
     redirect_to admin_account_merger_path, notice: "Merge complete! #{merge_results}"
-  rescue => e
-    Rails.logger.error("Account merge failed and was rolled back: #{e.message}")
-    redirect_to admin_account_merger_path, alert: "Merge failed and was rolled back: #{e.message}"
+  rescue StandardError => e
+    report_error(
+      e,
+      message: "Account merge failed and was rolled back for older user ##{older_id} and newer user ##{newer_id}: #{e.class}: #{e.message}",
+      extra: { older_user_id: older_id, newer_user_id: newer_id }
+    )
+    redirect_to admin_account_merger_path, alert: "Merge failed and was rolled back. Check the application logs for details."
   end
 
   private
@@ -55,108 +59,5 @@ class Admin::AccountMergerController < InertiaController
       username: user.username,
       email: user.email_addresses.first&.email
     }
-  end
-
-  def perform_merge(older_user, newer_user)
-    results = []
-
-    ActiveRecord::Base.transaction do
-      # 1. Move heartbeats from newer to older
-      results << "#{Heartbeat.where(user_id: newer_user.id).update_all(user_id: older_user.id)} heartbeats moved"
-
-      # 2. Transfer API keys from newer to older
-      results << "#{transfer_api_keys(older_user:, newer_user:)} API keys transferred"
-
-      # 3. Transfer goals from newer to older
-      results << "#{newer_user.goals.update_all(user_id: older_user.id)} goals transferred"
-
-      # 4. Reconcile instance import sources before deleting the newer user.
-      deleted_records = reconcile_instance_import_source(older_user:, newer_user:)
-
-      # 5. Revoke newer user's sessions
-      revoked_tokens = newer_user.sign_in_tokens.destroy_all.count
-      revoked_tokens += Doorkeeper::AccessToken.where(resource_owner_id: newer_user.id).update_all(revoked_at: Time.current)
-      revoked_tokens += Doorkeeper::AccessGrant.where(resource_owner_id: newer_user.id).update_all(revoked_at: Time.current)
-      results << "#{revoked_tokens} sessions/tokens revoked"
-
-      # 6. Delete all related data for the newer user
-      deleted_records += newer_user.email_addresses.destroy_all.count
-      deleted_records += newer_user.email_verification_requests.destroy_all.count
-      deleted_records += newer_user.goals.destroy_all.count
-      deleted_records += newer_user.admin_api_keys.destroy_all.count
-      deleted_records += ProjectRepoMapping.where(user_id: newer_user.id).delete_all
-      deleted_records += newer_user.heartbeat_import_runs.destroy_all.count
-      deleted_records += delete_rows("heartbeat_import_sources", user_id: newer_user.id)
-      deleted_records += delete_rows("wakatime_mirrors", user_id: newer_user.id)
-      deleted_records += Commit.where(user_id: newer_user.id).delete_all
-      deleted_records += RepoHostEvent.where(user_id: newer_user.id).delete_all
-      deleted_records += TrustLevelAuditLog.where(user_id: newer_user.id).delete_all
-      deleted_records += TrustLevelAuditLog.where(changed_by_id: newer_user.id).delete_all
-      deleted_records += DeletionRequest.where(user_id: newer_user.id).delete_all
-      deleted_records += LeaderboardEntry.where(user_id: newer_user.id).delete_all
-      deleted_records += Doorkeeper::Application.where(owner_id: newer_user.id, owner_type: "User").destroy_all.count
-      Doorkeeper::AccessToken.where(resource_owner_id: newer_user.id).delete_all
-      Doorkeeper::AccessGrant.where(resource_owner_id: newer_user.id).delete_all
-      deleted_records += delete_rows("project_labels", user_id: newer_user.id.to_s)
-      deleted_records += PaperTrail::Version.where(item_type: "User", item_id: newer_user.id).delete_all
-      results << "#{deleted_records} related records cleaned up"
-
-      # 7. Finally, delete the newer user
-      newer_user.reload
-      newer_user.destroy!
-      results << "user ##{newer_user.id} deleted"
-    end
-
-    results.join(", ")
-  end
-
-  DELETABLE_TABLES = %w[heartbeat_import_sources wakatime_mirrors project_labels].freeze
-
-  def transfer_api_keys(older_user:, newer_user:)
-    transferred_count = 0
-    reserved_names = older_user.api_keys.pluck(:name).index_with(true)
-
-    ApiKey.where(user_id: newer_user.id).find_each do |api_key|
-      api_key.update!(user: older_user, name: unique_api_key_name_for(reserved_names, api_key.name))
-      transferred_count += 1
-    end
-
-    transferred_count
-  end
-
-  def unique_api_key_name_for(reserved_names, original_name)
-    unless reserved_names[original_name]
-      reserved_names[original_name] = true
-      return original_name
-    end
-
-    suffix = " (transferred)"
-    candidate_name = "#{original_name}#{suffix}"
-    counter = 2
-    while reserved_names[candidate_name]
-      candidate_name = "#{original_name}#{suffix} #{counter}"
-      counter += 1
-    end
-
-    reserved_names[candidate_name] = true
-    candidate_name
-  end
-
-  def reconcile_instance_import_source(older_user:, newer_user:)
-    newer_source = InstanceImportSource.find_by(user_id: newer_user.id)
-    return 0 unless newer_source
-    if InstanceImportSource.exists?(user_id: older_user.id)
-      newer_source.destroy!; 1
-    else
-      newer_source.update!(user_id: older_user.id); 0
-    end
-  end
-
-  def delete_rows(table_name, conditions)
-    raise ArgumentError, "Table '#{table_name}' is not in the allowlist" unless DELETABLE_TABLES.include?(table_name)
-
-    quoted = ActiveRecord::Base.connection.quote_table_name(table_name)
-    sql = ActiveRecord::Base.sanitize_sql_array([ "DELETE FROM #{quoted} WHERE user_id = ?", conditions.fetch(:user_id) ])
-    ActiveRecord::Base.connection.delete(sql)
   end
 end

--- a/app/services/account_merge_service.rb
+++ b/app/services/account_merge_service.rb
@@ -1,0 +1,106 @@
+class AccountMergeService < ApplicationService
+  DELETABLE_TABLES = %w[heartbeat_import_sources wakatime_mirrors project_labels].freeze
+
+  def self.call(older_user:, newer_user:) = new(older_user:, newer_user:).call
+
+  def initialize(older_user:, newer_user:)
+    @older_user = older_user
+    @newer_user = newer_user
+  end
+
+  def call
+    results = []
+
+    ActiveRecord::Base.transaction do
+      results << "#{Heartbeat.where(user_id: newer_user.id).update_all(user_id: older_user.id)} heartbeats moved"
+      results << "#{transfer_api_keys} API keys transferred"
+      results << "#{newer_user.goals.update_all(user_id: older_user.id)} goals transferred"
+
+      deleted_records = reconcile_instance_import_source
+
+      revoked_tokens = newer_user.sign_in_tokens.destroy_all.count
+      revoked_tokens += Doorkeeper::AccessToken.where(resource_owner_id: newer_user.id).update_all(revoked_at: Time.current)
+      revoked_tokens += Doorkeeper::AccessGrant.where(resource_owner_id: newer_user.id).update_all(revoked_at: Time.current)
+      results << "#{revoked_tokens} sessions/tokens revoked"
+
+      deleted_records += newer_user.email_addresses.destroy_all.count
+      deleted_records += newer_user.email_verification_requests.destroy_all.count
+      deleted_records += newer_user.goals.destroy_all.count
+      deleted_records += newer_user.admin_api_keys.destroy_all.count
+      deleted_records += ProjectRepoMapping.where(user_id: newer_user.id).delete_all
+      deleted_records += newer_user.heartbeat_import_runs.destroy_all.count
+      deleted_records += delete_rows("heartbeat_import_sources", user_id: newer_user.id)
+      deleted_records += delete_rows("wakatime_mirrors", user_id: newer_user.id)
+      deleted_records += Commit.where(user_id: newer_user.id).delete_all
+      deleted_records += RepoHostEvent.where(user_id: newer_user.id).delete_all
+      deleted_records += TrustLevelAuditLog.where(user_id: newer_user.id).delete_all
+      deleted_records += TrustLevelAuditLog.where(changed_by_id: newer_user.id).delete_all
+      deleted_records += DeletionRequest.where(user_id: newer_user.id).delete_all
+      deleted_records += LeaderboardEntry.where(user_id: newer_user.id).delete_all
+      deleted_records += Doorkeeper::Application.where(owner_id: newer_user.id, owner_type: "User").destroy_all.count
+      Doorkeeper::AccessToken.where(resource_owner_id: newer_user.id).delete_all
+      Doorkeeper::AccessGrant.where(resource_owner_id: newer_user.id).delete_all
+      deleted_records += delete_rows("project_labels", user_id: newer_user.id.to_s)
+      deleted_records += PaperTrail::Version.where(item_type: "User", item_id: newer_user.id).delete_all
+      results << "#{deleted_records} related records cleaned up"
+
+      newer_user.reload
+      newer_user.destroy!
+      results << "user ##{newer_user.id} deleted"
+    end
+
+    results.join(", ")
+  end
+
+  private
+
+  attr_reader :older_user, :newer_user
+
+  def transfer_api_keys
+    transferred_count = 0
+    reserved_names = older_user.api_keys.pluck(:name).index_with(true)
+
+    ApiKey.where(user_id: newer_user.id).find_each do |api_key|
+      api_key.update!(user: older_user, name: unique_api_key_name_for(reserved_names, api_key.name))
+      transferred_count += 1
+    end
+
+    transferred_count
+  end
+
+  def unique_api_key_name_for(reserved_names, original_name)
+    unless reserved_names[original_name]
+      reserved_names[original_name] = true
+      return original_name
+    end
+
+    suffix = " (transferred)"
+    candidate_name = "#{original_name}#{suffix}"
+    counter = 2
+    while reserved_names[candidate_name]
+      candidate_name = "#{original_name}#{suffix} #{counter}"
+      counter += 1
+    end
+
+    reserved_names[candidate_name] = true
+    candidate_name
+  end
+
+  def reconcile_instance_import_source
+    newer_source = InstanceImportSource.find_by(user_id: newer_user.id)
+    return 0 unless newer_source
+    if InstanceImportSource.exists?(user_id: older_user.id)
+      newer_source.destroy!; 1
+    else
+      newer_source.update!(user_id: older_user.id); 0
+    end
+  end
+
+  def delete_rows(table_name, conditions)
+    raise ArgumentError, "Table '#{table_name}' is not in the allowlist" unless DELETABLE_TABLES.include?(table_name)
+
+    quoted = ActiveRecord::Base.connection.quote_table_name(table_name)
+    sql = ActiveRecord::Base.sanitize_sql_array([ "DELETE FROM #{quoted} WHERE user_id = ?", conditions.fetch(:user_id) ])
+    ActiveRecord::Base.connection.delete(sql)
+  end
+end

--- a/app/services/account_merge_service.rb
+++ b/app/services/account_merge_service.rb
@@ -1,6 +1,8 @@
 class AccountMergeService < ApplicationService
   DELETABLE_TABLES = %w[heartbeat_import_sources wakatime_mirrors project_labels].freeze
 
+  class MergeError < StandardError; end
+
   def self.call(older_user:, newer_user:) = new(older_user:, newer_user:).call
 
   def initialize(older_user:, newer_user:)
@@ -50,6 +52,8 @@ class AccountMergeService < ApplicationService
     end
 
     results.join(", ")
+  rescue ActiveRecord::RecordNotUnique => error
+    raise MergeError, "Destination account has conflicting records", cause: error
   end
 
   private

--- a/test/controllers/admin/account_merger_controller_test.rb
+++ b/test/controllers/admin/account_merger_controller_test.rb
@@ -61,7 +61,7 @@ class Admin::AccountMergerControllerTest < ActionDispatch::IntegrationTest
     assert_includes flash[:notice], "3 related records cleaned up"
   end
 
-  test "merge renames transferred api keys when the older account already has the same key name" do
+  test "merge does not expose unexpected failure details" do
     admin = create(:user, :ultraadmin)
     older = create(:user, username: "older_user")
     newer = create(:user, username: "newer_user")
@@ -70,74 +70,13 @@ class Admin::AccountMergerControllerTest < ActionDispatch::IntegrationTest
     older.update_column(:created_at, 2.days.ago)
     newer.update_column(:created_at, 1.day.ago)
 
-    create(:api_key, user: older, name: "Wakatime API Key")
-    transferred_key = create(:api_key, user: newer, name: "Wakatime API Key")
+    create(:goal, user: older)
+    create(:goal, user: newer)
 
     post merge_admin_account_merger_path, params: { older_id: older.id, newer_id: newer.id }
 
     assert_redirected_to admin_account_merger_path
-    assert_nil User.find_by(id: newer.id)
-    assert_equal older.id, transferred_key.reload.user_id
-    assert_equal "Wakatime API Key (transferred)", transferred_key.name
-    assert_equal [ "Wakatime API Key", "Wakatime API Key (transferred)" ], older.api_keys.order(:name).pluck(:name)
-  end
-
-  test "merge transfers instance import sources to the older account when it does not have one" do
-    admin = create(:user, :ultraadmin)
-    older = create(:user, username: "older_user")
-    newer = create(:user, username: "newer_user")
-    sign_in_as(admin)
-
-    older.update_column(:created_at, 2.days.ago)
-    newer.update_column(:created_at, 1.day.ago)
-
-    create_instance_import_source_for(newer, endpoint_url: "https://newer.example.com")
-
-    post merge_admin_account_merger_path, params: { older_id: older.id, newer_id: newer.id }
-
-    assert_redirected_to admin_account_merger_path
-    assert_nil User.find_by(id: newer.id)
-    assert_equal 1, instance_import_source_count_for(older)
-    assert_equal 0, instance_import_source_count_for(newer)
-    assert_equal "https://newer.example.com", instance_import_source_endpoint_for(older)
-  end
-
-  test "merge removes the newer instance import source when the older account already has one" do
-    admin = create(:user, :ultraadmin)
-    older = create(:user, username: "older_user")
-    newer = create(:user, username: "newer_user")
-    sign_in_as(admin)
-
-    older.update_column(:created_at, 2.days.ago)
-    newer.update_column(:created_at, 1.day.ago)
-
-    create_instance_import_source_for(older, endpoint_url: "https://older.example.com")
-    create_instance_import_source_for(newer, endpoint_url: "https://newer.example.com")
-
-    post merge_admin_account_merger_path, params: { older_id: older.id, newer_id: newer.id }
-
-    assert_redirected_to admin_account_merger_path
-    assert_nil User.find_by(id: newer.id)
-    assert_equal 1, instance_import_source_count_for(older)
-    assert_equal 0, instance_import_source_count_for(newer)
-    assert_equal "https://older.example.com", instance_import_source_endpoint_for(older)
-  end
-
-  private
-
-  def create_instance_import_source_for(user, endpoint_url:)
-    create(:instance_import_source,
-      user: user,
-      endpoint_url: endpoint_url,
-      encrypted_api_key: "encrypted-api-key"
-    )
-  end
-
-  def instance_import_source_count_for(user)
-    InstanceImportSource.where(user_id: user.id).count
-  end
-
-  def instance_import_source_endpoint_for(user)
-    InstanceImportSource.find_by(user_id: user.id)&.endpoint_url
+    assert_equal "Merge failed and was rolled back. Check the application logs for details.", flash[:alert]
+    assert User.exists?(newer.id)
   end
 end

--- a/test/controllers/admin/account_merger_controller_test.rb
+++ b/test/controllers/admin/account_merger_controller_test.rb
@@ -61,7 +61,7 @@ class Admin::AccountMergerControllerTest < ActionDispatch::IntegrationTest
     assert_includes flash[:notice], "3 related records cleaned up"
   end
 
-  test "merge does not expose unexpected failure details" do
+  test "merge redirects after an expected failure without exposing details" do
     admin = create(:user, :ultraadmin)
     older = create(:user, username: "older_user")
     newer = create(:user, username: "newer_user")
@@ -78,5 +78,34 @@ class Admin::AccountMergerControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to admin_account_merger_path
     assert_equal "Merge failed and was rolled back. Check the application logs for details.", flash[:alert]
     assert User.exists?(newer.id)
+  end
+
+  test "merge reports and re-raises unexpected service failures" do
+    admin = create(:user, :ultraadmin)
+    older = create(:user, username: "older_user")
+    newer = create(:user, username: "newer_user")
+    sign_in_as(admin)
+
+    older.update_column(:created_at, 2.days.ago)
+    newer.update_column(:created_at, 1.day.ago)
+
+    log_output = StringIO.new
+    previous_logger = Rails.logger
+    Rails.logger = ActiveSupport::Logger.new(log_output)
+
+    unexpected_service = Class.new
+    unexpected_service.const_set(:MergeError, Class.new(StandardError))
+    unexpected_service.define_singleton_method(:call) { |**| raise "unexpected merge defect" }
+
+    stub_const(Object, :AccountMergeService, unexpected_service) do
+      error = assert_raises(RuntimeError) do
+        post merge_admin_account_merger_path, params: { older_id: older.id, newer_id: newer.id }
+      end
+
+      assert_equal "unexpected merge defect", error.message
+    end
+    assert_includes log_output.string, "older user ##{older.id} and newer user ##{newer.id}: RuntimeError: unexpected merge defect"
+  ensure
+    Rails.logger = previous_logger if previous_logger
   end
 end

--- a/test/services/account_merge_service_test.rb
+++ b/test/services/account_merge_service_test.rb
@@ -52,10 +52,12 @@ class AccountMergeServiceTest < ActiveSupport::TestCase
     create(:goal, user: older)
     create(:goal, user: newer)
 
-    assert_raises(ActiveRecord::RecordNotUnique) do
+    error = assert_raises(AccountMergeService::MergeError) do
       AccountMergeService.call(older_user: older, newer_user: newer)
     end
 
+    assert_equal "Destination account has conflicting records", error.message
+    assert_instance_of ActiveRecord::RecordNotUnique, error.cause
     assert_equal newer.id, heartbeat.reload.user_id
     assert_equal newer.id, transferred_key.reload.user_id
     assert_equal "Wakatime API Key", transferred_key.name

--- a/test/services/account_merge_service_test.rb
+++ b/test/services/account_merge_service_test.rb
@@ -1,0 +1,84 @@
+require "test_helper"
+
+class AccountMergeServiceTest < ActiveSupport::TestCase
+  test "renames transferred api keys when the older account already has the same key name" do
+    older = create(:user, username: "older_user")
+    newer = create(:user, username: "newer_user")
+    create(:api_key, user: older, name: "Wakatime API Key")
+    transferred_key = create(:api_key, user: newer, name: "Wakatime API Key")
+
+    result = AccountMergeService.call(older_user: older, newer_user: newer)
+
+    assert_match(/\A0 heartbeats moved, 1 API keys transferred, 0 goals transferred, 0 sessions\/tokens revoked, \d+ related records cleaned up, user ##{newer.id} deleted\z/, result)
+    assert_nil User.find_by(id: newer.id)
+    assert_equal older.id, transferred_key.reload.user_id
+    assert_equal "Wakatime API Key (transferred)", transferred_key.name
+    assert_equal [ "Wakatime API Key", "Wakatime API Key (transferred)" ], older.api_keys.order(:name).pluck(:name)
+  end
+
+  test "transfers the newer instance import source when the older account does not have one" do
+    older = create(:user, username: "older_user")
+    newer = create(:user, username: "newer_user")
+    create_instance_import_source_for(newer, endpoint_url: "https://newer.example.com")
+
+    AccountMergeService.call(older_user: older, newer_user: newer)
+
+    assert_nil User.find_by(id: newer.id)
+    assert_equal 1, instance_import_source_count_for(older)
+    assert_equal 0, instance_import_source_count_for(newer)
+    assert_equal "https://newer.example.com", instance_import_source_endpoint_for(older)
+  end
+
+  test "removes the newer instance import source when the older account already has one" do
+    older = create(:user, username: "older_user")
+    newer = create(:user, username: "newer_user")
+    create_instance_import_source_for(older, endpoint_url: "https://older.example.com")
+    create_instance_import_source_for(newer, endpoint_url: "https://newer.example.com")
+
+    AccountMergeService.call(older_user: older, newer_user: newer)
+
+    assert_nil User.find_by(id: newer.id)
+    assert_equal 1, instance_import_source_count_for(older)
+    assert_equal 0, instance_import_source_count_for(newer)
+    assert_equal "https://older.example.com", instance_import_source_endpoint_for(older)
+  end
+
+  test "rolls back earlier changes when a later write fails" do
+    older = create(:user, username: "older_user")
+    newer = create(:user, username: "newer_user")
+    heartbeat = create(:heartbeat, user: newer)
+    create(:api_key, user: older, name: "Wakatime API Key")
+    transferred_key = create(:api_key, user: newer, name: "Wakatime API Key")
+    create(:goal, user: older)
+    create(:goal, user: newer)
+
+    assert_raises(ActiveRecord::RecordNotUnique) do
+      AccountMergeService.call(older_user: older, newer_user: newer)
+    end
+
+    assert_equal newer.id, heartbeat.reload.user_id
+    assert_equal newer.id, transferred_key.reload.user_id
+    assert_equal "Wakatime API Key", transferred_key.name
+    assert User.exists?(newer.id)
+    assert_equal 1, Goal.where(user_id: older.id).count
+    assert_equal 1, Goal.where(user_id: newer.id).count
+  end
+
+  private
+
+  def create_instance_import_source_for(user, endpoint_url:)
+    create(:instance_import_source,
+      user: user,
+      endpoint_url: endpoint_url,
+      encrypted_api_key: "encrypted-api-key"
+    )
+  end
+
+  def instance_import_source_count_for(user)
+    InstanceImportSource.where(user_id: user.id).count
+  end
+
+  def instance_import_source_endpoint_for(user)
+    InstanceImportSource.find_by(user_id: user.id)&.endpoint_url
+  end
+end


### PR DESCRIPTION
## Summary of the problem

Admin account merging currently embeds a destructive, multi-model transaction in the controller. This mixes HTTP concerns with execution and makes rollback and reconciliation difficult to test directly.

## Describe your changes

Adds one `AccountMergeService` that owns the existing transaction, import source reconciliation, API key collision handling and allowlisted legacy table deletion. The controller retains parameter handling, lookup, authorisation, account ordering checks, redirects and admin messages.

The success summary is unchanged. Unexpected failures still retain exception context and both user IDs in logs and Sentry, while the admin response now avoids exposing raw exception details.

Direct service coverage now exercises API key reconciliation, both import source paths and rollback of earlier writes after a later database constraint failure.

## Screenshots / Media

Not applicable. No visual changes.