### PR TITLE
Consolidate Timeline user orchestration

### DIFF
--- a/app/controllers/admin/timeline_controller.rb
+++ b/app/controllers/admin/timeline_controller.rb
@@ -1,33 +1,22 @@
 class Admin::TimelineController < Admin::BaseController
   include ApplicationHelper
 
-  USER_SELECT_FIELDS = %i[id username slack_username github_username slack_avatar_url github_avatar_url display_name_override].freeze
-
   def show
     @date = parse_date_param
-    raw_user_ids = params[:user_ids].present? ? params[:user_ids].split(",").map(&:to_i).uniq : []
-    raw_user_ids += User.where(slack_uid: params[:slack_uids].split(",")).pluck(:id) if params[:slack_uids].present?
-
-    @selected_user_ids = ([ current_user.id ] + raw_user_ids).uniq
-
-    service = TimelineService.new(date: @date, selected_user_ids: @selected_user_ids)
-    timeline_data_unordered = service.timeline_data
-
-    data_map = timeline_data_unordered.index_by { |data| data[:user].id }
-    @users_with_timeline_data = @selected_user_ids.map do |id|
-      data_map[id] || (service.users_by_id[id] ? { user: service.users_by_id[id], spans: [], total_coded_time: 0 } : nil)
-    end.compact
-
-    selected_users = User.where(id: @selected_user_ids).select(*USER_SELECT_FIELDS).preload(:email_addresses)
-                         .map { |u| user_summary(u) }
-                         .sort_by { |u| @selected_user_ids.index(u[:id]) || Float::INFINITY }
+    service = TimelineService.for_selection(
+      date: @date,
+      current_user: current_user,
+      user_ids: params[:user_ids],
+      slack_uids: params[:slack_uids]
+    )
+    @users_with_timeline_data = service.timeline_data
 
     @primary_user = @users_with_timeline_data.first&.[](:user) || current_user
     primary_timezone = @primary_user.timezone.presence || current_user.timezone.presence || "UTC"
 
     render inertia: "Admin/Timeline", props: {
       current_user: user_summary(current_user).merge(admin_level: current_user.admin_level),
-      selected_users: selected_users,
+      selected_users: service.users.map { |user| user_summary(user) },
       date: @date.to_s,
       date_label: @date.in_time_zone(primary_timezone).strftime("%A, %B %-d, %Y"),
       today: Time.current.to_date.to_s,
@@ -39,32 +28,13 @@ class Admin::TimelineController < Admin::BaseController
   def search_users
     return render json: [] if params[:query].blank?
 
-    users = User.fuzzy_ranked_search(params[:query], limit: 20)
+    users = TimelineService.search_users(params[:query])
     render json: users.map { |u| user_summary(u) }
   end
 
   def leaderboard_users
-    limit = 25
-    leaderboard = Leaderboard.where.not(finished_generating_at: nil)
-                             .find_by(start_date: Date.current,
-                                      period_type: (params[:period] == "last_7_days") ? :last_7_days : :daily,
-                                      deleted_at: nil)
-
-    user_ids_from_leaderboard = leaderboard ? leaderboard.entries.order(total_seconds: :desc).limit(limit).pluck(:user_id) : []
-    all_ids_to_fetch = ([ current_user.id ] + user_ids_from_leaderboard).uniq
-
-    users_data = User.where(id: all_ids_to_fetch).select(*USER_SELECT_FIELDS).preload(:email_addresses).index_by(&:id)
-
-    final_user_objects = []
-    final_user_objects << user_summary(users_data[current_user.id]) if users_data[current_user.id]
-
-    user_ids_from_leaderboard.each do |uid|
-      break if final_user_objects.size >= limit
-      next if uid == current_user.id
-      final_user_objects << user_summary(users_data[uid]) if users_data[uid]
-    end
-
-    render json: { users: final_user_objects }
+    users = TimelineService.leaderboard_users(current_user: current_user, period: params[:period])
+    render json: { users: users.map { |user| user_summary(user) } }
   end
 
   private

--- a/app/controllers/api/admin/v1/timeline_controller.rb
+++ b/app/controllers/api/admin/v1/timeline_controller.rb
@@ -2,20 +2,14 @@ module Api
   module Admin
     module V1
       class TimelineController < Api::Admin::V1::ApplicationController
-        MAX_TIMELINE_USERS = 20
-
         def show
           date = params[:date] ? Date.parse(params[:date]) : Time.current.to_date
-
-          raw_user_ids = params[:user_ids].present? ? params[:user_ids].split(",").map(&:to_i).uniq : []
-          if params[:slack_uids].present?
-            slack_uids = params[:slack_uids].split(",").first(MAX_TIMELINE_USERS)
-            raw_user_ids += User.where(slack_uid: slack_uids).pluck(:id)
-          end
-          raw_user_ids = raw_user_ids.first(MAX_TIMELINE_USERS)
-
-          selected_user_ids = ([ current_user.id ] + raw_user_ids).uniq
-          service = TimelineService.new(date: date, selected_user_ids: selected_user_ids)
+          service = TimelineService.for_selection(
+            date: date,
+            current_user: current_user,
+            user_ids: params[:user_ids],
+            slack_uids: params[:slack_uids]
+          )
 
           users_with_timeline_data = service.timeline_data.map do |entry|
             u = entry[:user]
@@ -49,37 +43,13 @@ module Api
           query_term = params[:query].to_s
           return render_error("Query parameter is required") if query_term.blank?
 
-          users = User.fuzzy_ranked_search(query_term, limit: 20)
+          users = TimelineService.search_users(query_term)
           render json: { users: users.map { |u| user_summary(u) } }
         end
 
         def leaderboard_users
-          period = params[:period]
-          limit = 25
-
-          leaderboard = Leaderboard.where.not(finished_generating_at: nil)
-                                   .find_by(start_date: Date.current,
-                                            period_type: (period == "last_7_days") ? :last_7_days : :daily,
-                                            deleted_at: nil)
-
-          user_ids_from_leaderboard = leaderboard ? leaderboard.entries.order(total_seconds: :desc).limit(limit).pluck(:user_id) : []
-          all_ids_to_fetch = ([ current_user.id ] + user_ids_from_leaderboard).uniq
-
-          users_data = User.where(id: all_ids_to_fetch)
-                           .select(:id, :username, :slack_username, :github_username, :slack_avatar_url, :github_avatar_url, :display_name_override)
-                           .preload(:email_addresses)
-                           .index_by(&:id)
-
-          final_user_objects = []
-          final_user_objects << user_summary(users_data[current_user.id]) if users_data[current_user.id]
-
-          user_ids_from_leaderboard.each do |uid|
-            break if final_user_objects.size >= limit
-            next if uid == current_user.id
-            final_user_objects << user_summary(users_data[uid]) if users_data[uid]
-          end
-
-          render json: { users: final_user_objects }
+          users = TimelineService.leaderboard_users(current_user: current_user, period: params[:period])
+          render json: { users: users.map { |user| user_summary(user) } }
         end
 
         private

--- a/app/services/timeline_service.rb
+++ b/app/services/timeline_service.rb
@@ -1,20 +1,55 @@
 class TimelineService
+  MAX_TIMELINE_USERS = 20
+  LEADERBOARD_USERS_LIMIT = 25
+  SEARCH_USERS_LIMIT = 20
+  LEADERBOARD_USER_SELECT_FIELDS = %i[id username slack_username github_username slack_avatar_url github_avatar_url display_name_override].freeze
   TIMEOUT_DURATION = 10.minutes.to_i
 
   attr_reader :date, :selected_user_ids
 
+  class << self
+    def for_selection(date:, current_user:, user_ids:, slack_uids:)
+      requested_user_ids = user_ids.to_s.split(",").map(&:to_i).uniq.first(MAX_TIMELINE_USERS)
+      requested_slack_uids = slack_uids.to_s.split(",").uniq.first(MAX_TIMELINE_USERS)
+      user_ids_by_slack_uid = User.where(slack_uid: requested_slack_uids).pluck(:slack_uid, :id).to_h
+      requested_user_ids.concat(requested_slack_uids.filter_map { |slack_uid| user_ids_by_slack_uid[slack_uid] })
+
+      new(date: date, selected_user_ids: [ current_user.id, *requested_user_ids ])
+    end
+
+    def search_users(query)
+      User.fuzzy_ranked_search(query, limit: SEARCH_USERS_LIMIT)
+    end
+
+    def leaderboard_users(current_user:, period:)
+      leaderboard = Leaderboard.where.not(finished_generating_at: nil)
+                               .find_by(start_date: Date.current,
+                                        period_type: period == "last_7_days" ? :last_7_days : :daily,
+                                        deleted_at: nil)
+      leaderboard_user_ids = leaderboard ? leaderboard.entries.order(total_seconds: :desc).limit(LEADERBOARD_USERS_LIMIT).pluck(:user_id) : []
+      ordered_user_ids = [ current_user.id, *leaderboard_user_ids ].uniq.first(LEADERBOARD_USERS_LIMIT)
+      users_by_id = User.where(id: ordered_user_ids).select(*LEADERBOARD_USER_SELECT_FIELDS).preload(:email_addresses).index_by(&:id)
+
+      ordered_user_ids.filter_map { |user_id| users_by_id[user_id] }
+    end
+  end
+
   def initialize(date:, selected_user_ids:)
     @date = date
-    @selected_user_ids = selected_user_ids.uniq
+    @selected_user_ids = selected_user_ids.uniq.first(MAX_TIMELINE_USERS)
+  end
+
+  def users
+    @users ||= selected_user_ids.filter_map { |user_id| users_by_id[user_id] }
   end
 
   def users_by_id
-    @users_by_id ||= User.where(id: selected_user_ids).index_by(&:id)
+    @users_by_id ||= User.where(id: selected_user_ids).preload(:email_addresses).index_by(&:id)
   end
 
   def timeline_data
     duration_cap = Heartbeat.heartbeat_timeout_duration.to_i
-    users_by_id.values.map do |user|
+    users.map do |user|
       user_tz = user.timezone || "UTC"
       day_start = date.in_time_zone(user_tz).beginning_of_day.to_f
       day_end = date.in_time_zone(user_tz).end_of_day.to_f

--- a/app/services/timeline_service.rb
+++ b/app/services/timeline_service.rb
@@ -1,5 +1,6 @@
 class TimelineService
-  MAX_TIMELINE_USERS = 20
+  MAX_REQUESTED_TIMELINE_USERS = 20
+  MAX_TIMELINE_USERS = MAX_REQUESTED_TIMELINE_USERS + 1
   LEADERBOARD_USERS_LIMIT = 25
   SEARCH_USERS_LIMIT = 20
   LEADERBOARD_USER_SELECT_FIELDS = %i[id username slack_username github_username slack_avatar_url github_avatar_url display_name_override].freeze
@@ -9,10 +10,11 @@ class TimelineService
 
   class << self
     def for_selection(date:, current_user:, user_ids:, slack_uids:)
-      requested_user_ids = user_ids.to_s.split(",").map(&:to_i).uniq.first(MAX_TIMELINE_USERS)
-      requested_slack_uids = slack_uids.to_s.split(",").uniq.first(MAX_TIMELINE_USERS)
+      requested_user_ids = user_ids.to_s.split(",").map(&:to_i).uniq.first(MAX_REQUESTED_TIMELINE_USERS)
+      requested_slack_uids = slack_uids.to_s.split(",").uniq.first(MAX_REQUESTED_TIMELINE_USERS)
       user_ids_by_slack_uid = User.where(slack_uid: requested_slack_uids).pluck(:slack_uid, :id).to_h
       requested_user_ids.concat(requested_slack_uids.filter_map { |slack_uid| user_ids_by_slack_uid[slack_uid] })
+      requested_user_ids = requested_user_ids.uniq.first(MAX_REQUESTED_TIMELINE_USERS)
 
       new(date: date, selected_user_ids: [ current_user.id, *requested_user_ids ])
     end

--- a/spec/requests/api/admin/v1/admin_timeline_spec.rb
+++ b/spec/requests/api/admin/v1/admin_timeline_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Admin::Timeline', type: :request, openapi_spec: 'admin/swagger.y
   path '/api/admin/v1/timeline' do
     get('Get timeline') do
       tags 'Admin Timeline'
-      description 'Get timeline events including coding activity and commits for up to 20 users. The authenticated admin is always included, even when no users are selected.'
+      description 'Get timeline events including coding activity and commits for up to 20 requested users plus the authenticated admin, for a maximum of 21 users.'
       security [ AdminToken: [] ]
       produces 'application/json'
 
@@ -20,7 +20,7 @@ RSpec.describe 'Admin::Timeline', type: :request, openapi_spec: 'admin/swagger.y
             prev_date: { type: :string, format: :date, example: '2024-03-19' },
             users: {
               type: :array,
-              maxItems: 20,
+              maxItems: 21,
               items: {
                 type: :object,
                 properties: {
@@ -90,7 +90,7 @@ RSpec.describe 'Admin::Timeline', type: :request, openapi_spec: 'admin/swagger.y
             prev_date: { type: :string, format: :date, example: '2024-03-19' },
             users: {
               type: :array,
-              maxItems: 20,
+              maxItems: 21,
               items: {
                 type: :object,
                 properties: {

--- a/spec/requests/api/admin/v1/admin_timeline_spec.rb
+++ b/spec/requests/api/admin/v1/admin_timeline_spec.rb
@@ -4,13 +4,13 @@ RSpec.describe 'Admin::Timeline', type: :request, openapi_spec: 'admin/swagger.y
   path '/api/admin/v1/timeline' do
     get('Get timeline') do
       tags 'Admin Timeline'
-      description 'Get timeline events including coding activity and commits for selected users.'
+      description 'Get timeline events including coding activity and commits for up to 20 users. The authenticated admin is always included, even when no users are selected.'
       security [ AdminToken: [] ]
       produces 'application/json'
 
       parameter name: :date, in: :query, schema: { type: :string, format: :date }, description: 'Date for the timeline (YYYY-MM-DD)'
-      parameter name: :user_ids, in: :query, type: :string, description: 'Comma-separated list of User IDs'
-      parameter name: :slack_uids, in: :query, type: :string, description: 'Comma-separated list of Slack User IDs'
+      parameter name: :user_ids, in: :query, type: :string, description: 'Comma-separated list of User IDs, in display order'
+      parameter name: :slack_uids, in: :query, type: :string, description: 'Comma-separated list of Slack User IDs, in display order'
 
       response(200, 'successful') do
         schema type: :object,
@@ -20,6 +20,7 @@ RSpec.describe 'Admin::Timeline', type: :request, openapi_spec: 'admin/swagger.y
             prev_date: { type: :string, format: :date, example: '2024-03-19' },
             users: {
               type: :array,
+              maxItems: 20,
               items: {
                 type: :object,
                 properties: {
@@ -89,6 +90,7 @@ RSpec.describe 'Admin::Timeline', type: :request, openapi_spec: 'admin/swagger.y
             prev_date: { type: :string, format: :date, example: '2024-03-19' },
             users: {
               type: :array,
+              maxItems: 20,
               items: {
                 type: :object,
                 properties: {
@@ -204,6 +206,11 @@ RSpec.describe 'Admin::Timeline', type: :request, openapi_spec: 'admin/swagger.y
       response(422, 'unprocessable entity') do
         let(:Authorization) { "Bearer dev-admin-api-key-12345" }
         let(:query) { '' }
+        schema type: :object,
+          properties: {
+            error: { type: :string, example: 'Query parameter is required' }
+          },
+          required: [ 'error' ]
         run_test!
       end
 

--- a/swagger/admin/swagger.yaml
+++ b/swagger/admin/swagger.yaml
@@ -1266,8 +1266,7 @@ paths:
       tags:
       - Admin Timeline
       description: Get timeline events including coding activity and commits for up
-        to 20 users. The authenticated admin is always included, even when no users
-        are selected.
+        to 20 requested users plus the authenticated admin, for a maximum of 21 users.
       security:
       - AdminToken: []
       parameters:
@@ -1309,7 +1308,7 @@ paths:
                     example: '2024-03-19'
                   users:
                     type: array
-                    maxItems: 20
+                    maxItems: 21
                     items:
                       type: object
                       properties:

--- a/swagger/admin/swagger.yaml
+++ b/swagger/admin/swagger.yaml
@@ -1265,8 +1265,9 @@ paths:
       summary: Get timeline
       tags:
       - Admin Timeline
-      description: Get timeline events including coding activity and commits for selected
-        users.
+      description: Get timeline events including coding activity and commits for up
+        to 20 users. The authenticated admin is always included, even when no users
+        are selected.
       security:
       - AdminToken: []
       parameters:
@@ -1278,12 +1279,12 @@ paths:
         description: Date for the timeline (YYYY-MM-DD)
       - name: user_ids
         in: query
-        description: Comma-separated list of User IDs
+        description: Comma-separated list of User IDs, in display order
         schema:
           type: string
       - name: slack_uids
         in: query
-        description: Comma-separated list of Slack User IDs
+        description: Comma-separated list of Slack User IDs, in display order
         schema:
           type: string
       responses:
@@ -1308,6 +1309,7 @@ paths:
                     example: '2024-03-19'
                   users:
                     type: array
+                    maxItems: 20
                     items:
                       type: object
                       properties:
@@ -1467,6 +1469,16 @@ paths:
                           example: https://avatars.slack-edge.com/2024-03-20/orpheus_512.png
         '422':
           description: unprocessable entity
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: Query parameter is required
+                required:
+                - error
         '401':
           description: unauthorized
   "/api/admin/v1/timeline/leaderboard_users":

--- a/test/controllers/admin/timeline_controller_test.rb
+++ b/test/controllers/admin/timeline_controller_test.rb
@@ -23,6 +23,19 @@ class Admin::TimelineControllerTest < ActionDispatch::IntegrationTest
     assert_empty inertia.props.dig("columns", 0, "spans")
   end
 
+  test "show limits the browser timeline to the shared maximum user count" do
+    admin = create(:user, :admin)
+    requested_users = create_list(:user, TimelineService::MAX_TIMELINE_USERS + 2)
+    sign_in_as(admin)
+
+    get admin_timeline_path(user_ids: requested_users.map(&:id).join(","))
+
+    assert_response :success
+    selected_user_ids = inertia.props.fetch("selected_users").pluck("id")
+    assert_equal TimelineService::MAX_TIMELINE_USERS, selected_user_ids.size
+    assert_equal [ admin.id, *requested_users.first(TimelineService::MAX_TIMELINE_USERS - 1).map(&:id) ], selected_user_ids
+  end
+
   test "show falls back to today for a malformed date param" do
     admin = create(:user, :admin)
     sign_in_as(admin)

--- a/test/controllers/admin/timeline_controller_test.rb
+++ b/test/controllers/admin/timeline_controller_test.rb
@@ -11,6 +11,18 @@ class Admin::TimelineControllerTest < ActionDispatch::IntegrationTest
     assert_inertia_component "Admin/Timeline"
   end
 
+  test "show includes the current admin with an empty timeline when no users are selected" do
+    admin = create(:user, :admin)
+    sign_in_as(admin)
+
+    get admin_timeline_path
+
+    assert_response :success
+    assert_equal [ admin.id ], inertia.props.fetch("selected_users").pluck("id")
+    assert_equal [ admin.id ], inertia.props.fetch("columns").pluck("user").pluck("id")
+    assert_empty inertia.props.dig("columns", 0, "spans")
+  end
+
   test "show falls back to today for a malformed date param" do
     admin = create(:user, :admin)
     sign_in_as(admin)
@@ -19,5 +31,15 @@ class Admin::TimelineControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_equal Time.current.to_date.to_s, inertia.props["date"]
+  end
+
+  test "search_users returns a bare empty array for a blank query" do
+    admin = create(:user, :admin)
+    sign_in_as(admin)
+
+    get "/admin/timeline/search_users", params: { query: "" }
+
+    assert_response :success
+    assert_equal [], response.parsed_body
   end
 end

--- a/test/controllers/admin/timeline_controller_test.rb
+++ b/test/controllers/admin/timeline_controller_test.rb
@@ -23,9 +23,9 @@ class Admin::TimelineControllerTest < ActionDispatch::IntegrationTest
     assert_empty inertia.props.dig("columns", 0, "spans")
   end
 
-  test "show limits the browser timeline to the shared maximum user count" do
+  test "show limits the browser timeline to 20 requested users plus the current admin" do
     admin = create(:user, :admin)
-    requested_users = create_list(:user, TimelineService::MAX_TIMELINE_USERS + 2)
+    requested_users = create_list(:user, TimelineService::MAX_REQUESTED_TIMELINE_USERS + 2)
     sign_in_as(admin)
 
     get admin_timeline_path(user_ids: requested_users.map(&:id).join(","))
@@ -33,7 +33,7 @@ class Admin::TimelineControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     selected_user_ids = inertia.props.fetch("selected_users").pluck("id")
     assert_equal TimelineService::MAX_TIMELINE_USERS, selected_user_ids.size
-    assert_equal [ admin.id, *requested_users.first(TimelineService::MAX_TIMELINE_USERS - 1).map(&:id) ], selected_user_ids
+    assert_equal [ admin.id, *requested_users.first(TimelineService::MAX_REQUESTED_TIMELINE_USERS).map(&:id) ], selected_user_ids
   end
 
   test "show falls back to today for a malformed date param" do

--- a/test/controllers/api/admin/v1/timeline_controller_test.rb
+++ b/test/controllers/api/admin/v1/timeline_controller_test.rb
@@ -12,9 +12,9 @@ class Api::Admin::V1::TimelineControllerTest < ActionDispatch::IntegrationTest
     assert_empty response.parsed_body.dig("users", 0, "spans")
   end
 
-  test "show limits the JSON timeline to the shared maximum user count" do
+  test "show preserves the API limit of 20 requested users plus the current admin" do
     admin = create(:user, :admin)
-    requested_users = create_list(:user, TimelineService::MAX_TIMELINE_USERS + 2)
+    requested_users = create_list(:user, TimelineService::MAX_REQUESTED_TIMELINE_USERS + 2)
     key = create(:admin_api_key, user: admin, name: "test")
 
     get "/api/admin/v1/timeline", params: { user_ids: requested_users.map(&:id).join(",") }, headers: auth_headers(key)
@@ -22,7 +22,7 @@ class Api::Admin::V1::TimelineControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     selected_user_ids = response.parsed_body.fetch("users").pluck("user").pluck("id")
     assert_equal TimelineService::MAX_TIMELINE_USERS, selected_user_ids.size
-    assert_equal [ admin.id, *requested_users.first(TimelineService::MAX_TIMELINE_USERS - 1).map(&:id) ], selected_user_ids
+    assert_equal [ admin.id, *requested_users.first(TimelineService::MAX_REQUESTED_TIMELINE_USERS).map(&:id) ], selected_user_ids
   end
 
   test "show rejects a malformed date instead of falling back" do

--- a/test/controllers/api/admin/v1/timeline_controller_test.rb
+++ b/test/controllers/api/admin/v1/timeline_controller_test.rb
@@ -12,6 +12,19 @@ class Api::Admin::V1::TimelineControllerTest < ActionDispatch::IntegrationTest
     assert_empty response.parsed_body.dig("users", 0, "spans")
   end
 
+  test "show limits the JSON timeline to the shared maximum user count" do
+    admin = create(:user, :admin)
+    requested_users = create_list(:user, TimelineService::MAX_TIMELINE_USERS + 2)
+    key = create(:admin_api_key, user: admin, name: "test")
+
+    get "/api/admin/v1/timeline", params: { user_ids: requested_users.map(&:id).join(",") }, headers: auth_headers(key)
+
+    assert_response :success
+    selected_user_ids = response.parsed_body.fetch("users").pluck("user").pluck("id")
+    assert_equal TimelineService::MAX_TIMELINE_USERS, selected_user_ids.size
+    assert_equal [ admin.id, *requested_users.first(TimelineService::MAX_TIMELINE_USERS - 1).map(&:id) ], selected_user_ids
+  end
+
   test "show rejects a malformed date instead of falling back" do
     admin = create(:user, :admin)
     key = create(:admin_api_key, user: admin, name: "test")

--- a/test/controllers/api/admin/v1/timeline_controller_test.rb
+++ b/test/controllers/api/admin/v1/timeline_controller_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+
+class Api::Admin::V1::TimelineControllerTest < ActionDispatch::IntegrationTest
+  test "show includes the current admin with an empty timeline when no users are selected" do
+    admin = create(:user, :admin)
+    key = create(:admin_api_key, user: admin, name: "test")
+
+    get "/api/admin/v1/timeline", headers: auth_headers(key)
+
+    assert_response :success
+    assert_equal [ admin.id ], response.parsed_body.fetch("users").pluck("user").pluck("id")
+    assert_empty response.parsed_body.dig("users", 0, "spans")
+  end
+
+  test "show rejects a malformed date instead of falling back" do
+    admin = create(:user, :admin)
+    key = create(:admin_api_key, user: admin, name: "test")
+
+    get "/api/admin/v1/timeline", params: { date: "not-a-date" }, headers: auth_headers(key)
+
+    assert_response :unprocessable_entity
+    assert_equal({ "error" => "Invalid date format" }, response.parsed_body)
+  end
+
+  test "search_users returns an error object for a blank query" do
+    admin = create(:user, :admin)
+    key = create(:admin_api_key, user: admin, name: "test")
+
+    get "/api/admin/v1/timeline/search_users", params: { query: "" }, headers: auth_headers(key)
+
+    assert_response :unprocessable_entity
+    assert_equal({ "error" => "Query parameter is required" }, response.parsed_body)
+  end
+
+  private
+
+  def auth_headers(key)
+    { "Authorization" => ActionController::HttpAuthentication::Token.encode_credentials(key.token) }
+  end
+end

--- a/test/services/timeline_service_test.rb
+++ b/test/services/timeline_service_test.rb
@@ -3,6 +3,38 @@ require "test_helper"
 class TimelineServiceTest < ActiveSupport::TestCase
   DATE = Date.new(2026, 8, 10)
 
+  test "for_selection forces the current user, preserves request order, and caps the selection" do
+    current_user = create(:user)
+    requested_users = create_list(:user, TimelineService::MAX_TIMELINE_USERS + 2, :with_slack)
+    users_selected_by_id = requested_users.first(10)
+    users_selected_by_slack = requested_users.drop(10)
+
+    service = TimelineService.for_selection(
+      date: DATE,
+      current_user: current_user,
+      user_ids: users_selected_by_id.map(&:id).join(","),
+      slack_uids: users_selected_by_slack.map(&:slack_uid).join(",")
+    )
+
+    expected_user_ids = [ current_user.id, *requested_users.first(TimelineService::MAX_TIMELINE_USERS - 1).map(&:id) ]
+    assert_equal expected_user_ids, service.selected_user_ids
+    assert_equal expected_user_ids, service.timeline_data.map { |entry| entry[:user].id }
+    assert service.timeline_data.all? { |entry| entry[:spans].empty? }
+  end
+
+  test "leaderboard_users keeps the current user first and the remaining users in leaderboard order" do
+    current_user = create(:user)
+    first_place = create(:user)
+    second_place = create(:user)
+    leaderboard = create(:leaderboard, finished_generating_at: Time.current)
+    create(:leaderboard_entry, leaderboard: leaderboard, user: second_place, total_seconds: 100)
+    create(:leaderboard_entry, leaderboard: leaderboard, user: first_place, total_seconds: 200)
+
+    users = TimelineService.leaderboard_users(current_user: current_user, period: "daily")
+
+    assert_equal [ current_user.id, first_place.id, second_place.id ], users.map(&:id)
+  end
+
   test "total_coded_time matches Heartbeat.duration_seconds for the user's day" do
     user = create(:user)
     day_start = DATE.in_time_zone("UTC").beginning_of_day.to_f

--- a/test/services/timeline_service_test.rb
+++ b/test/services/timeline_service_test.rb
@@ -3,9 +3,9 @@ require "test_helper"
 class TimelineServiceTest < ActiveSupport::TestCase
   DATE = Date.new(2026, 8, 10)
 
-  test "for_selection forces the current user, preserves request order, and caps the selection" do
+  test "for_selection caps requested users before forcing the current user" do
     current_user = create(:user)
-    requested_users = create_list(:user, TimelineService::MAX_TIMELINE_USERS + 2, :with_slack)
+    requested_users = create_list(:user, TimelineService::MAX_REQUESTED_TIMELINE_USERS + 2, :with_slack)
     users_selected_by_id = requested_users.first(10)
     users_selected_by_slack = requested_users.drop(10)
 
@@ -16,10 +16,25 @@ class TimelineServiceTest < ActiveSupport::TestCase
       slack_uids: users_selected_by_slack.map(&:slack_uid).join(",")
     )
 
-    expected_user_ids = [ current_user.id, *requested_users.first(TimelineService::MAX_TIMELINE_USERS - 1).map(&:id) ]
+    expected_user_ids = [ current_user.id, *requested_users.first(TimelineService::MAX_REQUESTED_TIMELINE_USERS).map(&:id) ]
     assert_equal expected_user_ids, service.selected_user_ids
     assert_equal expected_user_ids, service.timeline_data.map { |entry| entry[:user].id }
     assert service.timeline_data.all? { |entry| entry[:spans].empty? }
+  end
+
+  test "for_selection preserves requested order and deduplicates IDs and Slack UIDs" do
+    current_user = create(:user, :with_slack)
+    first_requested_user = create(:user, :with_slack)
+    second_requested_user = create(:user, :with_slack)
+
+    service = TimelineService.for_selection(
+      date: DATE,
+      current_user: current_user,
+      user_ids: [ first_requested_user.id, current_user.id, first_requested_user.id ].join(","),
+      slack_uids: [ first_requested_user.slack_uid, second_requested_user.slack_uid, current_user.slack_uid ].join(",")
+    )
+
+    assert_equal [ current_user.id, first_requested_user.id, second_requested_user.id ], service.selected_user_ids
   end
 
   test "leaderboard_users keeps the current user first and the remaining users in leaderboard order" do


### PR DESCRIPTION
## Summary of the problem

The browser and admin JSON Timeline controllers repeat user selection, search and leaderboard preset logic. The browser also allows an unbounded user selection while ordering and empty-selection behaviour can drift between transports.

## Describe your changes

Move ID and Slack UID parsing, current-user inclusion, the 20-requested-user cap, fuzzy search and ordered leaderboard loading into `TimelineService`. Preserve the existing API contract of up to 20 requested users plus the authenticated admin, for at most 21 users. Keep browser and JSON serialisers separate, preserve the browser fallback for invalid dates and preserve the JSON 422 error contract. Document the shared API limit and both transport contracts.

## Screenshots / Media

Not applicable. There are no visual changes.