### PR TITLE
Fix settings form state ownership

### DIFF
--- a/app/javascript/pages/Users/Settings/Editors.svelte
+++ b/app/javascript/pages/Users/Settings/Editors.svelte
@@ -24,9 +24,15 @@
 
   let { user, options }: Props = $props();
 
-  let goalsDisabled = $derived(
-    user.hackatime_extension_text_type !== "simple_text",
-  );
+  let extensionTextType = $state("");
+  let showGoalsInStatusbar = $state(false);
+
+  $effect(() => {
+    extensionTextType = user.hackatime_extension_text_type;
+    showGoalsInStatusbar = user.show_goals_in_statusbar;
+  });
+
+  let goalsDisabled = $derived(extensionTextType !== "simple_text");
 </script>
 
 <svelte:head>
@@ -49,14 +55,14 @@
       <Select
         id="extension_type"
         name="user[hackatime_extension_text_type]"
-        bind:value={user.hackatime_extension_text_type}
+        bind:value={extensionTextType}
         items={options.extension_text_types}
       />
     </FormField>
 
     <CheckboxField
       name="user[show_goals_in_statusbar]"
-      bind:checked={user.show_goals_in_statusbar}
+      bind:checked={showGoalsInStatusbar}
       disabled={goalsDisabled}
       align="start"
       label="Show daily goal in status bar"

--- a/app/javascript/pages/Users/Settings/Editors.svelte
+++ b/app/javascript/pages/Users/Settings/Editors.svelte
@@ -24,8 +24,8 @@
 
   let { user, options }: Props = $props();
 
-  let extensionTextType = $state("");
-  let showGoalsInStatusbar = $state(false);
+  let extensionTextType = $state(user.hackatime_extension_text_type);
+  let showGoalsInStatusbar = $state(user.show_goals_in_statusbar);
 
   $effect(() => {
     extensionTextType = user.hackatime_extension_text_type;

--- a/app/javascript/pages/Users/Settings/Notifications.svelte
+++ b/app/javascript/pages/Users/Settings/Notifications.svelte
@@ -16,7 +16,7 @@
 
   let { user }: Props = $props();
 
-  let weeklySummaryEmailEnabled = $state(false);
+  let weeklySummaryEmailEnabled = $state(user.weekly_summary_email_enabled);
 
   $effect(() => {
     weeklySummaryEmailEnabled = user.weekly_summary_email_enabled;

--- a/app/javascript/pages/Users/Settings/Notifications.svelte
+++ b/app/javascript/pages/Users/Settings/Notifications.svelte
@@ -15,6 +15,12 @@
   };
 
   let { user }: Props = $props();
+
+  let weeklySummaryEmailEnabled = $state(false);
+
+  $effect(() => {
+    weeklySummaryEmailEnabled = user.weekly_summary_email_enabled;
+  });
 </script>
 
 <svelte:head>
@@ -36,7 +42,7 @@
     <div id="user_weekly_summary_email">
       <CheckboxField
         name="user[weekly_summary_email_enabled]"
-        bind:checked={user.weekly_summary_email_enabled}
+        bind:checked={weeklySummaryEmailEnabled}
         label="Weekly coding summary email (sent Sundays at 6:30 PM GMT)"
       />
       <p class="mt-2 text-xs text-muted">

--- a/app/javascript/pages/Users/Settings/Privacy.svelte
+++ b/app/javascript/pages/Users/Settings/Privacy.svelte
@@ -42,6 +42,7 @@
     "Something else",
   ];
 
+  let allowPublicStatsLookup = $state(false);
   let rotatingApiKey = $state(false);
   let apiKeyCopied = $state(false);
   let rotateApiKeyModalOpen = $state(false);
@@ -51,6 +52,10 @@
   let canSubmitDeletionRequest = $derived(
     deletionReason.length > 0 && deletionReasonDetails.trim().length > 0,
   );
+
+  $effect(() => {
+    allowPublicStatsLookup = user.allow_public_stats_lookup;
+  });
 
   const rotateApiKey = () => {
     if (rotatingApiKey) return;
@@ -93,7 +98,7 @@
   >
     <CheckboxField
       name="user[allow_public_stats_lookup]"
-      bind:checked={user.allow_public_stats_lookup}
+      bind:checked={allowPublicStatsLookup}
       label="Allow public stats lookup"
     />
   </Form>

--- a/app/javascript/pages/Users/Settings/Privacy.svelte
+++ b/app/javascript/pages/Users/Settings/Privacy.svelte
@@ -42,7 +42,7 @@
     "Something else",
   ];
 
-  let allowPublicStatsLookup = $state(false);
+  let allowPublicStatsLookup = $state(user.allow_public_stats_lookup);
   let rotatingApiKey = $state(false);
   let apiKeyCopied = $state(false);
   let rotateApiKeyModalOpen = $state(false);

--- a/app/javascript/pages/Users/Settings/SlackGithub.svelte
+++ b/app/javascript/pages/Users/Settings/SlackGithub.svelte
@@ -31,7 +31,12 @@
 
   let { user, slack, github }: Props = $props();
 
+  let usesSlackStatus = $state(false);
   let unlinkGithubModalOpen = $state(false);
+
+  $effect(() => {
+    usesSlackStatus = user.uses_slack_status;
+  });
 </script>
 
 <svelte:head>
@@ -62,7 +67,7 @@
     >
       <CheckboxField
         name="user[uses_slack_status]"
-        bind:checked={user.uses_slack_status}
+        bind:checked={usesSlackStatus}
         label="Update my Slack status automatically"
       />
     </Form>

--- a/app/javascript/pages/Users/Settings/SlackGithub.svelte
+++ b/app/javascript/pages/Users/Settings/SlackGithub.svelte
@@ -31,7 +31,7 @@
 
   let { user, slack, github }: Props = $props();
 
-  let usesSlackStatus = $state(false);
+  let usesSlackStatus = $state(user.uses_slack_status);
   let unlinkGithubModalOpen = $state(false);
 
   $effect(() => {

--- a/test/system/settings/editors_settings_test.rb
+++ b/test/system/settings/editors_settings_test.rb
@@ -13,9 +13,29 @@ class EditorsSettingsTest < ApplicationSystemTestCase
     visit my_settings_editors_path
 
     choose_select_option("extension_type", "Clock emoji")
+    assert_selector "[role='checkbox'][disabled]"
     click_on "Save extension settings"
 
     assert_text "Settings updated successfully"
     assert_equal "clock_emoji", @user.reload.hackatime_extension_text_type
+  end
+
+  test "editors settings restores server values after a rejected update" do
+    @user.update!(
+      hackatime_extension_text_type: :simple_text,
+      show_goals_in_statusbar: false
+    )
+
+    visit my_settings_editors_path
+    @user.update_column(:country_code, "ZZ")
+
+    find("[role='checkbox']").click
+    choose_select_option("extension_type", "Clock emoji")
+    click_on "Save extension settings"
+
+    assert_text "Country code is not included in the list"
+
+    choose_select_option("extension_type", "Simple text")
+    assert_selector "[role='checkbox'][aria-checked='false']:not([disabled])"
   end
 end


### PR DESCRIPTION
## Summary of the problem
Settings controls mutated nested Inertia props directly, leaving editable state without a clear local owner or an explicit resynchronisation path when Rails returned fresh props.

## Describe your changes
Editors, Notifications, Privacy and Slack & GitHub now bind through minimal local scalar state that resynchronises from the corresponding user prop. Editors continues to derive the goals control state from the editable display style. Browser coverage verifies dependent state and restoration after a rejected update.

Appearance keeps its overrideable derived theme value because it already follows prop updates without mutating the user prop.

## Screenshots / Media
No visual changes.