### PR TITLE
Simplify setup screen header props

### DIFF
--- a/app/javascript/pages/Setup/Index.svelte
+++ b/app/javascript/pages/Setup/Index.svelte
@@ -90,7 +90,6 @@
     <div in:popIn>
       {#if step === "welcome"}
         <TwoChoiceLayout
-          emoji="/images/emojis/ms-grinning.svg"
           title="Welcome to Hackatime!"
           subtitle="Hackatime is a free tool from Hack Club that tracks the time you spend working on projects."
           question="To get started, do you have a code editor (like VSCode) installed?"
@@ -108,7 +107,6 @@
         </TwoChoiceLayout>
       {:else if step === "install-programs"}
         <TwoChoiceLayout
-          emoji="/images/emojis/ms-hugging-face.svg"
           title="Not a problem!"
           subtitle="We'll help you get set up with a code editor, so you can get started on your project."
           question="Are you able to install programs on your computer?"
@@ -126,7 +124,6 @@
         </TwoChoiceLayout>
       {:else if step === "codespaces-link"}
         <LinkScreen
-          emoji="/images/emojis/ms-cloud.svg"
           title="Codespaces setup"
           subtitle="We suggest using GitHub Codespaces, a free online code editor, to get started."
           lead="To use Codespaces, head here:"
@@ -141,7 +138,6 @@
         <VsCodeSteps onDone={() => goToStep("finish")} />
       {:else if step === "vscode-download"}
         <LinkScreen
-          emoji="/images/emojis/ms-computer.svg"
           title="VSCode setup"
           subtitle="Let's install Microsoft VSCode on your computer. It's our suggested code editor for making things for Hack Club!"
           lead="To download VSCode, go to this URL and select your system type:"
@@ -151,7 +147,6 @@
         />
       {:else if step === "terminal-choice"}
         <TwoChoiceLayout
-          emoji="/images/emojis/ms-cool.svg"
           title="Awesome!"
           subtitle="Let's get you set up with Hackatime directly."
           question="Are you comfortable with pasting a setup script in your terminal, or would you like to manually install each extension?"

--- a/app/javascript/pages/Setup/LinkScreen.svelte
+++ b/app/javascript/pages/Setup/LinkScreen.svelte
@@ -3,7 +3,6 @@
   import ScreenHeader from "./components/ScreenHeader.svelte";
 
   interface Props {
-    emoji: string;
     title: string;
     subtitle: string;
     lead: string;
@@ -16,7 +15,6 @@
   }
 
   let {
-    emoji,
     title,
     subtitle,
     lead,
@@ -30,7 +28,7 @@
 </script>
 
 <div class="space-y-8 sm:space-y-10">
-  <ScreenHeader {emoji} {title} {subtitle} />
+  <ScreenHeader {title} {subtitle} />
 
   <div class="text-center">
     <p class="text-base font-semibold sm:text-lg">{lead}</p>

--- a/app/javascript/pages/Setup/TerminalCommand.svelte
+++ b/app/javascript/pages/Setup/TerminalCommand.svelte
@@ -73,9 +73,8 @@
 
 <div class="space-y-8 sm:space-y-10">
   <ScreenHeader
-    emoji="/images/emojis/ms-lightning.svg"
     title="Let's do it!"
-    html="<b>Pick your operating system</b>, then follow the steps to run the setup command. It installs Hackatime and your editor plugins for you."
+    subtitle="Pick your operating system, then follow the steps to run the setup command. It installs Hackatime and your editor plugins for you."
   />
 
   <div class="mx-auto max-w-2xl space-y-4">

--- a/app/javascript/pages/Setup/VsCodeSteps.svelte
+++ b/app/javascript/pages/Setup/VsCodeSteps.svelte
@@ -46,7 +46,6 @@
 
 <div class="space-y-8 sm:space-y-10">
   <ScreenHeader
-    emoji="/images/emojis/ms-computer.svg"
     title="Awesome!"
     subtitle="Now let's install the Hackatime extension in your editor."
   />

--- a/app/javascript/pages/Setup/components/ScreenHeader.svelte
+++ b/app/javascript/pages/Setup/components/ScreenHeader.svelte
@@ -1,16 +1,13 @@
 <script lang="ts">
   interface Props {
-    emoji: string;
     title: string;
     subtitle?: string;
-    html?: string;
   }
 
-  let { emoji, title, subtitle, html }: Props = $props();
+  let { title, subtitle }: Props = $props();
 </script>
 
 <div class="text-center">
-  <!-- <img src={emoji} alt="" class="mx-auto mb-4 size-12 sm:size-14" /> -->
   <h1
     class="mx-auto max-w-[35ch] text-2xl font-semibold tracking-tight text-balance sm:text-3xl"
   >
@@ -19,11 +16,6 @@
   {#if subtitle}
     <p class="mx-auto mt-3 max-w-[48ch] text-base text-pretty text-secondary">
       {subtitle}
-    </p>
-  {/if}
-  {#if html}
-    <p class="mx-auto mt-3 max-w-[48ch] text-base text-pretty text-secondary">
-      {@html html}
     </p>
   {/if}
 </div>

--- a/app/javascript/pages/Setup/components/TwoChoiceLayout.svelte
+++ b/app/javascript/pages/Setup/components/TwoChoiceLayout.svelte
@@ -3,18 +3,17 @@
   import ScreenHeader from "./ScreenHeader.svelte";
 
   interface Props {
-    emoji: string;
     title: string;
     subtitle?: string;
     question: string;
     children: Snippet;
   }
 
-  let { emoji, title, subtitle, question, children }: Props = $props();
+  let { title, subtitle, question, children }: Props = $props();
 </script>
 
 <div class="space-y-8 sm:space-y-10">
-  <ScreenHeader {emoji} {title} {subtitle} />
+  <ScreenHeader {title} {subtitle} />
 
   <div>
     <h2


### PR DESCRIPTION
## Summary of the problem

`ScreenHeader` required setup callers to provide an emoji that was never rendered. It also accepted raw HTML only to bold one phrase in the terminal guidance.

## Describe your changes

Remove the unused emoji prop and its wrapper plumbing. Render terminal guidance through the existing plain subtitle prop, then remove the raw HTML path and dead image comment.

## Screenshots / Media

![Setup command screen](https://ampcode.com/user-content/artifacts/016a165f64dd4d2951da8cda81c7277d0244012d2df4ed9bfb347a25bc992de1-file.png)