### PR TITLE
Deduplicate machine and IP candidate queries

### DIFF
--- a/app/controllers/api/admin/v1/admin_controller.rb
+++ b/app/controllers/api/admin/v1/admin_controller.rb
@@ -134,67 +134,6 @@ module Api
           render json: { days: days }
         end
 
-        def alt_candidates
-          lookback_days = (params[:lookback_days] || 30).to_i.clamp(1, 365)
-          cutoff = lookback_days.days.ago.to_i
-
-          query = <<-SQL
-            SELECT
-                r1.user_id AS user_a_id,
-                r2.user_id AS user_b_id,
-                r1.machine,
-                r1.ip_address,
-                r1.first_seen as user_a_first_seen_on_combo,
-                r1.last_seen as user_a_last_seen_on_combo,
-                r2.first_seen as user_b_first_seen_on_combo,
-                r2.last_seen as user_b_last_seen_on_combo
-            FROM
-                (
-                    SELECT
-                        user_id,
-                        machine,
-                        ip_address,
-                        MIN(time) as first_seen,
-                        MAX(time) as last_seen
-                    FROM heartbeats
-                    WHERE
-                        user_id IS NOT NULL
-                        AND machine IS NOT NULL
-                        AND ip_address IS NOT NULL
-                        AND deleted_at IS NULL
-                        AND time >= ?
-                    GROUP BY 1, 2, 3
-                ) r1
-            JOIN
-                (
-                    SELECT
-                        user_id,
-                        machine,
-                        ip_address,
-                        MIN(time) as first_seen,
-                        MAX(time) as last_seen
-                    FROM heartbeats
-                    WHERE
-                        user_id IS NOT NULL
-                        AND machine IS NOT NULL
-                        AND ip_address IS NOT NULL
-                        AND deleted_at IS NULL
-                        AND time >= ?
-                    GROUP BY 1, 2, 3
-                ) r2 ON r1.machine = r2.machine AND r1.ip_address = r2.ip_address
-            WHERE
-                r1.user_id < r2.user_id
-            LIMIT 5000
-          SQL
-
-          result = ActiveRecord::Base.connection.exec_query(
-            ActiveRecord::Base.sanitize_sql([ query, cutoff, cutoff ])
-          )
-
-          render json: { candidates: result.to_a }
-        end
-
-
         def active_users
           since_ts = params[:since].to_i
           return render_error("invalid since parameter") if since_ts < 0

--- a/app/controllers/api/admin/v1/heartbeats_controller.rb
+++ b/app/controllers/api/admin/v1/heartbeats_controller.rb
@@ -4,59 +4,22 @@ module Api
       class HeartbeatsController < Api::Admin::V1::ApplicationController
         MAX_LIMIT = 10_000
         DEFAULT_LIMIT = 1_000
+        ALT_CANDIDATES_LIMIT = 5_000
+        MAX_LOOKBACK_DAYS = 365
+        DEFAULT_LOOKBACK_DAYS = 30
 
         def ip_machine_pairs
-          lookback_days = (params[:lookback_days] || 30).to_i.clamp(1, 365)
-          limit = parse_limit
-          cutoff = lookback_days.days.ago.to_i
+          render json: { pairs: ip_machine_pair_rows(limit: parse_limit) }
+        end
 
-          query = <<-SQL
-            SELECT
-              r1.user_id  AS user_a_id,
-              r2.user_id  AS user_b_id,
-              r1.machine,
-              r1.ip_address,
-              r1.first_seen AS user_a_first_seen,
-              r1.last_seen  AS user_a_last_seen,
-              r2.first_seen AS user_b_first_seen,
-              r2.last_seen  AS user_b_last_seen
-            FROM (
-              SELECT user_id, machine, ip_address,
-                     MIN(time) AS first_seen, MAX(time) AS last_seen
-              FROM heartbeats
-              WHERE user_id IS NOT NULL
-                AND machine IS NOT NULL
-                AND ip_address IS NOT NULL
-                AND deleted_at IS NULL
-                AND time > ?
-              GROUP BY user_id, machine, ip_address
-            ) r1
-            JOIN (
-              SELECT user_id, machine, ip_address,
-                     MIN(time) AS first_seen, MAX(time) AS last_seen
-              FROM heartbeats
-              WHERE user_id IS NOT NULL
-                AND machine IS NOT NULL
-                AND ip_address IS NOT NULL
-                AND deleted_at IS NULL
-                AND time > ?
-              GROUP BY user_id, machine, ip_address
-            ) r2 ON r1.machine = r2.machine AND r1.ip_address = r2.ip_address
-            WHERE r1.user_id < r2.user_id
-            LIMIT ?
-          SQL
-
-          result = ActiveRecord::Base.connection.exec_query(
-            ActiveRecord::Base.sanitize_sql([ query, cutoff, cutoff, limit ])
-          )
-
-          render json: { pairs: result.to_a }
+        def alt_candidates
+          candidates = ip_machine_pair_rows(limit: ALT_CANDIDATES_LIMIT).map { |pair| serialize_alt_candidate(pair) }
+          render json: { candidates: candidates }
         end
 
         def shared_machines
-          lookback_days = (params[:lookback_days] || 30).to_i.clamp(1, 365)
           limit = parse_limit
-          cutoff = lookback_days.days.ago.to_i
+          cutoff = lookback_cutoff
 
           query = <<-SQL
             SELECT
@@ -90,6 +53,62 @@ module Api
         end
 
         private
+
+        def ip_machine_pair_rows(limit:)
+          query = <<-SQL
+            WITH user_machine_ip_activity AS (
+              SELECT
+                user_id,
+                machine,
+                ip_address,
+                MIN(time) AS first_seen,
+                MAX(time) AS last_seen
+              FROM heartbeats
+              WHERE user_id IS NOT NULL
+                AND machine IS NOT NULL
+                AND ip_address IS NOT NULL
+                AND deleted_at IS NULL
+                AND time > ?
+              GROUP BY user_id, machine, ip_address
+            )
+            SELECT
+              r1.user_id AS user_a_id,
+              r2.user_id AS user_b_id,
+              r1.machine,
+              r1.ip_address,
+              r1.first_seen AS user_a_first_seen,
+              r1.last_seen AS user_a_last_seen,
+              r2.first_seen AS user_b_first_seen,
+              r2.last_seen AS user_b_last_seen
+            FROM user_machine_ip_activity r1
+            JOIN user_machine_ip_activity r2
+              ON r1.machine = r2.machine AND r1.ip_address = r2.ip_address
+            WHERE r1.user_id < r2.user_id
+            LIMIT ?
+          SQL
+
+          ActiveRecord::Base.connection.exec_query(
+            ActiveRecord::Base.sanitize_sql([ query, lookback_cutoff, limit ])
+          ).to_a
+        end
+
+        def serialize_alt_candidate(pair)
+          {
+            "user_a_id" => pair["user_a_id"],
+            "user_b_id" => pair["user_b_id"],
+            "machine" => pair["machine"],
+            "ip_address" => pair["ip_address"],
+            "user_a_first_seen_on_combo" => pair["user_a_first_seen"],
+            "user_a_last_seen_on_combo" => pair["user_a_last_seen"],
+            "user_b_first_seen_on_combo" => pair["user_b_first_seen"],
+            "user_b_last_seen_on_combo" => pair["user_b_last_seen"]
+          }
+        end
+
+        def lookback_cutoff
+          lookback_days = (params[:lookback_days] || DEFAULT_LOOKBACK_DAYS).to_i.clamp(1, MAX_LOOKBACK_DAYS)
+          lookback_days.days.ago.to_i
+        end
 
         def parse_limit
           return DEFAULT_LIMIT unless params[:limit].present?

--- a/app/controllers/api/admin/v1/heartbeats_controller.rb
+++ b/app/controllers/api/admin/v1/heartbeats_controller.rb
@@ -13,7 +13,7 @@ module Api
         end
 
         def alt_candidates
-          candidates = ip_machine_pair_rows(limit: ALT_CANDIDATES_LIMIT).map { |pair| serialize_alt_candidate(pair) }
+          candidates = ip_machine_pair_rows(limit: ALT_CANDIDATES_LIMIT, inclusive_cutoff: true).map { |pair| serialize_alt_candidate(pair) }
           render json: { candidates: candidates }
         end
 
@@ -54,7 +54,8 @@ module Api
 
         private
 
-        def ip_machine_pair_rows(limit:)
+        def ip_machine_pair_rows(limit:, inclusive_cutoff: false)
+          cutoff_operator = inclusive_cutoff ? ">=" : ">"
           query = <<-SQL
             WITH user_machine_ip_activity AS (
               SELECT
@@ -68,7 +69,7 @@ module Api
                 AND machine IS NOT NULL
                 AND ip_address IS NOT NULL
                 AND deleted_at IS NULL
-                AND time > ?
+                AND time #{cutoff_operator} ?
               GROUP BY user_id, machine, ip_address
             )
             SELECT

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -325,7 +325,7 @@ Rails.application.routes.draw do
         get "timeline/search_users", to: "timeline#search_users"
         get "timeline/leaderboard_users", to: "timeline#leaderboard_users"
         get "users/:id/visualization/quantized", to: "admin#visualization_quantized"
-        get "alts/candidates", to: "admin#alt_candidates"
+        get "alts/candidates", to: "heartbeats#alt_candidates"
         get "alts/shared_machines", to: "heartbeats#shared_machines"
         get "users/active", to: "admin#active_users"
         post "audit_logs/counts", to: "admin#audit_logs_counts"

--- a/spec/requests/api/admin/v1/admin_misc_spec.rb
+++ b/spec/requests/api/admin/v1/admin_misc_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe 'Api::Admin::V1::AdminMisc', type: :request, openapi_spec: 'admin
   path '/api/admin/v1/alts/candidates' do
     get('List potential alt-account candidates') do
       tags 'Admin'
-      description 'Returns pairs of users that have shared the same machine + IP address within the lookback window. Capped at 5000 candidate pairs.'
+      description 'Compatibility endpoint for the machine and IP pair report. Preserves the legacy candidate response keys and caps results at 5000 pairs.'
       security [ AdminToken: [] ]
       produces 'application/json'
 
@@ -102,10 +102,26 @@ RSpec.describe 'Api::Admin::V1::AdminMisc', type: :request, openapi_spec: 'admin
           }
 
         let(:Authorization) { "Bearer dev-admin-api-key-12345" }
+        let(:user_a) { create(:user, :with_email) }
+        let(:user_b) { create(:user, :with_email) }
         let(:lookback_days) { 30 }
+
+        before do
+          create(:heartbeat, user: user_a, machine: 'legacy-candidate-box', ip_address: '192.0.2.2')
+          create(:heartbeat, user: user_b, machine: 'legacy-candidate-box', ip_address: '192.0.2.2')
+        end
+
         run_test! do |response|
           body = JSON.parse(response.body)
           expect(body['candidates']).to be_an(Array)
+          candidate = body['candidates'].find do |record|
+            [ record['user_a_id'], record['user_b_id'] ].sort == [ user_a.id, user_b.id ].sort
+          end
+          expect(candidate.keys).to match_array(%w[
+            user_a_id user_b_id machine ip_address
+            user_a_first_seen_on_combo user_a_last_seen_on_combo
+            user_b_first_seen_on_combo user_b_last_seen_on_combo
+          ])
         end
       end
 

--- a/spec/requests/api/admin/v1/heartbeats_spec.rb
+++ b/spec/requests/api/admin/v1/heartbeats_spec.rb
@@ -1,14 +1,16 @@
 require 'swagger_helper'
 
 RSpec.describe 'Api::Admin::V1::Heartbeats', type: :request, openapi_spec: 'admin/swagger.yaml' do
+  include ActiveSupport::Testing::TimeHelpers
+
   def create_user(username, email)
     create(:user, :with_email, username: username, email: email)
   end
 
-  def create_heartbeat(user, machine:, ip_address: nil)
+  def create_heartbeat(user, machine:, ip_address: nil, time: Time.current.to_i)
     create(:heartbeat,
       user: user,
-      time: Time.current.to_i,
+      time: time,
       project: 'test',
       language: 'Ruby',
       editor: 'VS Code',
@@ -220,6 +222,31 @@ RSpec.describe 'Api::Admin::V1::Heartbeats', type: :request, openapi_spec: 'admi
         'user_b_first_seen_on_combo' => pair['user_b_first_seen'],
         'user_b_last_seen_on_combo' => pair['user_b_last_seen']
       )
+    end
+
+    it 'preserves the legacy inclusive lookback cutoff' do
+      travel_to(Time.utc(2026, 9, 1, 12)) do
+        user_a = create_user('candidate_cutoff_a', 'candidate_cutoff_a@example.com')
+        user_b = create_user('candidate_cutoff_b', 'candidate_cutoff_b@example.com')
+        cutoff = 30.days.ago.to_i
+        create_heartbeat(user_a, machine: 'candidate-cutoff-box', ip_address: '192.0.2.3', time: cutoff)
+        create_heartbeat(user_b, machine: 'candidate-cutoff-box', ip_address: '192.0.2.3', time: cutoff)
+        headers = { 'Authorization' => 'Bearer dev-admin-api-key-12345' }
+
+        get '/api/admin/v1/heartbeats/ip_machine_pairs', params: { lookback_days: 30 }, headers: headers
+        expect(response).to have_http_status(:ok)
+        pair_ids = JSON.parse(response.body).fetch('pairs').map do |pair|
+          [ pair['user_a_id'], pair['user_b_id'] ]
+        end
+        expect(pair_ids).not_to include([ user_a.id, user_b.id ].sort)
+
+        get '/api/admin/v1/alts/candidates', params: { lookback_days: 30 }, headers: headers
+        expect(response).to have_http_status(:ok)
+        candidate_ids = JSON.parse(response.body).fetch('candidates').map do |candidate|
+          [ candidate['user_a_id'], candidate['user_b_id'] ]
+        end
+        expect(candidate_ids).to include([ user_a.id, user_b.id ].sort)
+      end
     end
   end
 end

--- a/spec/requests/api/admin/v1/heartbeats_spec.rb
+++ b/spec/requests/api/admin/v1/heartbeats_spec.rb
@@ -183,4 +183,43 @@ RSpec.describe 'Api::Admin::V1::Heartbeats', type: :request, openapi_spec: 'admi
       end
     end
   end
+
+  describe 'machine and IP candidate compatibility' do
+    it 'returns equivalent records in each endpoint response shape' do
+      user_a = create_user('candidate_compat_a', 'candidate_compat_a@example.com')
+      user_b = create_user('candidate_compat_b', 'candidate_compat_b@example.com')
+      create_heartbeat(user_a, machine: 'candidate-compat-box', ip_address: '192.0.2.1')
+      create_heartbeat(user_b, machine: 'candidate-compat-box', ip_address: '192.0.2.1')
+      headers = { 'Authorization' => 'Bearer dev-admin-api-key-12345' }
+
+      get '/api/admin/v1/heartbeats/ip_machine_pairs', params: { lookback_days: 30, limit: 5_000 }, headers: headers
+      expect(response).to have_http_status(:ok)
+      pair = JSON.parse(response.body).fetch('pairs').find do |record|
+        [ record['user_a_id'], record['user_b_id'] ] == [ user_a.id, user_b.id ].sort
+      end
+
+      get '/api/admin/v1/alts/candidates', params: { lookback_days: 30 }, headers: headers
+      expect(response).to have_http_status(:ok)
+      candidate = JSON.parse(response.body).fetch('candidates').find do |record|
+        [ record['user_a_id'], record['user_b_id'] ] == [ user_a.id, user_b.id ].sort
+      end
+
+      expect(pair).not_to be_nil
+      expect(candidate).not_to be_nil
+      expect(pair.keys).to match_array(%w[
+        user_a_id user_b_id machine ip_address
+        user_a_first_seen user_a_last_seen user_b_first_seen user_b_last_seen
+      ])
+      expect(candidate).to eq(
+        'user_a_id' => pair['user_a_id'],
+        'user_b_id' => pair['user_b_id'],
+        'machine' => pair['machine'],
+        'ip_address' => pair['ip_address'],
+        'user_a_first_seen_on_combo' => pair['user_a_first_seen'],
+        'user_a_last_seen_on_combo' => pair['user_a_last_seen'],
+        'user_b_first_seen_on_combo' => pair['user_b_first_seen'],
+        'user_b_last_seen_on_combo' => pair['user_b_last_seen']
+      )
+    end
+  end
 end

--- a/swagger/admin/swagger.yaml
+++ b/swagger/admin/swagger.yaml
@@ -89,8 +89,8 @@ paths:
       summary: List potential alt-account candidates
       tags:
       - Admin
-      description: Returns pairs of users that have shared the same machine + IP address
-        within the lookback window. Capped at 5000 candidate pairs.
+      description: Compatibility endpoint for the machine and IP pair report. Preserves
+        the legacy candidate response keys and caps results at 5000 pairs.
       security:
       - AdminToken: []
       parameters:


### PR DESCRIPTION
## Summary of the problem

The alt candidate and heartbeat machine/IP endpoints maintained separate copies of the same aggregate query. Their aliases and limit handling had drifted despite reporting the same records.

## Describe your changes

Moves the bounded machine/IP candidate query into the heartbeat API controller. Both routes remain available: the heartbeat endpoint returns its existing pair shape while the legacy alt endpoint serialises the same rows with its existing wrapper and timestamp keys.

Adds request coverage comparing equivalent records from both routes and documents the compatibility contract in the generated admin API specification.

## Screenshots / Media

Not applicable. This is an API-only change.