### PR TITLE
Replace manual goal requests with Inertia forms

### DIFF
--- a/app/javascript/pages/Users/Settings/Goals.svelte
+++ b/app/javascript/pages/Users/Settings/Goals.svelte
@@ -4,7 +4,7 @@
 </script>
 
 <script lang="ts">
-  import { router } from "@inertiajs/svelte";
+  import { Form } from "@inertiajs/svelte";
   import { secondsToDisplay } from "../../../utils";
   import Button from "../../../components/Button.svelte";
   import Modal from "../../../components/Modal.svelte";
@@ -76,7 +76,6 @@
   let selectedPeriod = $state<ProgrammingGoal["period"]>(defaultPeriod());
   let selectedLanguages = $state<string[]>([]);
   let selectedProjects = $state<string[]>([]);
-  let submitting = $state(false);
 
   $effect(() => {
     goalModalOpen = goal_form?.open ?? false;
@@ -130,48 +129,9 @@
     goalModalOpen = true;
   }
 
-  function submit(
-    method: "patch" | "post" | "delete",
-    url: string,
-    data: Record<string, unknown> = {},
-  ) {
-    if (submitting) return;
-    submitting = true;
-    const options = {
-      preserveScroll: true,
-      onSuccess: () => {
-        goalModalOpen = false;
-        editingGoal = null;
-      },
-      onFinish: () => {
-        submitting = false;
-      },
-    };
-    if (method === "delete") {
-      router.delete(url, options);
-    } else {
-      router[method](url, data as never, options);
-    }
-  }
-
-  function saveGoal() {
-    const data = {
-      goal: {
-        period: selectedPeriod,
-        target_seconds: currentTargetSeconds,
-        languages: selectedLanguages,
-        projects: selectedProjects,
-      },
-    };
-    if (editingGoal) {
-      submit(
-        "patch",
-        settingsGoals.update.path({ goalId: editingGoal.id }),
-        data,
-      );
-    } else {
-      submit("post", settingsGoals.create.path(), data);
-    }
+  function closeGoalModal() {
+    goalModalOpen = false;
+    editingGoal = null;
   }
 </script>
 
@@ -226,24 +186,26 @@
               size="xs"
               class="rounded-md"
               onclick={() => openEditModal(goal)}
-              disabled={submitting}
             >
               Edit
             </Button>
-            <Button
-              type="button"
-              variant="surface"
-              size="xs"
-              class="rounded-md"
-              onclick={() =>
-                submit(
-                  "delete",
-                  settingsGoals.destroy.path({ goalId: goal.id }),
-                )}
-              disabled={submitting}
+            <Form
+              action={settingsGoals.destroy.path({ goalId: goal.id })}
+              method="delete"
+              options={{ preserveScroll: true }}
             >
-              Delete
-            </Button>
+              {#snippet children({ processing })}
+                <Button
+                  type="submit"
+                  variant="surface"
+                  size="xs"
+                  class="rounded-md"
+                  disabled={processing}
+                >
+                  {processing ? "Deleting..." : "Delete"}
+                </Button>
+              {/snippet}
+            </Form>
           </div>
         </article>
       {/each}
@@ -263,7 +225,7 @@
       variant="primary"
       class="rounded-md px-3 py-2"
       onclick={openCreateModal}
-      disabled={hasReachedGoalLimit || submitting}
+      disabled={hasReachedGoalLimit}
     >
       New goal
     </Button>
@@ -351,24 +313,53 @@
   {/snippet}
 
   {#snippet actions()}
-    <div class="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
-      <Button
-        type="button"
-        variant="dark"
-        class="h-10 rounded-md border border-surface-300 text-muted"
-        onclick={() => (goalModalOpen = false)}
-      >
-        Cancel
-      </Button>
-      <Button
-        type="button"
-        variant="primary"
-        class="h-10 rounded-md"
-        onclick={saveGoal}
-        disabled={submitting}
-      >
-        {submitting ? "Saving..." : editingGoal ? "Update Goal" : "Create Goal"}
-      </Button>
-    </div>
+    <Form
+      action={editingGoal
+        ? settingsGoals.update.path({ goalId: editingGoal.id })
+        : settingsGoals.create.path()}
+      method={editingGoal ? "patch" : "post"}
+      options={{ preserveScroll: true }}
+      onSuccess={closeGoalModal}
+    >
+      {#snippet children({ processing })}
+        <input type="hidden" name="goal[period]" value={selectedPeriod} />
+        <input
+          type="hidden"
+          name="goal[target_seconds]"
+          value={currentTargetSeconds}
+        />
+        <input type="hidden" name="goal[languages][]" value="" />
+        {#each selectedLanguages as language}
+          <input type="hidden" name="goal[languages][]" value={language} />
+        {/each}
+        <input type="hidden" name="goal[projects][]" value="" />
+        {#each selectedProjects as project}
+          <input type="hidden" name="goal[projects][]" value={project} />
+        {/each}
+
+        <div class="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+          <Button
+            type="button"
+            variant="dark"
+            class="h-10 rounded-md border border-surface-300 text-muted"
+            onclick={() => (goalModalOpen = false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            variant="primary"
+            class="h-10 rounded-md"
+            disabled={processing}
+          >
+            {processing
+              ? "Saving..."
+              : editingGoal
+                ? "Update Goal"
+                : "Create Goal"}
+          </Button>
+        </div>
+      {/snippet}
+    </Form>
   {/snippet}
 </Modal>

--- a/test/controllers/settings_goals_controller_test.rb
+++ b/test/controllers/settings_goals_controller_test.rb
@@ -80,6 +80,41 @@ class SettingsGoalsControllerTest < ActionDispatch::IntegrationTest
     assert_equal 0, user.reload.goals.count
   end
 
+  test "create rejects a duplicate and returns the normalized goal form" do
+    user = create(:user)
+    create(:goal,
+      user: user,
+      period: "day",
+      target_seconds: 2.hours.to_i,
+      languages: [ "Python", "Ruby" ],
+      projects: [ "alpha", "beta" ]
+    )
+    sign_in_as(user)
+
+    post my_settings_goals_create_path, params: {
+      goal: {
+        period: "day",
+        target_seconds: 2.hours.to_i,
+        languages: [ "", "Ruby", "Python" ],
+        projects: [ "", "beta", "alpha" ]
+      }
+    }
+
+    assert_response :unprocessable_entity
+    assert_inertia_component "Users/Settings/Goals"
+    assert_equal 1, user.reload.goals.count
+
+    form = inertia.props["goal_form"]
+    assert_equal true, form["open"]
+    assert_equal "create", form["mode"]
+    assert_nil form["goal_id"]
+    assert_equal "day", form["period"]
+    assert_equal 2.hours.to_i, form["target_seconds"]
+    assert_equal [ "Python", "Ruby" ], form["languages"]
+    assert_equal [ "alpha", "beta" ], form["projects"]
+    assert_includes form["errors"], "duplicate goal"
+  end
+
   test "update saves valid goal changes" do
     user = create(:user)
     goal = create(:goal,

--- a/test/system/settings/goals_settings_test.rb
+++ b/test/system/settings/goals_settings_test.rb
@@ -10,6 +10,7 @@ class GoalsSettingsTest < ApplicationSystemTestCase
   end
 
   test "goals settings can create edit and delete goal" do
+    create_goal_options
     visit my_settings_goals_path
 
     assert_text(/0 Active Goals/i)
@@ -17,23 +18,37 @@ class GoalsSettingsTest < ApplicationSystemTestCase
 
     within("[role='dialog']") do
       click_on "2h"
+    end
+    select_goal_scope "Languages (optional)", "Ruby"
+    select_goal_scope "Projects (optional)", "alpha"
+    within("[role='dialog']") do
       click_on "Create Goal"
     end
 
     assert_text "Goal created."
     assert_text(/1 Active Goal/i)
     assert_text "Daily: 2h"
-    assert_equal 2.hours.to_i, @user.reload.goals.first.target_seconds
+    assert_text "Languages: Ruby AND Projects: alpha"
+
+    goal = @user.reload.goals.first
+    assert_equal 2.hours.to_i, goal.target_seconds
+    assert_equal [ "Ruby" ], goal.languages
+    assert_equal [ "alpha" ], goal.projects
 
     click_on "Edit"
     within("[role='dialog']") do
       click_on "30m"
+      all("button", text: "×", exact_text: true).each(&:click)
       click_on "Update Goal"
     end
 
     assert_text "Goal updated."
     assert_text "Daily: 30m"
-    assert_equal 30.minutes.to_i, @user.reload.goals.first.target_seconds
+
+    goal.reload
+    assert_equal 30.minutes.to_i, goal.target_seconds
+    assert_equal [], goal.languages
+    assert_equal [], goal.projects
 
     click_on "Delete"
     assert_text "Goal deleted."
@@ -41,18 +56,37 @@ class GoalsSettingsTest < ApplicationSystemTestCase
     assert_equal 0, @user.reload.goals.count
   end
 
-  test "goals settings rejects duplicate goal" do
-    create(:goal, user: @user, period: "day", target_seconds: 2.hours.to_i, languages: [], projects: [])
+  test "goals settings keeps the normalized form open after a duplicate goal response" do
+    create_goal_options
+    create(:goal,
+      user: @user,
+      period: "day",
+      target_seconds: 2.hours.to_i,
+      languages: [ "Python", "Ruby" ],
+      projects: [ "alpha", "beta" ]
+    )
 
     visit my_settings_goals_path
     click_on "New goal"
 
     within("[role='dialog']") do
       click_on "2h"
+    end
+    select_goal_scope "Languages (optional)", "Ruby", "Python"
+    select_goal_scope "Projects (optional)", "beta", "alpha"
+    within("[role='dialog']") do
       click_on "Create Goal"
     end
 
     assert_text "duplicate goal"
+    assert_selector "[role='dialog']"
+
+    within("[role='dialog']") do
+      assert_button "Create Goal"
+      assert_equal [ "", "Python", "Ruby" ], hidden_goal_values("languages")
+      assert_equal [ "", "alpha", "beta" ], hidden_goal_values("projects")
+    end
+
     assert_equal 1, @user.reload.goals.count
   end
 
@@ -76,5 +110,39 @@ class GoalsSettingsTest < ApplicationSystemTestCase
     assert_text(/5 Active Goals/i)
     assert_button "New goal", disabled: true
     assert_equal 5, @user.reload.goals.count
+  end
+
+  private
+
+  def create_goal_options
+    create(:heartbeat,
+      user: @user,
+      language: "Python",
+      project: "alpha",
+      time: 2.minutes.ago.to_f
+    )
+    create(:heartbeat,
+      user: @user,
+      language: "Ruby",
+      project: "beta",
+      time: 1.minute.ago.to_f
+    )
+  end
+
+  def select_goal_scope(label, *values)
+    find("p", text: label, exact_text: true)
+      .find(:xpath, "..")
+      .find(".group")
+      .click
+
+    values.each do |value|
+      find(".dashboard-select-popover button", text: value, exact_text: true).click
+    end
+
+    page.send_keys(:escape)
+  end
+
+  def hidden_goal_values(field)
+    all("input[name='goal[#{field}][]']", visible: :all).map { |input| input[:value] }
   end
 end


### PR DESCRIPTION
## Summary of the problem

The goals settings page manually dispatched create, update and delete requests through a shared router helper and processing lock. This obscured the submitted form shape and coupled otherwise independent actions.

## Describe your changes

Replace the shared request machinery with a create or update Inertia Form in the modal and an independent delete Form for each goal. Submit Rails-compatible nested array fields, including empty array sentinels so filters can be cleared. Keep server-provided `goal_form` resynchronisation after a 422 and close the modal only after a successful save.

Extend controller and system coverage for scoped create, edit and delete payloads plus duplicate goal normalisation after a 422 response.

## Screenshots / Media

No visual changes.
