### PR TITLE
Install Compose in orbs with an existing Docker CLI

### DIFF
--- a/.agents/setup
+++ b/.agents/setup
@@ -27,7 +27,7 @@ if [ -z "$gh_version" ] || ! dpkg --compare-versions "$gh_version" ge "$gh_min_v
   sudo apt-get install -y gh
 fi
 
-if ! command -v docker >/dev/null 2>&1; then
+if ! command -v docker >/dev/null 2>&1 || ! docker compose version >/dev/null 2>&1; then
   echo "==> Installing Docker and Docker Compose"
   sudo install -m 0755 -d /etc/apt/keyrings
   sudo curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc


### PR DESCRIPTION
## Summary of the problem
Orb setup skipped Compose installation whenever Docker was already installed, leaving the development environment unusable.

## Describe your changes
Check for the Compose plugin as well as Docker before skipping installation. This is the foundation of the heartbeat audit follow-up stack above #1686.

## Screenshots / Media
Not applicable: backend-only changes.