### PR TITLE
Add a heartbeat remapping pipeline

### DIFF
--- a/.agents/setup
+++ b/.agents/setup
@@ -27,7 +27,7 @@ if [ -z "$gh_version" ] || ! dpkg --compare-versions "$gh_version" ge "$gh_min_v
   sudo apt-get install -y gh
 fi
 
-if ! command -v docker >/dev/null 2>&1; then
+if ! command -v docker >/dev/null 2>&1 || ! docker compose version >/dev/null 2>&1; then
   echo "==> Installing Docker and Docker Compose"
   sudo install -m 0755 -d /etc/apt/keyrings
   sudo curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc

--- a/app/jobs/heartbeat_remap_job.rb
+++ b/app/jobs/heartbeat_remap_job.rb
@@ -1,0 +1,29 @@
+class HeartbeatRemapJob < ApplicationJob
+  queue_as :default
+
+  include ActiveJob::Continuable
+  include GoodJob::ActiveJobExtensions::Concurrency
+
+  good_job_control_concurrency_with(total_limit: 1, key: "heartbeat_remap_job")
+  retry_on(*HeartbeatRemapRunner::TRANSIENT_ERRORS, wait: 5.seconds, attempts: 5)
+
+  def perform(run_id)
+    run = HeartbeatRemapRun.find_by(id: run_id)
+    return unless run
+
+    step :process_batches, start: 0 do |step|
+      loop do
+        case run.reload.state
+        when "queued", "running"
+          HeartbeatRemapRunner.process_batch!(run)
+        when "rolling_back"
+          HeartbeatRemapRunner.rollback_batch!(run)
+        else
+          break
+        end
+        step.advance!
+      end
+    end
+    HeartbeatRemapRunner.schedule_rollups!(run) if run.completed? || run.rolled_back?
+  end
+end

--- a/app/lib/heartbeat_remapper.rb
+++ b/app/lib/heartbeat_remapper.rb
@@ -1,0 +1,36 @@
+module HeartbeatRemapper
+  class InvalidRule < ArgumentError; end
+
+  WRITABLE_FIELDS = %i[language].freeze
+
+  Result = Data.define(:attributes, :rule_ids)
+
+  REGISTRY = [ AuthoritativeFilename, AuthoritativeExtension, AutoDetected ].freeze
+
+  def self.call(attributes, registry: REGISTRY)
+    corrected = attributes.to_h.deep_symbolize_keys.deep_dup
+    applied = []
+
+    registry.each do |rule|
+      writable_fields = Array(rule::WRITABLE_FIELDS).map(&:to_sym)
+      invalid_fields = writable_fields - WRITABLE_FIELDS
+      if invalid_fields.any?
+        raise InvalidRule, "#{rule} declares forbidden writable fields: #{invalid_fields.join(", ")}"
+      end
+
+      changes = rule.call(corrected.deep_dup).to_h.deep_symbolize_keys
+      undeclared_fields = changes.keys - writable_fields
+      if undeclared_fields.any?
+        raise InvalidRule, "#{rule} changed undeclared fields: #{undeclared_fields.join(", ")}"
+      end
+
+      effective_changes = changes.reject { |field, value| corrected[field] == value }
+      next if effective_changes.empty?
+
+      corrected.merge!(effective_changes)
+      applied << rule::ID
+    end
+
+    Result.new(attributes: corrected, rule_ids: applied.freeze)
+  end
+end

--- a/app/lib/heartbeat_remapper/authoritative_extension.rb
+++ b/app/lib/heartbeat_remapper/authoritative_extension.rb
@@ -1,0 +1,14 @@
+module HeartbeatRemapper
+  class AuthoritativeExtension
+    ID = "language/authoritative-extension/v1"
+    WRITABLE_FIELDS = %i[language].freeze
+    EXTENSIONS = %w[.cjs .jinja .luau .postcss].freeze
+
+    def self.call(attributes)
+      extension = File.extname(attributes[:entity].to_s).downcase
+      return {} unless EXTENSIONS.include?(extension)
+
+      { language: LanguageUtils.detect_from_extension(attributes[:entity]) }
+    end
+  end
+end

--- a/app/lib/heartbeat_remapper/authoritative_filename.rb
+++ b/app/lib/heartbeat_remapper/authoritative_filename.rb
@@ -1,0 +1,14 @@
+module HeartbeatRemapper
+  class AuthoritativeFilename
+    ID = "language/authoritative-filename/v1"
+    WRITABLE_FIELDS = %i[language].freeze
+    LANGUAGES = [ "Dotenv", "Git Attributes", "Ignore List", "Option List" ].freeze
+
+    def self.call(attributes)
+      language = LanguageUtils.detect_from_filename(attributes[:entity])
+      return {} unless LANGUAGES.include?(language)
+
+      { language: }
+    end
+  end
+end

--- a/app/lib/heartbeat_remapper/auto_detected.rb
+++ b/app/lib/heartbeat_remapper/auto_detected.rb
@@ -1,0 +1,12 @@
+module HeartbeatRemapper
+  class AutoDetected
+    ID = "language/auto-detected/v1"
+    WRITABLE_FIELDS = %i[language].freeze
+
+    def self.call(attributes)
+      return {} unless attributes[:language] == "AUTO_DETECTED"
+
+      { language: LanguageUtils.detect_unambiguous_from_entity(attributes[:entity]) || "Unknown" }
+    end
+  end
+end

--- a/app/lib/language_utils.rb
+++ b/app/lib/language_utils.rb
@@ -1,12 +1,6 @@
 module LanguageUtils
   DEFAULT_COLOR = "#888888"
 
-  # Some extensions are silly and report the wrong language for a given entity path.
-  # But, we know better!
-  # This means that we can just override the language when we think it's incorrect, and Hackatime
-  # will be accurate Most Of The Time(tm). Without this, it's the opposite!
-  AUTHORITATIVE_EXTENSIONS = %w[.luau].freeze
-
   def self.data
     @data ||= begin
       base = YAML.load_file(Rails.root.join("config/languages.yml"))
@@ -41,9 +35,21 @@ module LanguageUtils
   end
   private_class_method :build_lookup
 
+  def self.build_unambiguous_lookup(key)
+    owners = Hash.new { |hash, value| hash[value] = [] }
+    data.each do |name, info|
+      (info[key] || []).each { |value| owners[value.downcase] << name }
+    end
+    owners.filter_map { |value, names| [ value, names.first ] if names.uniq.one? }.to_h
+  end
+  private_class_method :build_unambiguous_lookup
+
   def self.alias_map = @alias_map ||= build_lookup("aliases", include_name_as_key: true)
   def self.extension_map = @extension_map ||= build_lookup("extensions")
   def self.filename_map = @filename_map ||= build_lookup("filenames")
+  def self.unambiguous_extension_map = @unambiguous_extension_map ||= build_unambiguous_lookup("extensions")
+  def self.unambiguous_filename_map = @unambiguous_filename_map ||= build_unambiguous_lookup("filenames")
+  private_class_method :unambiguous_extension_map, :unambiguous_filename_map
 
   # Resolve a raw language string to its canonical name.
   def self.find_name(raw)
@@ -63,23 +69,14 @@ module LanguageUtils
 
   def self.detect_from_entity(entity) = detect_from_filename(entity) || detect_from_extension(entity)
 
-  def self.authoritative_language(entity)
-    return nil if entity.blank?
-    return nil unless AUTHORITATIVE_EXTENSIONS.include?(File.extname(entity).downcase)
-    detect_from_extension(entity)
+  def self.detect_unambiguous_from_entity(entity)
+    return if entity.blank?
+
+    unambiguous_filename_map[File.basename(entity).downcase] || unambiguous_extension_map[File.extname(entity).downcase]
   end
 
-  def self.fill_missing_language(raw, entity:)
-    authoritative_language(entity) || legacy_fill_missing_language(raw, entity:)
-  end
-
-  # The pre-override fill, without AUTHORITATIVE_EXTENSIONS. Kept so the import
-  # dedup path can reproduce fields hashes stored before the override existed;
-  # routing those through the override would compute hashes that never existed
-  # and re-importing an old dump would mint duplicate heartbeats.
-  def self.legacy_fill_missing_language(raw, entity:)
-    blank_or_unknown?(raw) ? detect_from_entity(entity) : raw
-  end
+  def self.fill_missing_language(raw, entity:) = blank_or_unknown?(raw) ? detect_unambiguous_from_entity(entity) : raw
+  def self.legacy_fill_missing_language(raw, entity:) = blank_or_unknown?(raw) ? detect_from_entity(entity) : raw
 
   # Canonical display name: "js" → "JavaScript", "cpp" → "C++"
   def self.display_name(raw) = raw.blank? ? "Unknown" : (find_name(raw) || raw)

--- a/app/models/heartbeat.rb
+++ b/app/models/heartbeat.rb
@@ -38,12 +38,16 @@ class Heartbeat < ApplicationRecord
   def self.recent_imported_count = Cache::HeartbeatCountsJob.perform_now[:recent_imported_count]
 
   def self.generate_fields_hash(attributes)
+    Digest::MD5.hexdigest(identity_attributes(attributes).to_json)
+  end
+
+  def self.identity_attributes(attributes)
     attributes = attributes.transform_keys(&:to_s)
-    indexed = attributes.slice(*indexed_attributes)
-    ai_indexed_attributes.each do |attribute|
-      indexed[attribute] = attributes[attribute] unless attributes[attribute].nil?
+    attributes.slice(*indexed_attributes).tap do |indexed|
+      ai_indexed_attributes.each do |attribute|
+        indexed[attribute] = attributes[attribute] unless attributes[attribute].nil?
+      end
     end
-    Digest::MD5.hexdigest(indexed.to_json)
   end
 
   def self.indexed_attributes

--- a/app/models/heartbeat_hash_alias.rb
+++ b/app/models/heartbeat_hash_alias.rb
@@ -1,0 +1,6 @@
+class HeartbeatHashAlias < ApplicationRecord
+  belongs_to :user
+
+  validates :alias_hash, :canonical_hash, :heartbeat_id, presence: true
+  validates :alias_hash, uniqueness: { scope: :user_id }
+end

--- a/app/models/heartbeat_remap_alias_change.rb
+++ b/app/models/heartbeat_remap_alias_change.rb
@@ -1,0 +1,7 @@
+class HeartbeatRemapAliasChange < ApplicationRecord
+  belongs_to :heartbeat_remap_run, inverse_of: :remap_alias_changes
+  belongs_to :user
+
+  validates :heartbeat_id, :alias_hash, :after_heartbeat_id, :after_canonical_hash, presence: true
+  validates :alias_hash, uniqueness: { scope: %i[heartbeat_remap_run_id user_id] }
+end

--- a/app/models/heartbeat_remap_change.rb
+++ b/app/models/heartbeat_remap_change.rb
@@ -1,0 +1,12 @@
+class HeartbeatRemapChange < ApplicationRecord
+  belongs_to :heartbeat_remap_run, inverse_of: :remap_changes
+
+  enum :action, {
+    update: "update",
+    duplicate_soft_delete: "duplicate_soft_delete",
+    unsafe_collision: "unsafe_collision",
+    stale: "stale"
+  }, prefix: true
+
+  validates :heartbeat_id, presence: true
+end

--- a/app/models/heartbeat_remap_run.rb
+++ b/app/models/heartbeat_remap_run.rb
@@ -1,0 +1,26 @@
+class HeartbeatRemapRun < ApplicationRecord
+  DEFAULT_BATCH_SIZE = 1_000
+
+  has_many :remap_changes,
+    class_name: "HeartbeatRemapChange",
+    dependent: :delete_all,
+    inverse_of: :heartbeat_remap_run
+  has_many :remap_alias_changes,
+    class_name: "HeartbeatRemapAliasChange",
+    dependent: :delete_all,
+    inverse_of: :heartbeat_remap_run
+
+  enum :state, {
+    queued: 0,
+    running: 1,
+    completed: 2,
+    failed: 3,
+    rolling_back: 4,
+    rolled_back: 5
+  }
+
+  validates :batch_size, numericality: { only_integer: true, greater_than: 0, less_than_or_equal_to: 10_000 }
+  validates :max_heartbeat_id, presence: true
+
+  def terminal? = completed? || failed? || rolled_back?
+end

--- a/app/services/heartbeat_ingest.rb
+++ b/app/services/heartbeat_ingest.rb
@@ -17,6 +17,7 @@ class HeartbeatIngest
 
   Result = Data.define(:total_count, :persisted_count, :duplicate_count, :failed_count, :errors, :items)
   Item = Data.define(:heartbeat, :status, :error)
+  Normalized = Data.define(:attributes, :pre_remap_hash)
 
   def self.call(...) = new(...).call
   def self.schedule_rollup_refresh(user:) = DashboardRollupRefreshJob.schedule_for(user.id)
@@ -48,7 +49,8 @@ class HeartbeatIngest
     placeholder_state = { contexts: {}, last_project: nil }
 
     @heartbeats.each_with_index do |heartbeat, index|
-      attrs = normalize_direct_heartbeat(heartbeat, placeholder_state:)
+      normalized = normalize_direct_heartbeat(heartbeat, placeholder_state:)
+      attrs = normalized.attributes
       model_attributes = validated_model_attributes(attrs)
       attrs = model_attributes.symbolize_keys
       update_placeholder_state!(attrs, placeholder_state)
@@ -57,7 +59,8 @@ class HeartbeatIngest
         heartbeat:,
         attrs:,
         model_attributes:,
-        fields_hash: Heartbeat.generate_fields_hash(model_attributes)
+        fields_hash: Heartbeat.generate_fields_hash(model_attributes),
+        identity_hashes: [ normalized.pre_remap_hash ]
       }
     rescue => e
       errors << { heartbeat: heartbeat, error: e.message, type: e.class.name }
@@ -111,7 +114,7 @@ class HeartbeatIngest
     attrs[:user_agent] = attrs[:user_agent].presence || attrs.delete(:plugin).presence || @request_context[:user_agent].presence
     parsed_ua = WakatimeUserAgentParser.parse(attrs[:user_agent], category: attrs[:category])
 
-    attrs.merge(
+    normalized = attrs.merge(
       user_id: @user.id,
       source_type:,
       ip_address: @request_context[:ip_address],
@@ -121,12 +124,23 @@ class HeartbeatIngest
       operating_system: parsed_ua[:os].presence || attrs[:operating_system].presence,
       machine: @request_context[:machine].presence || attrs[:machine].presence
     ).slice(*Heartbeat.column_names.map(&:to_sym))
+    pre_remap_hash = fields_hash_for(normalized)
+    result = HeartbeatRemapper.call(normalized)
+    Normalized.new(attributes: result.attributes, pre_remap_hash:)
   end
 
   def persist_direct_heartbeats(entries)
+    result = with_heartbeat_transaction { persist_direct_batch(entries) }
+    if result.second.any? && @schedule_rollup_refresh
+      self.class.schedule_rollup_refresh(user: @user)
+    end
+    result
+  end
+
+  def persist_direct_batch(entries)
     entries_by_hash = entries.group_by { |entry| entry[:fields_hash] }
     hashes = entries_by_hash.keys
-    persisted_by_hash = @user.heartbeats.where(fields_hash: hashes).index_by(&:fields_hash)
+    persisted_by_hash = resolve_heartbeats(entries)
     missing_entries = entries_by_hash.filter_map do |fields_hash, matching_entries|
       matching_entries.first unless persisted_by_hash.key?(fields_hash)
     end
@@ -139,7 +153,7 @@ class HeartbeatIngest
         Heartbeat.insert_all(records, unique_by:, returning: Heartbeat.column_names)
       end
       inserted_by_hash = result.to_a.index_by { |attributes| attributes.fetch("fields_hash") }
-        .transform_values { |attributes| Heartbeat.new(attributes) }
+        .transform_values { |attributes| Heartbeat.instantiate(attributes) }
       persisted_by_hash.merge!(inserted_by_hash)
 
       # Another request can win the conflict after our prefetch but before the
@@ -153,10 +167,7 @@ class HeartbeatIngest
     end
 
     hashes.each { |fields_hash| persisted_by_hash.fetch(fields_hash) }
-    if inserted_by_hash.any? && @schedule_rollup_refresh
-      self.class.schedule_rollup_refresh(user: @user)
-    end
-
+    persist_hash_aliases(entries, persisted_by_hash)
     [ persisted_by_hash, inserted_by_hash.keys ]
   end
 
@@ -171,6 +182,14 @@ class HeartbeatIngest
     heartbeat.validate!
     heartbeat.attributes
   end
+
+  def model_attributes_for(attrs)
+    heartbeat = Heartbeat.new(attrs)
+    heartbeat.user = @user
+    heartbeat.attributes
+  end
+
+  def fields_hash_for(attrs) = Heartbeat.generate_fields_hash(model_attributes_for(attrs))
 
   def direct_insert_record(entry, timestamp:)
     entry[:model_attributes]
@@ -193,7 +212,12 @@ class HeartbeatIngest
       total_count += 1
       attrs = normalize_imported_heartbeat(heartbeat, placeholder_state:)
       existing = seen_hashes[attrs[:fields_hash]]
-      seen_hashes[attrs[:fields_hash]] = attrs if existing.nil? || attrs[:time] > existing[:time]
+      if existing.nil? || attrs[:time] > existing[:time]
+        attrs[:identity_hashes] |= existing[:identity_hashes] if existing
+        seen_hashes[attrs[:fields_hash]] = attrs
+      else
+        existing[:identity_hashes] |= attrs[:identity_hashes]
+      end
     rescue => e
       errors << { heartbeat: heartbeat, error: e.message, type: e.class.name }
     end
@@ -252,17 +276,20 @@ class HeartbeatIngest
     resolve_placeholders!(attrs, placeholder_state)
     attrs[:language] = LanguageUtils.fill_missing_language(attrs[:language], entity: attrs[:entity])
     attrs[:category] = default_category(attrs[:category], type: attrs[:type])
+    pre_remap_hash = import_fields_hash(model_attributes_for(attrs), source: hb)
+    attrs = HeartbeatRemapper.call(attrs).attributes
     model_attributes = validated_model_attributes(attrs)
     normalized = model_attributes
       .except("id", "fields_hash", "created_at", "updated_at", "time_epoch")
       .symbolize_keys
     normalized[:fields_hash] = import_fields_hash(model_attributes, source: hb)
-    normalized[:legacy_fields_hash] = legacy_import_fields_hash(
+    legacy_fields_hash = legacy_import_fields_hash(
       hb,
       user_agent_info:,
       resolved_user_agent:,
       normalized_time: normalized[:time]
     )
+    normalized[:identity_hashes] = [ pre_remap_hash, legacy_fields_hash ].compact.uniq
     update_placeholder_state!(normalized, placeholder_state)
     normalized
   end
@@ -270,28 +297,81 @@ class HeartbeatIngest
   def flush_import_batch(seen_hashes)
     return 0 if seen_hashes.empty?
 
-    records = seen_hashes.values
-    compatible_hashes = records.flat_map { |record| [ record[:fields_hash], record[:legacy_fields_hash] ] }.compact.uniq
-    existing_hashes = compatible_hashes.each_slice(10_000).flat_map do |hashes|
-      @user.heartbeats.where(fields_hash: hashes).pluck(:fields_hash)
-    end.to_set
-    records = records.reject do |record|
-      existing_hashes.include?(record[:fields_hash]) || existing_hashes.include?(record[:legacy_fields_hash])
+    with_heartbeat_transaction { flush_import_records(seen_hashes.values) }
+  end
+
+  def flush_import_records(records)
+    persisted_by_hash = resolve_heartbeats(records)
+    missing_records = records.reject { |record| persisted_by_hash.key?(record[:fields_hash]) }
+    if missing_records.empty?
+      persist_hash_aliases(records, persisted_by_hash)
+      return 0
     end
-    return 0 if records.empty?
 
     timestamp = Time.current
-    ActiveRecord::Base.logger.silence do
+    inserted_by_hash = ActiveRecord::Base.logger.silence do
       # Build records inside the retry block so a cutover-time schema refresh
       # recomputes both the conflict target and the time_epoch partition column.
       with_heartbeat_unique_by do |unique_by|
-        insert_records = records.map do |record|
-          record.except(:legacy_fields_hash)
+        insert_records = missing_records.map do |record|
+          record.except(:identity_hashes)
             .merge(created_at: timestamp, updated_at: timestamp, **partition_attrs(record[:time]))
         end
-        Heartbeat.insert_all(insert_records, unique_by:).length
+        Heartbeat.insert_all(insert_records, unique_by:, returning: Heartbeat.column_names).to_a
       end
+    end.index_by { |attributes| attributes.fetch("fields_hash") }
+      .transform_values { |attributes| Heartbeat.instantiate(attributes) }
+    persisted_by_hash.merge!(inserted_by_hash)
+
+    unresolved_hashes = missing_records.map { |record| record[:fields_hash] } - inserted_by_hash.keys
+    if unresolved_hashes.any?
+      persisted_by_hash.merge!(@user.heartbeats.where(fields_hash: unresolved_hashes).index_by(&:fields_hash))
     end
+    persist_hash_aliases(records, persisted_by_hash)
+    inserted_by_hash.length
+  end
+
+  def resolve_heartbeats(entries)
+    lookup_hashes = entries.flat_map { |entry| [ entry[:fields_hash], *Array(entry[:identity_hashes]) ] }.compact.uniq
+    heartbeats_by_stored_hash = @user.heartbeats.where(fields_hash: lookup_hashes).index_by(&:fields_hash)
+    aliases = HeartbeatHashAlias.where(user_id: @user.id, alias_hash: lookup_hashes).pluck(:alias_hash, :heartbeat_id)
+    heartbeats_by_id = @user.heartbeats.where(id: aliases.map(&:second)).index_by(&:id)
+    heartbeats_by_alias = aliases.to_h { |alias_hash, heartbeat_id| [ alias_hash, heartbeats_by_id[heartbeat_id] ] }.compact
+
+    entries.group_by { |entry| entry[:fields_hash] }.to_h do |fields_hash, matching_entries|
+      heartbeat = heartbeats_by_stored_hash[fields_hash] || heartbeats_by_alias[fields_hash]
+      heartbeat ||= matching_entries
+        .flat_map { |entry| Array(entry[:identity_hashes]) }
+        .filter_map { |identity_hash| heartbeats_by_stored_hash[identity_hash] || heartbeats_by_alias[identity_hash] }
+        .min_by(&:id)
+      [ fields_hash, heartbeat ]
+    end.compact
+  end
+
+  def persist_hash_aliases(entries, persisted_by_hash)
+    timestamp = Time.current
+    records = entries.flat_map do |entry|
+      heartbeat = persisted_by_hash.fetch(entry[:fields_hash])
+      [ entry[:fields_hash], *Array(entry[:identity_hashes]) ].compact.uniq.filter_map do |alias_hash|
+        next if alias_hash == heartbeat.fields_hash
+
+        {
+          user_id: @user.id,
+          heartbeat_id: heartbeat.id,
+          alias_hash:,
+          canonical_hash: heartbeat.fields_hash,
+          created_at: timestamp,
+          updated_at: timestamp
+        }
+      end
+    end.uniq { |record| record.values_at(:user_id, :alias_hash) }
+    return if records.empty?
+
+    HeartbeatHashAlias.upsert_all(
+      records,
+      unique_by: %i[user_id alias_hash],
+      update_only: %i[heartbeat_id canonical_hash]
+    )
   end
 
   # Import normalization is part of the persisted dedup contract. Keep the
@@ -300,6 +380,14 @@ class HeartbeatIngest
   def legacy_import_fields_hash(hb, user_agent_info:, resolved_user_agent:, normalized_time:)
     legacy_user_agent = legacy_parse_user_agent(resolved_user_agent)
     Heartbeat.generate_fields_hash(
+      ai_model: hb[:ai_model],
+      ai_session: hb[:ai_session],
+      ai_subscription_plan: hb[:ai_subscription_plan],
+      ai_input_tokens: hb[:ai_input_tokens],
+      ai_output_tokens: hb[:ai_output_tokens],
+      ai_prompt_length: hb[:ai_prompt_length],
+      ai_line_changes: hb[:ai_line_changes],
+      human_line_changes: hb[:human_line_changes],
       user_id: @user.id,
       time: normalized_time,
       entity: hb[:entity],
@@ -378,6 +466,20 @@ class HeartbeatIngest
 
     Rails.logger.warn("HeartbeatIngest unique_by fallback: #{e.class}: #{e.message}")
     yield heartbeat_unique_by
+  end
+
+  def with_heartbeat_transaction
+    retried = false
+    begin
+      Heartbeat.transaction { yield }
+    rescue ActiveRecord::StatementInvalid, ArgumentError => e
+      raise if retried
+
+      retried = true
+      Heartbeat.reset_column_information
+      Rails.logger.warn("HeartbeatIngest transaction schema retry: #{e.class}: #{e.message}")
+      retry
+    end
   end
 
   def normalize_epoch_time(value)

--- a/app/services/heartbeat_remap_runner.rb
+++ b/app/services/heartbeat_remap_runner.rb
@@ -1,0 +1,594 @@
+class HeartbeatRemapRunner
+  SNAPSHOT_FIELDS = %w[user_id language fields_hash deleted_at time_epoch].freeze
+  ACTIVE_STATES = %w[queued running].freeze
+  TRANSIENT_ERRORS = [
+    ActiveRecord::Deadlocked,
+    ActiveRecord::SerializationFailure,
+    ActiveRecord::RecordNotUnique
+  ].freeze
+
+  def self.start!(dry_run: true, batch_size: HeartbeatRemapRun::DEFAULT_BATCH_SIZE)
+    HeartbeatRemapRun.create!(
+      dry_run:,
+      batch_size:,
+      max_heartbeat_id: Heartbeat.with_deleted.maximum(:id) || 0,
+      rule_ids: HeartbeatRemapper::REGISTRY.map { |rule| rule::ID }
+    )
+  end
+
+  def self.process_batch!(run)
+    affected_user_ids = []
+
+    begin
+      HeartbeatRemapRun.transaction do
+        run.lock!
+        return run unless ACTIVE_STATES.include?(run.state)
+        unless run.rule_ids == HeartbeatRemapper::REGISTRY.map { |rule| rule::ID }
+          raise ArgumentError, "Heartbeat remap rules changed after this run started"
+        end
+
+        run.update_columns(state: HeartbeatRemapRun.states.fetch("running"), started_at: run.started_at || Time.current)
+        ids = candidate_ids(run)
+        if ids.empty?
+          complete!(run)
+          next
+        end
+
+        heartbeats = Heartbeat.with_deleted.where(id: ids).order(:id).lock.to_a
+        users_by_id = User.where(id: heartbeats.map(&:user_id)).index_by(&:id)
+        plans = heartbeats.filter_map { |heartbeat| build_plan(heartbeat, users_by_id[heartbeat.user_id]) }
+        collision_rows = Heartbeat.where(fields_hash: plans.map { |plan| plan[:post_hash] }.uniq)
+          .where.not(id: plans.map { |plan| plan[:heartbeat].id }).order(:id).lock.to_a
+
+        outcome = plan_outcome(plans, collision_rows, dry_run: run.dry_run?)
+        alias_changes = plan_alias_changes(outcome)
+        persist_changes(run, outcome[:audits])
+        persist_alias_changes(run, alias_changes)
+        unless run.dry_run?
+          bulk_update_heartbeats(outcome[:updates])
+          apply_alias_changes(alias_changes)
+          affected_user_ids = outcome[:updates].filter_map { |update| update[:active_change] ? update[:user_id] : nil }.uniq
+        end
+
+        run.update_columns(
+          cursor_id: ids.last,
+          scanned_count: run.scanned_count + ids.length,
+          changed_count: run.changed_count + plans.length,
+          deduplicated_count: run.deduplicated_count + outcome[:deduplicated_count],
+          stale_count: run.stale_count + outcome[:stale_count],
+          unsafe_count: run.unsafe_count + outcome[:unsafe_count],
+          updated_at: Time.current
+        )
+        complete!(run) if ids.last >= run.max_heartbeat_id
+      end
+    rescue *TRANSIENT_ERRORS
+      raise
+    rescue => error
+      run.update_columns(
+        state: HeartbeatRemapRun.states.fetch("failed"),
+        error_count: run.error_count + 1,
+        error_message: error.message,
+        finished_at: Time.current,
+        updated_at: Time.current
+      ) if run.persisted?
+      raise
+    end
+
+    affected_user_ids.each { |user_id| DashboardRollupRefreshJob.schedule_for(user_id) }
+    run
+  end
+
+  def self.start_rollback!(run)
+    raise ArgumentError, "Dry runs do not change heartbeats" if run.dry_run?
+    raise ArgumentError, "Only completed runs can be rolled back" unless run.completed?
+
+    run.update!(
+      state: :rolling_back,
+      finished_at: nil,
+      error_message: nil
+    )
+  end
+
+  def self.rollback_batch!(run)
+    affected_user_ids = []
+
+    HeartbeatRemapRun.transaction do
+      run.lock!
+      return run unless run.rolling_back?
+
+      changes = pending_rollback_changes(run)
+      if changes.empty?
+        finish_rollback!(run)
+        next
+      end
+
+      heartbeats_by_id = Heartbeat.with_deleted.where(id: changes.map(&:heartbeat_id)).order(:id).lock.index_by(&:id)
+      updates = []
+      stale_count = 0
+      changes.each do |change|
+        heartbeat = heartbeats_by_id[change.heartbeat_id]
+        next unless change.action_update? || change.action_duplicate_soft_delete?
+
+        unless heartbeat && snapshot_matches?(heartbeat, change.postimage)
+          stale_count += 1
+          next
+        end
+
+        updates << update_from_snapshot(heartbeat, change.preimage)
+      end
+
+      updates, collision_stale_count = reject_occupied_restores(updates)
+      stale_count += collision_stale_count
+      bulk_update_heartbeats(updates)
+      alias_changes = run.remap_alias_changes.where(heartbeat_id: changes.map(&:heartbeat_id), rolled_back_at: nil).lock.to_a
+      alias_stale_count = rollback_alias_changes(alias_changes, restored_heartbeat_ids: updates.map { |update| update[:id] })
+      stale_count += alias_stale_count
+      affected_user_ids = updates.map { |update| update[:user_id] }.uniq
+      now = Time.current
+      HeartbeatRemapChange.where(id: changes.map(&:id)).update_all(rolled_back_at: now, updated_at: now)
+      HeartbeatRemapAliasChange.where(id: alias_changes.map(&:id)).update_all(rolled_back_at: now, updated_at: now)
+      run.update_columns(
+        stale_count: run.stale_count + stale_count,
+        updated_at: now
+      )
+      finish_rollback!(run) unless run.remap_changes.where(rolled_back_at: nil).exists?
+    end
+
+    affected_user_ids.each { |user_id| DashboardRollupRefreshJob.schedule_for(user_id) }
+    run
+  end
+
+  def self.schedule_rollups!(run)
+    return if run.dry_run?
+
+    affected_users = run.remap_changes.where(action: %w[update duplicate_soft_delete])
+      .where("preimage ->> 'deleted_at' IS NULL")
+      .select("(preimage ->> 'user_id')::bigint")
+    User.where(id: affected_users).select(:id).find_each(batch_size: run.batch_size) do |user|
+      DashboardRollupRefreshJob.schedule_for(user.id)
+    end
+  end
+
+  def self.candidate_ids(run)
+    Heartbeat.with_deleted
+      .where(id: (run.cursor_id + 1)..run.max_heartbeat_id)
+      .order(:id).limit(run.batch_size).pluck(:id)
+  end
+  private_class_method :candidate_ids
+
+  def self.pending_rollback_changes(run)
+    pending = run.remap_changes.where(rolled_back_at: nil)
+    action = %w[update duplicate_soft_delete].find { |candidate| pending.where(action: candidate).exists? }
+    pending = pending.where(action:) if action
+    pending.order(id: :desc).limit(run.batch_size).to_a
+  end
+  private_class_method :pending_rollback_changes
+
+  def self.build_plan(heartbeat, user)
+    result = HeartbeatRemapper.call(heartbeat.attributes)
+    return if result.rule_ids.empty?
+
+    corrected = heartbeat.dup
+    corrected.assign_attributes(result.attributes.slice(*HeartbeatRemapper::WRITABLE_FIELDS))
+    corrected.user = user
+    unless corrected.valid?
+      return {
+        heartbeat:,
+        preimage: snapshot_for(heartbeat),
+        postimage: snapshot_for(heartbeat),
+        rule_ids: result.rule_ids,
+        stale: true
+      }
+    end
+
+    post_hash = Heartbeat.generate_fields_hash(corrected.attributes)
+    {
+      heartbeat:,
+      preimage: snapshot_for(heartbeat),
+      corrected_attributes: result.attributes.slice(*HeartbeatRemapper::WRITABLE_FIELDS),
+      post_hash:,
+      post_identity: Heartbeat.identity_attributes(corrected.attributes),
+      rule_ids: result.rule_ids
+    }
+  end
+  private_class_method :build_plan
+
+  def self.plan_outcome(plans, collision_rows, dry_run:)
+    outcome = {
+      audits: [], updates: [], aliases: [], alias_redirects: [],
+      deduplicated_count: 0, stale_count: 0, unsafe_count: 0
+    }
+    stale_plans, valid_plans = plans.partition { |plan| plan[:stale] }
+    stale_plans.each do |plan|
+      outcome[:audits] << audit_for(plan[:heartbeat], :stale, plan[:rule_ids], plan[:preimage], plan[:postimage])
+      outcome[:stale_count] += 1
+    end
+
+    valid_plans.partition { |plan| plan[:heartbeat].deleted_at.present? }.then do |deleted_plans, active_plans|
+      deleted_plans.each { |plan| add_update(outcome, plan, dry_run:) }
+      active_plans.group_by { |plan| plan[:post_hash] }.each_value do |group|
+        collisions = collision_rows.select { |heartbeat| heartbeat.fields_hash == group.first[:post_hash] }
+        identities = group.map { |plan| plan[:post_identity] } + collisions.map { |heartbeat| Heartbeat.identity_attributes(heartbeat.attributes) }
+        unless identities.all? { |identity| identity == identities.first }
+          group.each do |plan|
+            outcome[:audits] << audit_for(
+              plan[:heartbeat], :unsafe_collision, plan[:rule_ids], plan[:preimage], plan[:preimage]
+            )
+            outcome[:unsafe_count] += 1
+          end
+          next
+        end
+
+        winner = (group.map { |plan| plan[:heartbeat] } + collisions).min_by(&:id)
+        group.each do |plan|
+          if plan[:heartbeat].id == winner.id
+            add_update(outcome, plan, dry_run:)
+          else
+            add_duplicate(
+              outcome, plan[:heartbeat], winner, plan[:rule_ids], plan[:post_hash],
+              language: group.first[:corrected_attributes][:language], dry_run:
+            )
+          end
+        end
+        collisions.reject { |heartbeat| heartbeat.id == winner.id }.each do |heartbeat|
+          add_duplicate(
+            outcome, heartbeat, winner, group.first[:rule_ids], group.first[:post_hash],
+            language: group.first[:corrected_attributes][:language], dry_run:
+          )
+        end
+      end
+    end
+    outcome
+  end
+  private_class_method :plan_outcome
+
+  def self.add_update(outcome, plan, dry_run:)
+    heartbeat = plan[:heartbeat]
+    postimage = plan[:preimage].merge(
+      "language" => plan[:corrected_attributes][:language],
+      "fields_hash" => plan[:post_hash]
+    )
+    outcome[:audits] << audit_for(heartbeat, :update, plan[:rule_ids], plan[:preimage], postimage)
+    return if dry_run
+
+    outcome[:updates] << {
+      id: heartbeat.id,
+      time_epoch: heartbeat.attributes["time_epoch"],
+      user_id: heartbeat.user_id,
+      language: plan[:corrected_attributes][:language],
+      fields_hash: plan[:post_hash],
+      deleted_at: heartbeat.deleted_at,
+      active_change: heartbeat.deleted_at.nil?
+    }
+    outcome[:aliases] << alias_for(
+      heartbeat, heartbeat.fields_hash, plan[:post_hash], heartbeat_id: heartbeat.id
+    )
+  end
+  private_class_method :add_update
+
+  def self.add_duplicate(outcome, heartbeat, winner, rule_ids, post_hash, language:, dry_run:)
+    preimage = snapshot_for(heartbeat)
+    postimage = preimage.merge("language" => language, "fields_hash" => post_hash, "deleted_at" => Time.current)
+    outcome[:audits] << audit_for(heartbeat, :duplicate_soft_delete, rule_ids, preimage, postimage, winner:)
+    outcome[:deduplicated_count] += 1
+    return if dry_run
+
+    outcome[:updates] << {
+      id: heartbeat.id,
+      time_epoch: heartbeat.attributes["time_epoch"],
+      user_id: heartbeat.user_id,
+      language:,
+      fields_hash: post_hash,
+      deleted_at: postimage["deleted_at"],
+      active_change: true,
+      soft_delete_first: true
+    }
+    outcome[:aliases] << alias_for(winner, heartbeat.fields_hash, post_hash, heartbeat_id: heartbeat.id)
+    outcome[:alias_redirects] << {
+      loser_id: heartbeat.id,
+      winner_id: winner.id,
+      canonical_hash: post_hash,
+      heartbeat_id: heartbeat.id
+    }
+  end
+  private_class_method :add_duplicate
+
+  def self.audit_for(heartbeat, action, rule_ids, preimage, postimage, winner: nil)
+    {
+      heartbeat_id: heartbeat.id,
+      winner_heartbeat_id: winner&.id,
+      action: action.to_s,
+      rule_ids:,
+      preimage:,
+      postimage:
+    }
+  end
+  private_class_method :audit_for
+
+  def self.persist_changes(run, audits)
+    return if audits.empty?
+
+    now = Time.current
+    HeartbeatRemapChange.insert_all(
+      audits.map { |audit| audit.merge(heartbeat_remap_run_id: run.id, created_at: now, updated_at: now) },
+      unique_by: :index_heartbeat_remap_changes_on_run_and_heartbeat
+    )
+  end
+  private_class_method :persist_changes
+
+  def self.alias_for(winner, alias_hash, canonical_hash, heartbeat_id:)
+    return if alias_hash == canonical_hash && winner.fields_hash == canonical_hash
+
+    {
+      user_id: winner.user_id,
+      heartbeat_id:,
+      after_heartbeat_id: winner.id,
+      alias_hash:,
+      after_canonical_hash: canonical_hash
+    }
+  end
+  private_class_method :alias_for
+
+  def self.plan_alias_changes(outcome)
+    updates_by_id = outcome[:updates].index_by { |update| update[:id] }
+    redirects_by_id = outcome[:alias_redirects].index_by { |redirect| redirect[:loser_id] }
+    aliases = outcome[:aliases].compact
+    target_ids = (updates_by_id.keys + redirects_by_id.keys).uniq
+    return [] if target_ids.empty? && aliases.empty?
+
+    existing_scope = HeartbeatHashAlias.where(heartbeat_id: target_ids)
+    if aliases.any?
+      existing_scope = existing_scope.or(
+        HeartbeatHashAlias.where(
+          user_id: aliases.pluck(:user_id).uniq,
+          alias_hash: aliases.pluck(:alias_hash).uniq
+        )
+      )
+    end
+    existing = existing_scope.lock.to_a
+    existing_by_key = existing.index_by { |record| [ record.user_id, record.alias_hash ] }
+    desired = {}
+
+    existing.each do |record|
+      redirect = redirects_by_id[record.heartbeat_id]
+      update = updates_by_id[record.heartbeat_id]
+      next unless redirect || update
+
+      desired[[ record.user_id, record.alias_hash ]] = {
+        user_id: record.user_id,
+        heartbeat_id: redirect ? redirect[:heartbeat_id] : update[:id],
+        alias_hash: record.alias_hash,
+        after_heartbeat_id: redirect ? redirect[:winner_id] : update[:id],
+        after_canonical_hash: redirect ? redirect[:canonical_hash] : update[:fields_hash]
+      }
+    end
+    aliases.each { |record| desired[[ record[:user_id], record[:alias_hash] ]] = record }
+
+    desired.values.filter_map do |record|
+      before = existing_by_key[[ record[:user_id], record[:alias_hash] ]]
+      next if before&.heartbeat_id == record[:after_heartbeat_id] &&
+        before.canonical_hash == record[:after_canonical_hash]
+
+      record.merge(
+        before_heartbeat_id: before&.heartbeat_id,
+        before_canonical_hash: before&.canonical_hash
+      )
+    end
+  end
+  private_class_method :plan_alias_changes
+
+  def self.persist_alias_changes(run, changes)
+    return if changes.empty?
+
+    now = Time.current
+    HeartbeatRemapAliasChange.upsert_all(
+      changes.map do |change|
+        change.merge(heartbeat_remap_run_id: run.id, created_at: now, updated_at: now)
+      end,
+      unique_by: :index_heartbeat_remap_alias_changes_on_run_user_alias,
+      update_only: %i[after_heartbeat_id after_canonical_hash]
+    )
+  end
+  private_class_method :persist_alias_changes
+
+  def self.apply_alias_changes(changes)
+    return if changes.empty?
+
+    now = Time.current
+    HeartbeatHashAlias.upsert_all(
+      changes.map do |change|
+        {
+          user_id: change[:user_id],
+          heartbeat_id: change[:after_heartbeat_id],
+          alias_hash: change[:alias_hash],
+          canonical_hash: change[:after_canonical_hash],
+          created_at: now,
+          updated_at: now
+        }
+      end,
+      unique_by: %i[user_id alias_hash],
+      update_only: %i[heartbeat_id canonical_hash]
+    )
+  end
+  private_class_method :apply_alias_changes
+
+  def self.bulk_update_heartbeats(updates)
+    return if updates.empty?
+
+    execute_heartbeat_soft_deletes(updates.select { |update| update[:soft_delete_first] })
+    execute_heartbeat_updates(updates)
+  end
+  private_class_method :bulk_update_heartbeats
+
+  def self.execute_heartbeat_soft_deletes(updates)
+    return if updates.empty?
+
+    connection = Heartbeat.connection
+    has_time_epoch = Heartbeat.column_names.include?("time_epoch")
+    sql = if has_time_epoch
+      <<~SQL
+        UPDATE heartbeats
+        SET deleted_at = CURRENT_TIMESTAMP,
+            updated_at = CURRENT_TIMESTAMP
+        FROM jsonb_to_recordset($1::jsonb) AS changes(id bigint, time_epoch bigint)
+        WHERE heartbeats.id = changes.id
+          AND heartbeats.time_epoch = changes.time_epoch
+      SQL
+    else
+      <<~SQL
+        UPDATE heartbeats
+        SET deleted_at = CURRENT_TIMESTAMP,
+            updated_at = CURRENT_TIMESTAMP
+        FROM jsonb_to_recordset($1::jsonb) AS changes(id bigint)
+        WHERE heartbeats.id = changes.id
+      SQL
+    end
+    execute_json_update(connection, sql, updates.map { |update| update.slice(:id, :time_epoch) })
+  end
+  private_class_method :execute_heartbeat_soft_deletes
+
+  def self.execute_heartbeat_updates(updates)
+    return if updates.empty?
+
+    connection = Heartbeat.connection
+    has_time_epoch = Heartbeat.column_names.include?("time_epoch")
+    sql = if has_time_epoch
+      <<~SQL
+        UPDATE heartbeats
+        SET language = changes.language,
+            fields_hash = changes.fields_hash,
+            deleted_at = changes.deleted_at,
+            updated_at = CURRENT_TIMESTAMP
+        FROM jsonb_to_recordset($1::jsonb)
+          AS changes(id bigint, language varchar, fields_hash text, deleted_at timestamp, time_epoch bigint)
+        WHERE heartbeats.id = changes.id
+          AND heartbeats.time_epoch = changes.time_epoch
+      SQL
+    else
+      <<~SQL
+        UPDATE heartbeats
+        SET language = changes.language,
+            fields_hash = changes.fields_hash,
+            deleted_at = changes.deleted_at,
+            updated_at = CURRENT_TIMESTAMP
+        FROM jsonb_to_recordset($1::jsonb)
+          AS changes(id bigint, language varchar, fields_hash text, deleted_at timestamp)
+        WHERE heartbeats.id = changes.id
+      SQL
+    end
+    payload = updates.map do |update|
+      update.slice(:id, :language, :fields_hash, :deleted_at, :time_epoch)
+    end
+    execute_json_update(connection, sql, payload)
+  end
+  private_class_method :execute_heartbeat_updates
+
+  def self.execute_json_update(connection, sql, records)
+    bind = ActiveRecord::Relation::QueryAttribute.new(
+      "records",
+      records.to_json,
+      ActiveRecord::Type::String.new
+    )
+    connection.exec_update(sql.squish, "Heartbeat remap batch", [ bind ])
+  end
+  private_class_method :execute_json_update
+
+  def self.snapshot_for(heartbeat)
+    heartbeat.attributes.slice(*SNAPSHOT_FIELDS)
+  end
+  private_class_method :snapshot_for
+
+  def self.snapshot_matches?(heartbeat, snapshot)
+    snapshot.slice("language", "fields_hash", "deleted_at").all? do |field, expected|
+      actual = heartbeat.public_send(field)
+      if field == "deleted_at"
+        actual.nil? ? expected.nil? : expected.present? && (actual.to_f - expected.to_time.to_f).abs < 0.001
+      else
+        actual == expected
+      end
+    end
+  end
+  private_class_method :snapshot_matches?
+
+  def self.update_from_snapshot(heartbeat, snapshot)
+    {
+      id: heartbeat.id,
+      time_epoch: heartbeat.attributes["time_epoch"],
+      user_id: heartbeat.user_id,
+      language: snapshot["language"],
+      fields_hash: snapshot.fetch("fields_hash"),
+      deleted_at: snapshot["deleted_at"],
+      active_change: heartbeat.deleted_at.nil? || snapshot["deleted_at"].nil?,
+      soft_delete_first: heartbeat.deleted_at.nil? && heartbeat.fields_hash != snapshot["fields_hash"]
+    }
+  end
+  private_class_method :update_from_snapshot
+
+  def self.reject_occupied_restores(updates)
+    active_updates = updates.select { |update| update[:deleted_at].nil? }
+    occupied_hashes = Heartbeat.where(fields_hash: active_updates.pluck(:fields_hash))
+      .where.not(id: updates.pluck(:id)).pluck(:fields_hash).to_set
+    updates.partition { |update| update[:deleted_at].present? || !occupied_hashes.include?(update[:fields_hash]) }
+      .then { |safe, stale| [ safe, stale.length ] }
+  end
+  private_class_method :reject_occupied_restores
+
+  def self.rollback_alias_changes(changes, restored_heartbeat_ids:)
+    eligible = changes.select { |change| restored_heartbeat_ids.include?(change.heartbeat_id) }
+    return 0 if eligible.empty?
+
+    current = HeartbeatHashAlias.where(
+      user_id: eligible.map(&:user_id).uniq,
+      alias_hash: eligible.map(&:alias_hash).uniq
+    ).lock.to_a.index_by { |record| [ record.user_id, record.alias_hash ] }
+    matched, stale = eligible.partition do |change|
+      record = current[[ change.user_id, change.alias_hash ]]
+      record&.heartbeat_id == change.after_heartbeat_id &&
+        record.canonical_hash == change.after_canonical_hash
+    end
+    delete_ids = matched.filter_map do |change|
+      current[[ change.user_id, change.alias_hash ]].id unless change.before_heartbeat_id
+    end
+    HeartbeatHashAlias.where(id: delete_ids).delete_all if delete_ids.any?
+
+    restores = matched.filter_map do |change|
+      next unless change.before_heartbeat_id
+
+      {
+        user_id: change.user_id,
+        heartbeat_id: change.before_heartbeat_id,
+        alias_hash: change.alias_hash,
+        canonical_hash: change.before_canonical_hash,
+        created_at: Time.current,
+        updated_at: Time.current
+      }
+    end
+    if restores.any?
+      HeartbeatHashAlias.upsert_all(
+        restores,
+        unique_by: %i[user_id alias_hash],
+        update_only: %i[heartbeat_id canonical_hash]
+      )
+    end
+    stale.length
+  end
+  private_class_method :rollback_alias_changes
+
+  def self.complete!(run)
+    run.update_columns(
+      state: HeartbeatRemapRun.states.fetch("completed"),
+      finished_at: Time.current,
+      updated_at: Time.current
+    )
+  end
+  private_class_method :complete!
+
+  def self.finish_rollback!(run)
+    run.update_columns(
+      state: HeartbeatRemapRun.states.fetch("rolled_back"),
+      finished_at: Time.current,
+      updated_at: Time.current
+    )
+  end
+  private_class_method :finish_rollback!
+end

--- a/db/migrate/20260905203922_create_heartbeat_remapping_tables.rb
+++ b/db/migrate/20260905203922_create_heartbeat_remapping_tables.rb
@@ -1,0 +1,75 @@
+class CreateHeartbeatRemappingTables < ActiveRecord::Migration[8.1]
+  def change
+    create_table :heartbeat_hash_aliases do |t|
+      t.references :user, null: false, foreign_key: true
+      t.bigint :heartbeat_id, null: false
+      t.text :alias_hash, null: false
+      t.text :canonical_hash, null: false
+
+      t.timestamps
+    end
+    add_index :heartbeat_hash_aliases, [ :user_id, :alias_hash ], unique: true
+    add_index :heartbeat_hash_aliases, :heartbeat_id
+
+    create_table :heartbeat_remap_runs do |t|
+      t.boolean :dry_run, null: false, default: true
+      t.integer :state, null: false, default: 0
+      t.integer :batch_size, null: false
+      t.bigint :cursor_id, null: false, default: 0
+      t.bigint :max_heartbeat_id, null: false
+      t.bigint :scanned_count, null: false, default: 0
+      t.bigint :changed_count, null: false, default: 0
+      t.bigint :deduplicated_count, null: false, default: 0
+      t.bigint :stale_count, null: false, default: 0
+      t.bigint :unsafe_count, null: false, default: 0
+      t.bigint :error_count, null: false, default: 0
+      t.string :rule_ids, array: true, null: false, default: []
+      t.text :error_message
+      t.datetime :started_at
+      t.datetime :finished_at
+
+      t.timestamps
+    end
+
+    create_table :heartbeat_remap_changes do |t|
+      t.references :heartbeat_remap_run, null: false, foreign_key: { on_delete: :cascade }
+      t.bigint :heartbeat_id, null: false
+      t.bigint :winner_heartbeat_id
+      t.string :action, null: false
+      t.string :rule_ids, array: true, null: false, default: []
+      t.jsonb :preimage, null: false, default: {}
+      t.jsonb :postimage, null: false, default: {}
+      t.datetime :rolled_back_at
+
+      t.timestamps
+    end
+    add_index :heartbeat_remap_changes,
+      [ :heartbeat_remap_run_id, :heartbeat_id ],
+      unique: true,
+      name: :index_heartbeat_remap_changes_on_run_and_heartbeat
+    add_index :heartbeat_remap_changes,
+      [ :heartbeat_remap_run_id, :rolled_back_at, :action, :id ],
+      name: :index_heartbeat_remap_changes_on_pending_rollback
+
+    create_table :heartbeat_remap_alias_changes do |t|
+      t.references :heartbeat_remap_run, null: false, foreign_key: { on_delete: :cascade }
+      t.references :user, null: false, foreign_key: true
+      t.bigint :heartbeat_id, null: false
+      t.text :alias_hash, null: false
+      t.bigint :before_heartbeat_id
+      t.text :before_canonical_hash
+      t.bigint :after_heartbeat_id, null: false
+      t.text :after_canonical_hash, null: false
+      t.datetime :rolled_back_at
+
+      t.timestamps
+    end
+    add_index :heartbeat_remap_alias_changes,
+      [ :heartbeat_remap_run_id, :user_id, :alias_hash ],
+      unique: true,
+      name: :index_heartbeat_remap_alias_changes_on_run_user_alias
+    add_index :heartbeat_remap_alias_changes,
+      [ :heartbeat_remap_run_id, :heartbeat_id, :rolled_back_at ],
+      name: :index_heartbeat_remap_alias_changes_on_rollback_owner
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_20_115013) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_05_203922) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -273,6 +273,18 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_115013) do
     t.index ["scheduled_at"], name: "index_good_jobs_on_scheduled_at_unfinished_unperformed", where: "((finished_at IS NULL) AND (performed_at IS NULL))"
   end
 
+  create_table "heartbeat_hash_aliases", force: :cascade do |t|
+    t.text "alias_hash", null: false
+    t.text "canonical_hash", null: false
+    t.datetime "created_at", null: false
+    t.bigint "heartbeat_id", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["heartbeat_id"], name: "index_heartbeat_hash_aliases_on_heartbeat_id"
+    t.index ["user_id", "alias_hash"], name: "index_heartbeat_hash_aliases_on_user_id_and_alias_hash", unique: true
+    t.index ["user_id"], name: "index_heartbeat_hash_aliases_on_user_id"
+  end
+
   create_table "heartbeat_import_runs", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "encrypted_api_key"
@@ -317,6 +329,60 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_115013) do
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.index ["user_id"], name: "index_heartbeat_import_sources_on_user_id", unique: true
+  end
+
+  create_table "heartbeat_remap_alias_changes", force: :cascade do |t|
+    t.text "after_canonical_hash", null: false
+    t.bigint "after_heartbeat_id", null: false
+    t.text "alias_hash", null: false
+    t.text "before_canonical_hash"
+    t.bigint "before_heartbeat_id"
+    t.datetime "created_at", null: false
+    t.bigint "heartbeat_id", null: false
+    t.bigint "heartbeat_remap_run_id", null: false
+    t.datetime "rolled_back_at"
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["heartbeat_remap_run_id", "heartbeat_id", "rolled_back_at"], name: "index_heartbeat_remap_alias_changes_on_rollback_owner"
+    t.index ["heartbeat_remap_run_id", "user_id", "alias_hash"], name: "index_heartbeat_remap_alias_changes_on_run_user_alias", unique: true
+    t.index ["heartbeat_remap_run_id"], name: "index_heartbeat_remap_alias_changes_on_heartbeat_remap_run_id"
+    t.index ["user_id"], name: "index_heartbeat_remap_alias_changes_on_user_id"
+  end
+
+  create_table "heartbeat_remap_changes", force: :cascade do |t|
+    t.string "action", null: false
+    t.datetime "created_at", null: false
+    t.bigint "heartbeat_id", null: false
+    t.bigint "heartbeat_remap_run_id", null: false
+    t.jsonb "postimage", default: {}, null: false
+    t.jsonb "preimage", default: {}, null: false
+    t.datetime "rolled_back_at"
+    t.string "rule_ids", default: [], null: false, array: true
+    t.datetime "updated_at", null: false
+    t.bigint "winner_heartbeat_id"
+    t.index ["heartbeat_remap_run_id", "heartbeat_id"], name: "index_heartbeat_remap_changes_on_run_and_heartbeat", unique: true
+    t.index ["heartbeat_remap_run_id", "rolled_back_at", "action", "id"], name: "index_heartbeat_remap_changes_on_pending_rollback"
+    t.index ["heartbeat_remap_run_id"], name: "index_heartbeat_remap_changes_on_heartbeat_remap_run_id"
+  end
+
+  create_table "heartbeat_remap_runs", force: :cascade do |t|
+    t.integer "batch_size", null: false
+    t.bigint "changed_count", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.bigint "cursor_id", default: 0, null: false
+    t.bigint "deduplicated_count", default: 0, null: false
+    t.boolean "dry_run", default: true, null: false
+    t.bigint "error_count", default: 0, null: false
+    t.text "error_message"
+    t.datetime "finished_at"
+    t.bigint "max_heartbeat_id", null: false
+    t.string "rule_ids", default: [], null: false, array: true
+    t.bigint "scanned_count", default: 0, null: false
+    t.bigint "stale_count", default: 0, null: false
+    t.datetime "started_at"
+    t.integer "state", default: 0, null: false
+    t.bigint "unsafe_count", default: 0, null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "heartbeats", force: :cascade do |t|
@@ -767,8 +833,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_115013) do
   add_foreign_key "email_addresses", "users"
   add_foreign_key "email_verification_requests", "users"
   add_foreign_key "goals", "users"
+  add_foreign_key "heartbeat_hash_aliases", "users"
   add_foreign_key "heartbeat_import_runs", "users"
   add_foreign_key "heartbeat_import_sources", "users"
+  add_foreign_key "heartbeat_remap_alias_changes", "heartbeat_remap_runs", on_delete: :cascade
+  add_foreign_key "heartbeat_remap_alias_changes", "users"
+  add_foreign_key "heartbeat_remap_changes", "heartbeat_remap_runs", on_delete: :cascade
   add_foreign_key "heartbeats", "ja4s", on_delete: :nullify
   add_foreign_key "heartbeats", "users"
   add_foreign_key "instance_import_sources", "users"

--- a/docs/operations/heartbeat-remapping.md
+++ b/docs/operations/heartbeat-remapping.md
@@ -1,0 +1,56 @@
+# Heartbeat remapping
+
+Heartbeat remap rules correct deterministic client mistakes during ingestion. A historical run applies the same rules to existing rows. Deploy and apply `20260905203922_create_heartbeat_remapping_tables.rb` before starting web or worker processes that contain the remapping code.
+
+Missing languages and the JetBrains `AUTO_DETECTED` sentinel are inferred only when the language catalogue has one possible owner for the filename or extension. Ambiguous extensions such as `.rs` remain unknown rather than depending on catalogue order. Curated authoritative filenames and extensions correct deterministic client mistakes even when the client supplied a different language.
+
+## Start a run
+
+Create and enqueue a dry run from a Rails console:
+
+```ruby
+run = HeartbeatRemapRunner.start!(dry_run: true, batch_size: 1_000)
+HeartbeatRemapJob.perform_later(run.id)
+```
+
+Review that run, then create a separate write run. A dry run cannot be promoted: each run captures its own `max_heartbeat_id`, so dry and write runs are separate snapshots.
+
+```ruby
+run = HeartbeatRemapRunner.start!(dry_run: false, batch_size: 1_000)
+HeartbeatRemapJob.perform_later(run.id)
+```
+
+Rails 8.1 continuations are enabled because GoodJob 4.19 supports the required stopping hook. The database run, changes and counters remain authoritative for resume, audit and rollback.
+
+## Inspect progress
+
+```ruby
+run.reload.slice(
+  "id", "state", "dry_run", "cursor_id", "max_heartbeat_id",
+  "scanned_count", "changed_count", "deduplicated_count",
+  "stale_count", "unsafe_count", "error_count", "error_message"
+)
+run.remap_changes.group(:action).count
+run.remap_changes.order(:id).limit(20).pluck(:heartbeat_id, :action, :preimage, :postimage)
+run.remap_alias_changes.order(:id).limit(20).pluck(
+  :alias_hash, :before_heartbeat_id, :before_canonical_hash,
+  :after_heartbeat_id, :after_canonical_hash
+)
+```
+
+Runs checkpoint after every committed batch. Re-enqueue the same run ID after an interrupted job.
+
+## Roll back a write run
+
+Only completed write runs can be rolled back:
+
+```ruby
+HeartbeatRemapRunner.start_rollback!(run)
+HeartbeatRemapJob.perform_later(run.id)
+```
+
+Rollback first restores hash-changing winners, then collision losers, so every batch is safe even with `batch_size: 1`. It restores pre-existing aliases and removes aliases created by the run when their current state still matches the audit postimage. Concurrently changed heartbeats or aliases are recorded as stale and left unchanged.
+
+## Scan performance
+
+Candidate selection intentionally scans every heartbeat ID from `cursor_id + 1` through the run's captured `max_heartbeat_id` once. It is an indexed primary-key keyset scan with bounded memory and a constant number of database statements per batch. Rules run linearly in memory and reject overselected rows. This is acceptable for infrequent historical corrections and avoids maintaining rule-specific SQL. Add narrower candidate selection only if production measurement shows the full scan is not viable.

--- a/docs/operations/meta.ts
+++ b/docs/operations/meta.ts
@@ -1,0 +1,7 @@
+import { defineMeta } from "blume";
+
+export default defineMeta({
+  title: "Operations",
+  icon: "wrench",
+  order: 6,
+});

--- a/test/jobs/heartbeat_remap_job_test.rb
+++ b/test/jobs/heartbeat_remap_job_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class HeartbeatRemapJobTest < ActiveJob::TestCase
+  test "continuable job processes all database-backed batches" do
+    user = create(:user)
+    2.times do |offset|
+      create(:heartbeat,
+        user:,
+        entity: ".env",
+        language: "Ezhil",
+        category: "coding",
+        type: "file",
+        time: Time.current.to_f + offset)
+    end
+    run = HeartbeatRemapRunner.start!(dry_run: false, batch_size: 1)
+
+    HeartbeatRemapJob.perform_now(run.id)
+
+    assert_predicate run.reload, :completed?
+    assert_equal 2, run.scanned_count
+    assert_equal [ "Dotenv" ], user.heartbeats.distinct.pluck(:language)
+  end
+end

--- a/test/lib/heartbeat_remapper_test.rb
+++ b/test/lib/heartbeat_remapper_test.rb
@@ -1,0 +1,98 @@
+require "test_helper"
+
+class HeartbeatRemapperTest < ActiveSupport::TestCase
+  class FirstRule
+    ID = "test/first/v1"
+    WRITABLE_FIELDS = %i[language].freeze
+
+    def self.call(_attributes) = { language: "First" }
+  end
+
+  class SecondRule
+    ID = "test/second/v1"
+    WRITABLE_FIELDS = %i[language].freeze
+
+    def self.call(attributes) = { language: "#{attributes[:language]} Second" }
+  end
+
+  test "rules run in registry order without mutating the input" do
+    attributes = { entity: "file.txt", language: "Original", dependencies: [ "rack" ] }
+
+    result = HeartbeatRemapper.call(attributes, registry: [ FirstRule, SecondRule ].freeze)
+
+    assert_equal "First Second", result.attributes[:language]
+    assert_equal %w[test/first/v1 test/second/v1], result.rule_ids
+    assert_equal({ entity: "file.txt", language: "Original", dependencies: [ "rack" ] }, attributes)
+  end
+
+  test "rules cannot declare protected fields writable" do
+    rule = Class.new do
+      const_set(:ID, "test/protected/v1")
+      const_set(:WRITABLE_FIELDS, %i[user_id].freeze)
+      define_singleton_method(:call) { |_attributes| { user_id: 2 } }
+    end
+
+    assert_raises(HeartbeatRemapper::InvalidRule) do
+      HeartbeatRemapper.call({ user_id: 1 }, registry: [ rule ])
+    end
+  end
+
+  test "rules cannot change undeclared fields" do
+    rule = Class.new do
+      const_set(:ID, "test/undeclared/v1")
+      const_set(:WRITABLE_FIELDS, %i[language].freeze)
+      define_singleton_method(:call) { |_attributes| { entity: "other.rb" } }
+    end
+
+    assert_raises(HeartbeatRemapper::InvalidRule) do
+      HeartbeatRemapper.call({ entity: "main.rb" }, registry: [ rule ])
+    end
+  end
+
+  test "production rules are idempotent and report only effective changes" do
+    first = HeartbeatRemapper.call({ entity: "/app/main.luau", language: "Lua" })
+    second = HeartbeatRemapper.call(first.attributes)
+
+    assert_equal "Luau", first.attributes[:language]
+    assert_equal [ "language/authoritative-extension/v1" ], first.rule_ids
+    assert_equal first.attributes, second.attributes
+    assert_empty second.rule_ids
+  end
+
+  test "authoritative filenames use the language catalogue" do
+    assert_equal "Dotenv", HeartbeatRemapper.call({ entity: "/app/.env.local", language: "Ezhil" }).attributes[:language]
+    assert_equal "Ignore List", HeartbeatRemapper.call({ entity: "/app/.gitignore", language: "Ezhil" }).attributes[:language]
+    assert_equal "Ignore List", HeartbeatRemapper.call({ entity: "/app/.prettierignore", language: "Text" }).attributes[:language]
+    assert_equal "Option List", HeartbeatRemapper.call({ entity: "/app/.rspec", language: "Ezhil" }).attributes[:language]
+    assert_equal "Git Attributes", HeartbeatRemapper.call({ entity: "/app/.gitattributes", language: "Ezhil" }).attributes[:language]
+  end
+
+  test "authoritative extensions correct deterministic content guessing failures" do
+    assert_equal "JavaScript", HeartbeatRemapper.call({ entity: "/app/config.cjs", language: "Ezhil" }).attributes[:language]
+    assert_equal "Jinja", HeartbeatRemapper.call({ entity: "/app/page.jinja", language: "XML" }).attributes[:language]
+    assert_equal "PostCSS", HeartbeatRemapper.call({ entity: "/app/styles.postcss", language: "Ezhil" }).attributes[:language]
+  end
+
+  test "auto-detected file types use the language catalogue or Unknown" do
+    detected = HeartbeatRemapper.call({ entity: "/app/main.rb", language: "AUTO_DETECTED" })
+    unknown = HeartbeatRemapper.call({ entity: "/app/README.unrecognised", language: "AUTO_DETECTED" })
+    ambiguous_json = HeartbeatRemapper.call({ entity: "/app/package.json", language: "AUTO_DETECTED" })
+    ambiguous_rust = HeartbeatRemapper.call({ entity: "/app/main.rs", language: "AUTO_DETECTED" })
+
+    assert_equal "Ruby", detected.attributes[:language]
+    assert_equal [ "language/auto-detected/v1" ], detected.rule_ids
+    assert_equal "Unknown", unknown.attributes[:language]
+    assert_equal [ "language/auto-detected/v1" ], unknown.rule_ids
+    assert_equal "Unknown", ambiguous_json.attributes[:language]
+    assert_equal [ "language/auto-detected/v1" ], ambiguous_json.rule_ids
+    assert_equal "Unknown", ambiguous_rust.attributes[:language]
+    assert_equal [ "language/auto-detected/v1" ], ambiguous_rust.rule_ids
+  end
+
+  test "genuine Ezhil is preserved" do
+    result = HeartbeatRemapper.call({ entity: "/app/program.n", language: "Ezhil" })
+
+    assert_equal "Ezhil", result.attributes[:language]
+    assert_empty result.rule_ids
+  end
+end

--- a/test/lib/language_utils_test.rb
+++ b/test/lib/language_utils_test.rb
@@ -6,6 +6,8 @@ class LanguageUtilsTest < Minitest::Test
     LanguageUtils.instance_variable_set(:@extension_map, nil)
     LanguageUtils.instance_variable_set(:@alias_map, nil)
     LanguageUtils.instance_variable_set(:@filename_map, nil)
+    LanguageUtils.instance_variable_set(:@unambiguous_extension_map, nil)
+    LanguageUtils.instance_variable_set(:@unambiguous_filename_map, nil)
   end
 
   def teardown
@@ -13,6 +15,8 @@ class LanguageUtilsTest < Minitest::Test
     LanguageUtils.instance_variable_set(:@extension_map, nil)
     LanguageUtils.instance_variable_set(:@alias_map, nil)
     LanguageUtils.instance_variable_set(:@filename_map, nil)
+    LanguageUtils.instance_variable_set(:@unambiguous_extension_map, nil)
+    LanguageUtils.instance_variable_set(:@unambiguous_filename_map, nil)
   end
 
   def test_custom_assembly_extensions_override_other_languages
@@ -31,16 +35,12 @@ class LanguageUtilsTest < Minitest::Test
     assert_equal "Lapse", LanguageUtils.find_name("Lapse")
   end
 
-  def test_authoritative_extension_overrides_client_reported_language
-    assert_equal "Luau", LanguageUtils.fill_missing_language("Lua", entity: "/a/main.luau")
-    assert_equal "Luau", LanguageUtils.fill_missing_language("PLAIN_TEXT", entity: "/a/main.luau")
-    assert_equal "Luau", LanguageUtils.fill_missing_language("luau", entity: "/a/MAIN.LUAU")
-    assert_equal "Luau", LanguageUtils.fill_missing_language(nil, entity: "/a/main.luau")
-  end
-
-  def test_non_authoritative_extensions_still_trust_the_client
+  def test_fill_missing_language_trusts_present_client_languages
+    assert_equal "Lua", LanguageUtils.fill_missing_language("Lua", entity: "/a/main.luau")
     assert_equal "Lua", LanguageUtils.fill_missing_language("Lua", entity: "/a/main.lua")
     assert_equal "C++", LanguageUtils.fill_missing_language("C++", entity: "/a/foo.h")
+    assert_equal "Ruby", LanguageUtils.fill_missing_language(nil, entity: "/a/main.rb")
+    assert_nil LanguageUtils.fill_missing_language(nil, entity: "/a/main.rs")
     assert_nil LanguageUtils.fill_missing_language(nil, entity: "/a/noext")
   end
 end

--- a/test/services/heartbeat_ingest_test.rb
+++ b/test/services/heartbeat_ingest_test.rb
@@ -16,6 +16,32 @@ class HeartbeatIngestTest < ActiveSupport::TestCase
     ActiveJob::Base.queue_adapter = @original_queue_adapter
   end
 
+  test "direct and imported heartbeats share authoritative rules and deduplicate corrected replays" do
+    expected = {
+      ".env" => "Dotenv", ".gitignore" => "Ignore List", ".rspec" => "Option List",
+      ".gitattributes" => "Git Attributes", "config.cjs" => "JavaScript",
+      "page.jinja" => "Jinja", "main.luau" => "Luau", "styles.postcss" => "PostCSS"
+    }
+    %i[direct import].each do |mode|
+      user = create(:user)
+      payload = expected.keys.map do |entity|
+        { entity:, language: "Ezhil", time: 1_700_000_000.0, type: "file" }
+      end
+      first = HeartbeatIngest.call(user:, mode:, heartbeats: payload)
+
+      assert_equal expected.length, first.persisted_count
+      assert_equal 0, first.failed_count
+      assert_equal expected, user.heartbeats.pluck(:entity, :language).to_h
+      assert_equal [ mode == :direct ? "direct_entry" : "wakapi_import" ], user.heartbeats.distinct.pluck(:source_type)
+      replay = payload.map { |row| row.merge(language: expected.fetch(row[:entity])) }
+      assert_no_difference("user.heartbeats.count") do
+        result = HeartbeatIngest.call(user:, mode:, heartbeats: replay)
+        assert_equal expected.length, result.duplicate_count
+        assert_equal 0, result.failed_count
+      end
+    end
+  end
+
   test "direct heartbeat ingest persists normalized heartbeats and schedules dashboard rollup refresh" do
     user = create(:user)
 
@@ -107,6 +133,93 @@ class HeartbeatIngestTest < ActiveSupport::TestCase
     )
 
     assert_equal "coding", user.heartbeats.sole.category
+  end
+
+  test "direct heartbeat ingest corrects a Dotenv filename misclassified as Ezhil" do
+    user = create(:user)
+
+    HeartbeatIngest.call(
+      user: user,
+      mode: :direct,
+      heartbeats: [ { entity: ".env", language: "Ezhil", time: Time.current.to_f, type: "file" } ]
+    )
+
+    assert_equal "Dotenv", user.heartbeats.sole.language
+  end
+
+  test "direct heartbeat ingest replaces AUTO_DETECTED from the filename" do
+    user = create(:user)
+
+    HeartbeatIngest.call(
+      user:,
+      mode: :direct,
+      heartbeats: [ { entity: "main.rb", language: "AUTO_DETECTED", time: Time.current.to_f, type: "file" } ]
+    )
+
+    assert_equal "Ruby", user.heartbeats.sole.language
+  end
+
+  test "direct heartbeat ingest does not guess an ambiguous missing language" do
+    user = create(:user)
+
+    HeartbeatIngest.call(
+      user:,
+      mode: :direct,
+      heartbeats: [ { entity: "main.rs", time: Time.current.to_f, type: "file" } ]
+    )
+
+    assert_nil user.heartbeats.sole.language
+  end
+
+  test "direct heartbeat ingest persists the pre-remap hash as an alias" do
+    user = create(:user)
+
+    result = HeartbeatIngest.call(
+      user: user,
+      mode: :direct,
+      heartbeats: [ { entity: ".env", language: "Ezhil", time: Time.current.to_f, type: "file" } ]
+    )
+
+    heartbeat = result.items.sole.heartbeat
+    alias_record = HeartbeatHashAlias.find_by!(heartbeat_id: heartbeat.id)
+    pre_remap_attributes = heartbeat.attributes.merge("language" => "Ezhil")
+    assert_equal Heartbeat.generate_fields_hash(pre_remap_attributes), alias_record.alias_hash
+    assert_equal heartbeat.fields_hash, alias_record.canonical_hash
+  end
+
+  test "direct heartbeat ingest resolves a canonical hash through a durable alias" do
+    user = create(:user)
+    time = Time.current.to_f
+    legacy = create(:heartbeat, user:, entity: ".env", language: "Ezhil", time:, type: "file", category: "coding")
+    canonical_hash = Heartbeat.generate_fields_hash(legacy.attributes.merge("language" => "Dotenv"))
+    HeartbeatHashAlias.create!(
+      user:, heartbeat_id: legacy.id, alias_hash: canonical_hash,
+      canonical_hash: legacy.fields_hash
+    )
+
+    assert_no_difference("user.heartbeats.count") do
+      result = HeartbeatIngest.call(
+        user:, mode: :direct,
+        heartbeats: [ { entity: ".env", language: "Ezhil", time:, type: "file" } ]
+      )
+
+      assert_equal legacy.id, result.items.sole.heartbeat.id
+      assert_equal 0, result.persisted_count
+      assert_equal 1, result.duplicate_count
+    end
+  end
+
+  test "direct heartbeat ingest replaces an alias target after soft deletion" do
+    user = create(:user)
+    payload = { entity: ".env", language: "Ezhil", time: Time.current.to_f, type: "file" }
+    old_heartbeat = HeartbeatIngest.call(user:, mode: :direct, heartbeats: [ payload ]).items.sole.heartbeat
+    old_heartbeat.soft_delete
+
+    result = HeartbeatIngest.call(user:, mode: :direct, heartbeats: [ payload ])
+
+    new_heartbeat = result.items.sole.heartbeat
+    assert_not_equal old_heartbeat.id, new_heartbeat.id
+    assert_equal new_heartbeat.id, HeartbeatHashAlias.find_by!(user:).heartbeat_id
   end
 
   test "direct heartbeat ingest uses the HTTP user agent when the body omits it" do
@@ -485,6 +598,35 @@ class HeartbeatIngestTest < ActiveSupport::TestCase
     assert_equal [ 100, 200 ], user.heartbeats.order(:ai_output_tokens).pluck(:ai_output_tokens)
   end
 
+  test "direct batch resolution does not let an unresolved duplicate replace a resolved heartbeat" do
+    user = create(:user)
+    timestamp = Time.current.to_f
+    legacy = create(
+      :heartbeat,
+      user:,
+      entity: ".env",
+      language: "Ezhil",
+      time: timestamp,
+      type: "file",
+      category: "coding"
+    )
+
+    assert_no_difference("user.heartbeats.count") do
+      result = HeartbeatIngest.call(
+        user:,
+        mode: :direct,
+        heartbeats: [
+          { entity: ".env", language: "Ezhil", time: timestamp, type: "file" },
+          { entity: ".env", language: "Dotenv", time: timestamp, type: "file" }
+        ]
+      )
+
+      assert_equal 0, result.persisted_count
+      assert_equal 2, result.duplicate_count
+      assert_equal [ legacy.id, legacy.id ], result.items.map { |item| item.heartbeat.id }
+    end
+  end
+
   test "import heartbeat ingest normalizes nanosecond-scaled epoch times" do
     user = create(:user)
     sane_time = 1_700_000_000.0
@@ -496,6 +638,23 @@ class HeartbeatIngestTest < ActiveSupport::TestCase
     )
 
     assert_in_delta sane_time, user.heartbeats.sole.time, 1.0
+  end
+
+  test "import heartbeat ingest replaces an unresolved AUTO_DETECTED filename with Unknown" do
+    user = create(:user)
+
+    HeartbeatIngest.call(
+      user:,
+      mode: :import,
+      heartbeats: [ {
+        entity: "/tmp/file.unrecognised",
+        language: "AUTO_DETECTED",
+        time: 1_700_000_000.0,
+        type: "file"
+      } ]
+    )
+
+    assert_equal "Unknown", user.heartbeats.sole.language
   end
 
   test "import heartbeat ingest applies blank defaults and sanitizes project names" do
@@ -551,8 +710,8 @@ class HeartbeatIngestTest < ActiveSupport::TestCase
       time: 1_700_000_000.0,
       type: "file"
     }
-    # Stored before AUTHORITATIVE_EXTENSIONS existed, so its hash was computed
-    # with the client-reported "Lua" rather than the corrected "Luau".
+    # Stored before the Luau remap rule existed, so its hash was computed with
+    # the client-reported "Lua" rather than the corrected "Luau".
     create_legacy_imported_heartbeat(user, raw)
 
     assert_no_difference("user.heartbeats.count") do
@@ -561,6 +720,10 @@ class HeartbeatIngestTest < ActiveSupport::TestCase
       assert_equal 0, result.persisted_count
       assert_equal 1, result.duplicate_count
     end
+
+    legacy = user.heartbeats.sole
+    canonical_hash = Heartbeat.generate_fields_hash(legacy.attributes.merge("language" => "Luau"))
+    assert_equal legacy.id, HeartbeatHashAlias.find_by!(user:, alias_hash: canonical_hash).heartbeat_id
   end
 
   test "import heartbeat ingest recognizes legacy hashes containing placeholders" do
@@ -640,6 +803,33 @@ class HeartbeatIngestTest < ActiveSupport::TestCase
     assert_equal 80, heartbeat.ai_prompt_length
     assert_equal 12, heartbeat.ai_line_changes
     assert_equal 4, heartbeat.human_line_changes
+  end
+
+  test "legacy import compatibility hashes keep distinct AI telemetry separate" do
+    user = create(:user)
+    timestamp = 1_700_000_000.0
+    base = {
+      ai_session: "session-123",
+      category: "ai coding",
+      entity: "Claude session",
+      time: timestamp,
+      type: "app"
+    }
+
+    first = HeartbeatIngest.call(
+      user:,
+      mode: :import,
+      heartbeats: [ base.merge(ai_output_tokens: 100) ]
+    )
+    second = HeartbeatIngest.call(
+      user:,
+      mode: :import,
+      heartbeats: [ base.merge(ai_output_tokens: 200) ]
+    )
+
+    assert_equal 1, first.persisted_count
+    assert_equal 1, second.persisted_count
+    assert_equal [ 100, 200 ], user.heartbeats.order(:ai_output_tokens).pluck(:ai_output_tokens)
   end
 
   test "direct heartbeat ingest does not queue repo mapping for the last-project sentinel" do

--- a/test/services/heartbeat_remap_runner_test.rb
+++ b/test/services/heartbeat_remap_runner_test.rb
@@ -1,0 +1,356 @@
+require "test_helper"
+
+class HeartbeatRemapRunnerTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  setup do
+    Rails.cache.clear
+    clear_enqueued_jobs
+    @original_queue_adapter = ActiveJob::Base.queue_adapter
+    ActiveJob::Base.queue_adapter = :test
+  end
+
+  teardown do
+    Rails.cache.clear
+    clear_enqueued_jobs
+    ActiveJob::Base.queue_adapter = @original_queue_adapter
+  end
+
+  test "dry runs checkpoint and audit corrections without changing heartbeats or scheduling rollups" do
+    heartbeat = legacy_heartbeat(entity: ".env", language: "Ezhil")
+    original_hash = heartbeat.fields_hash
+    run = HeartbeatRemapRunner.start!(dry_run: true, batch_size: 1)
+    clear_enqueued_jobs
+
+    assert_no_enqueued_jobs(only: DashboardRollupRefreshJob) do
+      HeartbeatRemapRunner.process_batch!(run)
+    end
+
+    assert_predicate run.reload, :completed?
+    assert_equal heartbeat.id, run.cursor_id
+    assert_equal 1, run.scanned_count
+    assert_equal 1, run.changed_count
+    assert_equal "Ezhil", heartbeat.reload.language
+    assert_equal original_hash, heartbeat.fields_hash
+    change = run.remap_changes.sole
+    assert_equal "Ezhil", change.preimage.fetch("language")
+    assert_equal "Dotenv", change.postimage.fetch("language")
+  end
+
+  test "write runs resume in bounded batches and schedule one rollup per affected user" do
+    first = legacy_heartbeat(entity: ".env", language: "Ezhil")
+    second = legacy_heartbeat(entity: ".gitignore", language: "Text", time: first.time + 1, user: first.user)
+    run = HeartbeatRemapRunner.start!(dry_run: false, batch_size: 1)
+    clear_enqueued_jobs
+
+    assert_enqueued_with(job: DashboardRollupRefreshJob, args: [ first.user_id ]) do
+      HeartbeatRemapRunner.process_batch!(run)
+    end
+
+    assert_predicate run.reload, :running?
+    assert_equal first.id, run.cursor_id
+    assert_equal "Dotenv", first.reload.language
+    assert_equal "Text", second.reload.language
+
+    Rails.cache.clear
+    clear_enqueued_jobs
+    assert_enqueued_with(job: DashboardRollupRefreshJob, args: [ first.user_id ]) do
+      HeartbeatRemapRunner.process_batch!(run)
+    end
+
+    assert_predicate run.reload, :completed?
+    assert_equal "Ignore List", second.reload.language
+    assert_equal 2, run.changed_count
+  end
+
+  test "rollup scheduling failures do not mark committed batches as failed" do
+    heartbeat = legacy_heartbeat(entity: ".env", language: "Ezhil")
+    run = HeartbeatRemapRunner.start!(dry_run: false, batch_size: 10)
+    original_schedule_for = DashboardRollupRefreshJob.method(:schedule_for)
+    DashboardRollupRefreshJob.define_singleton_method(:schedule_for) { |*| raise "queue unavailable" }
+
+    error = assert_raises(RuntimeError) { HeartbeatRemapRunner.process_batch!(run) }
+    assert_equal "queue unavailable", error.message
+
+    assert_predicate run.reload, :completed?
+    assert_equal heartbeat.id, run.cursor_id
+    assert_equal "Dotenv", heartbeat.reload.language
+  ensure
+    DashboardRollupRefreshJob.define_singleton_method(:schedule_for, original_schedule_for) if original_schedule_for
+  end
+
+  test "write runs compare identity fields and soft-delete only proven duplicate collisions" do
+    legacy = legacy_heartbeat(entity: ".env", language: "Ezhil")
+    canonical = legacy_heartbeat(
+      entity: legacy.entity,
+      language: "Dotenv",
+      time: legacy.time,
+      user: legacy.user
+    )
+    legacy_hash = legacy.fields_hash
+    HeartbeatHashAlias.create!(
+      user: legacy.user,
+      heartbeat_id: canonical.id,
+      alias_hash: "pre-existing-client-hash",
+      canonical_hash: canonical.fields_hash
+    )
+    run = HeartbeatRemapRunner.start!(dry_run: false, batch_size: 10)
+
+    HeartbeatRemapRunner.process_batch!(run)
+
+    assert_equal legacy.id, legacy.reload.id
+    assert_equal "Dotenv", legacy.language
+    assert_nil legacy.deleted_at
+    assert_not_nil canonical.reload.deleted_at
+    assert_equal 1, run.reload.deduplicated_count
+    assert_equal legacy.id, HeartbeatHashAlias.find_by!(user_id: legacy.user_id, alias_hash: legacy_hash).heartbeat_id
+    assert_equal legacy.id, HeartbeatHashAlias.find_by!(alias_hash: "pre-existing-client-hash").heartbeat_id
+  end
+
+  test "write runs audit hash collisions with unequal identity and leave both rows unchanged" do
+    legacy = legacy_heartbeat(entity: ".env", language: "Ezhil")
+    canonical_hash = Heartbeat.generate_fields_hash(legacy.attributes.merge("language" => "Dotenv"))
+    unrelated = legacy_heartbeat(entity: "unrelated.rb", language: "Ruby", time: legacy.time + 1)
+    unrelated.update_column(:fields_hash, canonical_hash)
+    run = HeartbeatRemapRunner.start!(dry_run: false, batch_size: 10)
+
+    HeartbeatRemapRunner.process_batch!(run)
+
+    assert_equal "Ezhil", legacy.reload.language
+    assert_nil unrelated.reload.deleted_at
+    assert_equal 1, run.reload.unsafe_count
+    assert_predicate run.remap_changes.find_by!(heartbeat_id: legacy.id), :action_unsafe_collision?
+  end
+
+  test "rollback restores corrected rows and soft-deleted collision losers from audit preimages" do
+    legacy = legacy_heartbeat(entity: ".env", language: "Ezhil")
+    canonical = legacy_heartbeat(
+      entity: legacy.entity,
+      language: "Dotenv",
+      time: legacy.time,
+      user: legacy.user
+    )
+    run = HeartbeatRemapRunner.start!(dry_run: false, batch_size: 1)
+    HeartbeatRemapRunner.process_batch!(run) until run.reload.completed?
+    Rails.cache.clear
+    clear_enqueued_jobs
+
+    HeartbeatRemapRunner.start_rollback!(run)
+    assert_enqueued_with(job: DashboardRollupRefreshJob, args: [ legacy.user_id ]) do
+      HeartbeatRemapRunner.rollback_batch!(run)
+    end
+
+    assert_predicate run.reload, :rolling_back?
+    assert_equal "Ezhil", legacy.reload.language
+    assert_nil legacy.deleted_at
+    assert_not_nil canonical.reload.deleted_at
+
+    HeartbeatRemapRunner.rollback_batch!(run)
+
+    assert_predicate run.reload, :rolled_back?
+    assert_nil canonical.reload.deleted_at
+    assert run.remap_changes.all? { |change| change.rolled_back_at.present? }
+  end
+
+  test "rollback restores redirected aliases and removes aliases created by the remap" do
+    legacy = legacy_heartbeat(entity: ".env", language: "Ezhil")
+    canonical = legacy_heartbeat(
+      entity: legacy.entity,
+      language: "Dotenv",
+      time: legacy.time,
+      user: legacy.user
+    )
+    legacy_hash = legacy.fields_hash
+    canonical_hash = canonical.fields_hash
+    winner_alias = HeartbeatHashAlias.create!(
+      user: legacy.user,
+      heartbeat_id: legacy.id,
+      alias_hash: "winner-client-hash",
+      canonical_hash: legacy_hash
+    )
+    loser_alias = HeartbeatHashAlias.create!(
+      user: legacy.user,
+      heartbeat_id: canonical.id,
+      alias_hash: "loser-client-hash",
+      canonical_hash:
+    )
+    run = HeartbeatRemapRunner.start!(dry_run: false, batch_size: 1)
+
+    HeartbeatRemapRunner.process_batch!(run) until run.reload.completed?
+
+    assert_equal [ legacy.id, canonical_hash ], winner_alias.reload.values_at(:heartbeat_id, :canonical_hash)
+    assert_equal [ legacy.id, canonical_hash ], loser_alias.reload.values_at(:heartbeat_id, :canonical_hash)
+    assert HeartbeatHashAlias.exists?(user_id: legacy.user_id, alias_hash: legacy_hash)
+    alias_audits = run.remap_alias_changes.index_by(&:alias_hash)
+    assert_equal [ legacy.id, legacy_hash ], alias_audits.fetch("winner-client-hash")
+      .values_at(:before_heartbeat_id, :before_canonical_hash)
+    assert_equal [ canonical.id, canonical_hash ], alias_audits.fetch("loser-client-hash")
+      .values_at(:before_heartbeat_id, :before_canonical_hash)
+    assert_nil alias_audits.fetch(legacy_hash).before_heartbeat_id
+
+    HeartbeatRemapRunner.start_rollback!(run)
+    HeartbeatRemapRunner.rollback_batch!(run) until run.reload.rolled_back?
+
+    assert_equal [ legacy.id, legacy_hash ], winner_alias.reload.values_at(:heartbeat_id, :canonical_hash)
+    assert_equal [ canonical.id, canonical_hash ], loser_alias.reload.values_at(:heartbeat_id, :canonical_hash)
+    assert_not HeartbeatHashAlias.exists?(user_id: legacy.user_id, alias_hash: legacy_hash)
+  end
+
+  test "repeated alias transitions retain the original preimage and latest postimage" do
+    user = create(:user)
+    original = legacy_heartbeat(entity: "original.rb", language: "Ruby", user:)
+    intermediate = legacy_heartbeat(entity: "intermediate.rb", language: "Ruby", user:)
+    final = legacy_heartbeat(entity: "final.rb", language: "Ruby", user:)
+    alias_record = HeartbeatHashAlias.create!(
+      user:,
+      heartbeat_id: original.id,
+      alias_hash: "reused-alias",
+      canonical_hash: original.fields_hash
+    )
+    run = HeartbeatRemapRunner.start!(dry_run: false, batch_size: 1)
+    first_change = {
+      user_id: user.id,
+      heartbeat_id: original.id,
+      alias_hash: alias_record.alias_hash,
+      before_heartbeat_id: original.id,
+      before_canonical_hash: original.fields_hash,
+      after_heartbeat_id: intermediate.id,
+      after_canonical_hash: intermediate.fields_hash
+    }
+    second_change = first_change.merge(
+      before_heartbeat_id: intermediate.id,
+      before_canonical_hash: intermediate.fields_hash,
+      after_heartbeat_id: final.id,
+      after_canonical_hash: final.fields_hash
+    )
+
+    HeartbeatRemapRunner.send(:persist_alias_changes, run, [ first_change ])
+    HeartbeatRemapRunner.send(:apply_alias_changes, [ first_change ])
+    HeartbeatRemapRunner.send(:persist_alias_changes, run, [ second_change ])
+    HeartbeatRemapRunner.send(:apply_alias_changes, [ second_change ])
+
+    audit = run.remap_alias_changes.sole
+    assert_equal [ original.id, original.fields_hash ],
+      audit.values_at(:before_heartbeat_id, :before_canonical_hash)
+    assert_equal [ final.id, final.fields_hash ],
+      audit.values_at(:after_heartbeat_id, :after_canonical_hash)
+    assert_equal [ final.id, final.fields_hash ],
+      alias_record.reload.values_at(:heartbeat_id, :canonical_hash)
+
+    stale_count = HeartbeatRemapRunner.send(
+      :rollback_alias_changes,
+      [ audit ],
+      restored_heartbeat_ids: [ original.id ]
+    )
+    assert_equal 0, stale_count
+    assert_equal [ original.id, original.fields_hash ],
+      alias_record.reload.values_at(:heartbeat_id, :canonical_hash)
+  end
+
+  test "write runs update a batch with a constant number of heartbeat statements" do
+    user = create(:user)
+    5.times do |offset|
+      legacy_heartbeat(entity: ".env", language: "Ezhil", time: Time.current.to_f + offset, user:)
+    end
+    run = HeartbeatRemapRunner.start!(dry_run: false, batch_size: 10)
+    statements = []
+    subscriber = lambda do |_name, _started, _finished, _unique_id, payload|
+      statements << payload[:sql] unless payload[:cached]
+    end
+
+    ActiveSupport::Notifications.subscribed(subscriber, "sql.active_record") do
+      HeartbeatRemapRunner.process_batch!(run)
+    end
+
+    bulk_updates = statements.grep(/UPDATE heartbeats SET language/i)
+    alias_statements = statements.grep(/(?:SELECT|INSERT|UPDATE|DELETE).*heartbeat_hash_aliases/i)
+    assert_equal 1, bulk_updates.length
+    assert_operator alias_statements.length, :<=, 2
+    assert_equal 5, user.heartbeats.where(language: "Dotenv").count
+  end
+
+  test "rollback audits stale rows and leaves concurrent changes untouched" do
+    heartbeat = legacy_heartbeat(entity: ".env", language: "Ezhil")
+    run = HeartbeatRemapRunner.start!(dry_run: false, batch_size: 10)
+    HeartbeatRemapRunner.process_batch!(run)
+    heartbeat.reload.update!(language: "Concurrent change")
+
+    HeartbeatRemapRunner.start_rollback!(run)
+    HeartbeatRemapRunner.rollback_batch!(run)
+
+    assert_equal "Concurrent change", heartbeat.reload.language
+    assert_equal 1, run.reload.stale_count
+    assert_predicate run, :rolled_back?
+  end
+
+  test "rollback does not reactivate a concurrently deleted heartbeat" do
+    heartbeat = legacy_heartbeat(entity: ".env", language: "Ezhil")
+    run = HeartbeatRemapRunner.start!(dry_run: false, batch_size: 10)
+    HeartbeatRemapRunner.process_batch!(run)
+    heartbeat.soft_delete
+
+    HeartbeatRemapRunner.start_rollback!(run)
+    HeartbeatRemapRunner.rollback_batch!(run)
+
+    assert_not_nil heartbeat.reload.deleted_at
+    assert_equal 1, run.reload.stale_count
+    assert_predicate run, :rolled_back?
+  end
+
+  test "rollback preserves concurrently redirected aliases and counts them as stale" do
+    heartbeat = legacy_heartbeat(entity: ".env", language: "Ezhil")
+    other = legacy_heartbeat(entity: "main.rb", language: "Ruby", user: heartbeat.user)
+    run = HeartbeatRemapRunner.start!(dry_run: false, batch_size: 1)
+    HeartbeatRemapRunner.process_batch!(run) until run.reload.completed?
+    alias_record = HeartbeatHashAlias.find_by!(heartbeat_id: heartbeat.id)
+    alias_record.update!(heartbeat_id: other.id, canonical_hash: other.fields_hash)
+
+    HeartbeatRemapRunner.start_rollback!(run)
+    HeartbeatRemapRunner.rollback_batch!(run) until run.reload.rolled_back?
+
+    assert_equal "Ezhil", heartbeat.reload.language
+    assert_equal [ other.id, other.fields_hash ], alias_record.reload.values_at(:heartbeat_id, :canonical_hash)
+    assert_equal 1, run.reload.stale_count
+    assert_not_nil run.remap_alias_changes.sole.rolled_back_at
+  end
+
+  test "final rollup recovery uses bounded batches and schedules each affected user once" do
+    user = create(:user)
+    3.times do |offset|
+      legacy_heartbeat(entity: "config.cjs", language: "Ezhil", user:, time: Time.current.to_f + offset)
+    end
+    run = HeartbeatRemapRunner.start!(dry_run: false, batch_size: 1)
+    HeartbeatRemapRunner.process_batch!(run) until run.reload.completed?
+    assert_equal [ "JavaScript" ], user.heartbeats.distinct.pluck(:language)
+    Rails.cache.clear
+    clear_enqueued_jobs
+    statements = []
+    subscriber = lambda do |_name, _started, _finished, _unique_id, payload|
+      statements << payload[:sql] if payload[:sql].match?(/SELECT.*heartbeat_remap_changes/i)
+    end
+
+    ActiveSupport::Notifications.subscribed(subscriber, "sql.active_record") do
+      assert_enqueued_jobs 1, only: DashboardRollupRefreshJob do
+        HeartbeatRemapRunner.schedule_rollups!(run)
+      end
+    end
+
+    assert_not_empty statements
+    assert statements.all? { |sql| sql.include?("LIMIT") }, statements.join("\n")
+  end
+
+  private
+
+  def legacy_heartbeat(entity:, language:, time: Time.current.to_f, user: create(:user))
+    create(:heartbeat,
+      user:,
+      entity:,
+      language:,
+      time:,
+      type: "file",
+      category: "coding",
+      dependencies: [],
+      is_write: false,
+      source_type: :direct_entry)
+  end
+end


### PR DESCRIPTION
## Summary of the problem
WakaTime clients can submit incorrect language metadata, including classifying environment files as Ezhil. The existing Luau correction was a one-off ingest override and historical corrections had no reusable, auditable workflow.

## Describe your changes
Add an ordered pure remapper used before canonical hashing in direct and imported ingestion. Preserve deduplication through durable hash aliases and add a resumable, auditable historical runner with dry-run, collision handling, rollback and coalesced rollup refreshes. Include an operations runbook for rollout and recovery.

This is PR 3 of 3 in a stacked change. It depends on #1685, which depends on #1684. Apply the remapping migration before starting updated web or worker processes.

## Screenshots / Media
Not applicable. This is an ingestion and operations change.