### PR TITLE
Attribute project durations before filtering and grouping

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -136,9 +136,11 @@ derives it from ordered heartbeat timestamps. The default timeout is 2 minutes:
 
 * the first heartbeat contributes zero;
 * each later heartbeat contributes `min(current_time - previous_time, 120s)`;
-* grouped duration partitions by the requested group, while
-  `attributed_durations_by` computes globally ordered gaps and attributes each
-  gap to the current heartbeat's bucket;
+* legacy grouped duration partitions by the requested group; dimension reports
+  instead use `with_attributed_duration` / `attributed_durations_by`, which
+  compute ordered gaps per user before filtering or grouping by dimensions;
+* project details, weekly project buckets, dashboard rollups and ordinary stats
+  APIs attribute each gap to the current row over the complete eligible range;
 * `to_span` splits when a gap exceeds the timeout and caps the prior span's tail
   at the timeout; and
 * boundary-aware calculations include the preceding heartbeat so a requested

--- a/app/controllers/api/hackatime/v1/hackatime_controller.rb
+++ b/app/controllers/api/hackatime/v1/hackatime_controller.rb
@@ -182,7 +182,7 @@ class Api::Hackatime::V1::HackatimeController < ApplicationController
   end
 
   def calculate_category_stats(heartbeats, category)
-    durations = heartbeats.group(category).duration_seconds
+    durations = Heartbeat.attributed_durations_by(heartbeats, category, include_blank: true)
     total_duration = durations.values.sum.to_f
     return [] if total_duration == 0
 

--- a/app/controllers/api/v1/stats_controller.rb
+++ b/app/controllers/api/v1/stats_controller.rb
@@ -51,7 +51,12 @@ class Api::V1::StatsController < ApplicationController
       start_date: start_date,
       end_date: end_date
     }
-    service_params[:scope] = scope if scope
+    if params[:test_param] == "true"
+      service_params[:scope] = scope if scope
+    else
+      service_params[:projects] = filter_by_projects
+      service_params[:categories] = filter_by_categories
+    end
 
     no_ai_coding = params[:no_ai_coding] == "true"
 
@@ -70,6 +75,7 @@ class Api::V1::StatsController < ApplicationController
     else
       if params[:total_seconds] == "true"
         query = Heartbeat.where(user_id: @user.id).where("time >= ? AND time < ?", start_date.to_f, end_date.to_f)
+        query = Heartbeat.with_attributed_duration(query) unless params[:boundary_aware] == "true"
         query = query.where(project: filter_by_projects) if filter_by_projects
         query = query.where(category: filter_by_categories) if filter_by_categories
 
@@ -84,7 +90,7 @@ class Api::V1::StatsController < ApplicationController
           ) || 0
         else
           query = query.where.not(category: "ai coding") if no_ai_coding
-          query.duration_seconds || 0
+          query.pick(Arel.sql("COALESCE(SUM(duration), 0)::integer"))
         end
 
         return render json: { total_seconds: total_seconds }

--- a/app/models/concerns/heartbeatable.rb
+++ b/app/models/concerns/heartbeatable.rb
@@ -227,24 +227,23 @@ module Heartbeatable
       SQL
     end
 
-    def attributed_durations_by(scope, field)
-      scope = scope.with_valid_timestamps
-      field_expr = connection.quote_column_name(field.to_s)
-      attribution_heartbeats = scope.unscope(:group, :select, :order).select(:id, :time, field)
-      heartbeat_gaps = unscoped.from(attribution_heartbeats, :attribution_heartbeats).select(<<~SQL.squish)
-        attribution_heartbeats.#{field_expr} AS bucket,
-        LAG(attribution_heartbeats.time) OVER (
-          ORDER BY attribution_heartbeats.time, attribution_heartbeats.id
-        ) AS duration_start,
-        attribution_heartbeats.time AS duration_end
-      SQL
-      capped_durations = with_capped_duration(heartbeat_gaps)
+    # Apply range and eligibility inside the window, dimension filters outside.
+    def with_attributed_duration(scope = all)
+      timeline = scope.with_valid_timestamps.unscope(:group, :select, :order).select(
+        "#{quoted_table_name}.*",
+        Arel.sql("LEAST(COALESCE(time - LAG(time) OVER (PARTITION BY user_id ORDER BY time, id), 0), #{heartbeat_timeout_duration.to_i}) AS duration")
+      )
+      unscoped.from(timeline, table_name)
+    end
 
+    def attributed_durations_by(scope, field, include_blank: false)
+      field_expr = connection.quote_column_name(field.to_s)
+      attributed = with_attributed_duration(scope).select(field, :duration)
       sql = <<~SQL.squish
-        SELECT bucket, COALESCE(SUM(duration), 0)::integer AS duration
-        FROM (#{capped_durations.to_sql}) attributed_durations
-        WHERE bucket IS NOT NULL AND bucket <> ''
-        GROUP BY bucket
+        SELECT #{field_expr} AS bucket, COALESCE(SUM(duration), 0)::integer AS duration
+        FROM (#{attributed.to_sql}) attributed_durations
+        #{"WHERE #{field_expr} IS NOT NULL AND #{field_expr} <> ''" unless include_blank}
+        GROUP BY #{field_expr}
       SQL
 
       connection.select_all(sql).each_with_object({}) { |row, hash| hash[row["bucket"]] = row["duration"].to_i }

--- a/app/models/dashboard_rollup.rb
+++ b/app/models/dashboard_rollup.rb
@@ -6,6 +6,7 @@ class DashboardRollup < ApplicationRecord
   TODAY_STATS_DIMENSION = "today_stats".freeze
   FILTER_OPTIONS_DIMENSION = "filter_options".freeze
   CODING_RHYTHM_DIMENSION = "coding_rhythm".freeze
+  ATTRIBUTION_VERSION = 2
 
   belongs_to :user
 
@@ -30,6 +31,6 @@ class DashboardRollup < ApplicationRecord
     return false unless current_generation
 
     payload = find_by(user_id: user_id, dimension: TOTAL_DIMENSION)&.payload
-    payload&.fetch("source_generation", nil) != current_generation
+    payload&.fetch("source_generation", nil) != current_generation || payload&.fetch("attribution_version", nil) != ATTRIBUTION_VERSION
   end
 end

--- a/app/services/dashboard_data/snapshots.rb
+++ b/app/services/dashboard_data/snapshots.rb
@@ -14,40 +14,26 @@ module DashboardData
     end
 
     def project_grouped_durations(scope)
-      non_null = scope.where.not(project: nil).group(:project).duration_seconds
-      return non_null if scope.where(project: nil).none?
-
-      null_duration = scope.where(project: nil).duration_seconds
-      return non_null if null_duration.zero?
-
-      non_null.merge(nil => null_duration)
+      Heartbeat.attributed_durations_by(scope, :project, include_blank: true)
     end
 
-    def project_details_snapshot(scope:)
-      timeout = Heartbeat.heartbeat_timeout_duration.to_i
-      relation_sql = scope.with_valid_timestamps
-        .where.not(project: [ nil, "" ], time: nil)
-        .select(:id, :time, :project, :language)
+    def project_details_snapshot(scope:, names: nil)
+      attributed = Heartbeat.with_attributed_duration(scope)
+      attributed = attributed.where(project: names) if names.present?
+      relation_sql = attributed
+        .where.not(project: [ nil, "" ])
+        .select(:time, :project, :language, :duration)
         .to_sql
 
       rows = Heartbeat.connection.select_all(<<~SQL.squish)
-        SELECT grouped_time,
+        SELECT project AS grouped_time,
                COUNT(*)::integer AS heartbeat_count,
                MIN(time) AS first_heartbeat,
                MAX(time) AS last_heartbeat,
                ARRAY_REMOVE(ARRAY_AGG(DISTINCT NULLIF(language, '')), NULL) AS languages,
-               COALESCE(SUM(diff), 0)::integer AS duration
-        FROM (
-          SELECT project AS grouped_time,
-                 time,
-                 language,
-                 CASE
-                   WHEN LAG(time) OVER (PARTITION BY project ORDER BY time, id) IS NULL THEN 0
-                   ELSE LEAST(time - LAG(time) OVER (PARTITION BY project ORDER BY time, id), #{timeout})
-                 END AS diff
-          FROM (#{relation_sql}) project_detail_heartbeats
-        ) diffs
-        GROUP BY grouped_time
+               COALESCE(SUM(duration), 0)::integer AS duration
+        FROM (#{relation_sql}) project_detail_heartbeats
+        GROUP BY project
       SQL
 
       rows.each_with_object({}) do |row, result|
@@ -72,10 +58,9 @@ module DashboardData
       ranges = week_ranges(user.timezone)
       result = ranges.to_h { |week_key, *_| [ week_key, {} ] }
 
-      relation_sql = scope.with_valid_timestamps
-        .where.not(time: nil)
+      relation_sql = Heartbeat.with_attributed_duration(scope)
         .where(time: ranges.last[1]..ranges.first[2])
-        .select(:id, :time, :project)
+        .select(:time, :project, :duration)
         .to_sql
 
       quoted_timezone = Heartbeat.connection.quote(user.timezone)
@@ -84,17 +69,11 @@ module DashboardData
       rows = Heartbeat.connection.select_all(<<~SQL.squish)
         SELECT TO_CHAR(week_group, 'YYYY-MM-DD') AS week_key,
                grouped_time,
-               COALESCE(SUM(diff), 0)::integer AS duration
+               COALESCE(SUM(duration), 0)::integer AS duration
         FROM (
           SELECT project AS grouped_time,
                  #{week_group_sql} AS week_group,
-                 CASE
-                   WHEN LAG(time) OVER (PARTITION BY project, #{week_group_sql} ORDER BY time, id) IS NULL THEN 0
-                   ELSE LEAST(
-                     time - LAG(time) OVER (PARTITION BY project, #{week_group_sql} ORDER BY time, id),
-                     #{Heartbeat.heartbeat_timeout_duration.to_i}
-                   )
-                 END AS diff
+                 duration
           FROM (#{relation_sql}) dashboard_heartbeats
         ) diffs
         GROUP BY week_group, grouped_time
@@ -259,12 +238,7 @@ module DashboardData
     # Date range and archive eligibility belong inside this window; dashboard
     # dimension filters belong outside it. Each gap belongs to the current row.
     def attributed_dashboard_scope(scope)
-      timeout = Heartbeat.heartbeat_timeout_duration.to_i
-      timeline = scope.with_valid_timestamps.reorder(nil).select(
-        :id, :time, *GROUPED_DIMENSIONS,
-        Arel.sql("LEAST(COALESCE(time - LAG(time) OVER (ORDER BY time, id), 0), #{timeout}) AS duration")
-      )
-      Heartbeat.unscoped.from(timeline, :heartbeats)
+      Heartbeat.with_attributed_duration(scope)
     end
 
     def filtered_query_snapshot(user:, scope:)

--- a/app/services/dashboard_rollup_refresh_service.rb
+++ b/app/services/dashboard_rollup_refresh_service.rb
@@ -24,7 +24,7 @@ class DashboardRollupRefreshService < ApplicationService
     records = [
       build_record(dimension: DashboardRollup::TOTAL_DIMENSION, bucket: nil,
                    total_seconds: @scope.duration_seconds, now:,
-                   payload: { source_generation: generation },
+                   payload: { source_generation: generation, attribution_version: DashboardRollup::ATTRIBUTION_VERSION },
                    source_heartbeats_count: @scope.count,
                    source_max_heartbeat_time: @scope.maximum(:time)),
       build_record(dimension: DashboardRollup::FILTER_OPTIONS_DIMENSION, bucket: nil,

--- a/app/services/dashboard_stats.rb
+++ b/app/services/dashboard_stats.rb
@@ -16,7 +16,7 @@ class DashboardStats
     interval = params[:interval]
     return build_filterable_dashboard_data(interval) if rollup_eligible?
 
-    key = [ "attributed_dashboard_v1", user, archived_project_names ] + FILTERS.map { |field| params[field] } + [ interval.to_s, params[:from], params[:to] ]
+    key = [ "attributed_dashboard_v2", user, archived_project_names ] + FILTERS.map { |field| params[field] } + [ interval.to_s, params[:from], params[:to] ]
     Rails.cache.fetch(key, expires_in: 5.minutes) { build_filterable_dashboard_data(interval) }
   end
 

--- a/app/services/project_stats_query.rb
+++ b/app/services/project_stats_query.rb
@@ -18,7 +18,7 @@ class ProjectStatsQuery
   end
 
   def project_names
-    names = scoped_heartbeats(discovery_start_time, discovery_end_time).select(:project).distinct.pluck(:project).compact
+    names = scoped_heartbeats(discovery_start_time, discovery_end_time).select(:project).distinct.pluck(:project).compact_blank
     @include_archived ? names : names.reject { |name| archived_project_names.include?(name) }
   end
 
@@ -31,9 +31,9 @@ class ProjectStatsQuery
     end
 
     query = scoped_heartbeats(stats_start_time, stats_end_time)
-    query = query.where(project: requested_names) if requested_names.any?
+    query = query.where(project: nil).or(query.where.not(project: archived_project_names)) unless @include_archived || archived_project_names.empty?
 
-    stats = DashboardData::Snapshots.project_details_snapshot(scope: query)
+    stats = DashboardData::Snapshots.project_details_snapshot(scope: query, names: requested_names)
     return [] if stats.empty?
 
     candidate_names = requested_names.presence || stats.keys
@@ -79,7 +79,7 @@ class ProjectStatsQuery
     end_ts = timestamp_value(end_time)
     return @user.heartbeats.none if start_ts.nil? || end_ts.nil?
 
-    @user.heartbeats.with_valid_timestamps.where.not(project: [ nil, "" ]).where(time: start_ts..end_ts)
+    @user.heartbeats.with_valid_timestamps.where(time: start_ts..end_ts)
   end
 
   def archived_project_names
@@ -90,7 +90,7 @@ class ProjectStatsQuery
     rows = DashboardRollup.where(user_id: @user.id, dimension: DashboardRollup::PROJECT_DETAILS_DIMENSION, bucket_value_present: true).to_a
     return if rows.empty?
 
-    DashboardRollupRefreshJob.schedule_for(@user.id, wait: 0.seconds) if DashboardRollup.dirty?(@user.id)
+    DashboardRollupRefreshJob.enqueue_for(@user.id, wait: 0.seconds) if DashboardRollup.dirty?(@user.id)
 
     details_by_project = rows.index_by(&:bucket)
     details_by_project.delete("")

--- a/lib/wakatime_service.rb
+++ b/lib/wakatime_service.rb
@@ -4,10 +4,9 @@ include ApplicationHelper
 include ErrorReporting
 
 class WakatimeService
-  def initialize(user: nil, specific_filters: [], allow_cache: true, limit: 10, start_date: nil, end_date: nil, scope: nil, boundary_aware: false, valid_timestamps_only: false, exclude_categories: [])
+  def initialize(user: nil, specific_filters: [], allow_cache: true, limit: 10, start_date: nil, end_date: nil, scope: nil, boundary_aware: false, valid_timestamps_only: false, exclude_categories: [], projects: nil, categories: nil)
     @scope = scope || Heartbeat.all
     @scope = @scope.with_valid_timestamps if valid_timestamps_only
-    @scope = @scope.where.not("LOWER(category) IN (?)", exclude_categories) if exclude_categories.any?
     @exclude_categories = exclude_categories
     @user = user
     @boundary_aware = boundary_aware
@@ -25,6 +24,14 @@ class WakatimeService
     @limit = nil if @limit&.zero?
 
     @scope = @scope.where(user_id: @user.id) if @user.present?
+
+    @attributed_scope = Heartbeat.with_attributed_duration(@scope)
+    @attributed_scope = @attributed_scope.where(project: projects) if projects
+    @attributed_scope = @attributed_scope.where(category: categories) if categories
+    if exclude_categories.any?
+      @scope = @scope.where.not("LOWER(category) IN (?)", exclude_categories)
+      @attributed_scope = @attributed_scope.where.not("LOWER(category) IN (?)", exclude_categories)
+    end
 
     @specific_filters = specific_filters
     @allow_cache = allow_cache
@@ -90,7 +97,7 @@ class WakatimeService
     @total_seconds = if @boundary_aware
       Heartbeat.duration_seconds_boundary_aware(@scope, @start_date, @end_date, excluded_categories: @exclude_categories) || 0
     else
-      @scope.duration_seconds || 0
+      @attributed_scope.pick(Arel.sql("COALESCE(SUM(duration), 0)::integer"))
     end
     summary[:total_seconds] = @total_seconds
 
@@ -107,7 +114,7 @@ class WakatimeService
   end
 
   def summary_cache_key
-    scope_digest = Digest::SHA256.hexdigest(@scope.to_sql)
+    scope_digest = Digest::SHA256.hexdigest((@boundary_aware ? @scope : @attributed_scope).to_sql)
     filters = @specific_filters.map(&:to_s).sort.join(",")
 
     [ "wakatime_service", "summary", "v1", scope_digest, filters, @limit ].join(":")
@@ -115,14 +122,19 @@ class WakatimeService
 
   def generate_summary_chunk(group_by)
     result = []
-    @scope.group(group_by).duration_seconds.each do |key, value|
+    durations = if @boundary_aware
+      @scope.group(group_by).duration_seconds
+    else
+      @attributed_scope.group(group_by).pluck(group_by, Arel.sql("COALESCE(SUM(duration), 0)::integer")).to_h
+    end
+    durations.each do |key, value|
       entry = {
         name: @raw_names ? (key.presence || "Other") : transform_display_name(group_by, key),
         total_seconds: value,
         text: ApplicationController.helpers.short_time_simple(value),
         hours: value / 3600,
         minutes: (value % 3600) / 60,
-        percent: (100.0 * value / @total_seconds).round(2),
+        percent: @total_seconds.positive? ? (100.0 * value / @total_seconds).round(2) : 0,
         digital: ApplicationController.helpers.digital_time(value)
       }
       entry[:color] = LanguageUtils.color(key) if group_by == :language

--- a/test/controllers/api/v1/stats_controller_test.rb
+++ b/test/controllers/api/v1/stats_controller_test.rb
@@ -1,6 +1,27 @@
 require "test_helper"
 
 class Api::V1::StatsControllerTest < ActionDispatch::IntegrationTest
+  test "ordinary stats attribute before project and category filters" do
+    user = create(:user, username: "stats_#{SecureRandom.hex(3)}")
+    start = Time.utc(2026, 4, 14, 10)
+    [ [ "alpha", "coding" ], [ "beta", "browsing" ], [ "alpha", "coding" ], [ "beta", "browsing" ] ].each_with_index do |(project, category), index|
+      create_heartbeat(user:, time: start.to_f + index * 60, project:, category:)
+    end
+    params = { start_date: start.iso8601, end_date: (start + 1.hour).iso8601, features: "projects" }
+    get "/api/v1/users/#{user.username}/stats", params: params
+    assert_response :success
+    assert_equal({ "alpha" => 60, "beta" => 120 }, response.parsed_body.dig("data", "projects").to_h { |row| [ row["name"], row["total_seconds"] ] })
+
+    [ { filter_by_project: "alpha" }, { filter_by_category: "coding" } ].each do |filter|
+      get "/api/v1/users/#{user.username}/stats", params: params.merge(filter)
+      assert_response :success
+      assert_equal 60, response.parsed_body.dig("data", "total_seconds")
+      get "/api/v1/users/#{user.username}/stats", params: params.merge(filter).merge(total_seconds: "true")
+      assert_response :success
+      assert_equal 60, response.parsed_body["total_seconds"]
+    end
+  end
+
   test "user_stats total_seconds matches full summary total for the same filters" do
     user = create(:user, username: "stats_user_#{SecureRandom.hex(3)}")
 

--- a/test/controllers/static_pages_controller_test.rb
+++ b/test/controllers/static_pages_controller_test.rb
@@ -62,7 +62,7 @@ class StaticPagesControllerTest < ActionDispatch::IntegrationTest
       assert_equal(
         {
           "alpha" => 240,
-          "beta" => 120
+          "beta" => 240
         },
         stats["project_durations"]
       )
@@ -70,8 +70,8 @@ class StaticPagesControllerTest < ActionDispatch::IntegrationTest
       assert_equal(
         {
           "2026-04-13" => {
-            "alpha" => 60,
-            "beta" => 120
+            "alpha" => 180,
+            "beta" => 240
           },
           "2026-04-06" => {
             "alpha" => 60

--- a/test/services/dashboard_rollup_refresh_service_test.rb
+++ b/test/services/dashboard_rollup_refresh_service_test.rb
@@ -27,7 +27,7 @@ class DashboardRollupRefreshServiceTest < ActiveSupport::TestCase
       assert_equal user.heartbeats.maximum(:time), total_row.source_max_heartbeat_time
 
       assert_equal(
-        user.heartbeats.group(:project).duration_seconds,
+        { "alpha" => 240, "beta" => 240, nil => 180 },
         DashboardRollup.where(user: user, dimension: "project").to_h { |row| [ row.bucket, row.total_seconds ] }
       )
 
@@ -92,7 +92,7 @@ class DashboardRollupRefreshServiceTest < ActiveSupport::TestCase
       assert_equal [ "active" ], filter_options["project"]
       assert_equal [ "go", "ruby" ], filter_options["language"]
       assert_equal 180, today_stats["todays_duration_seconds"]
-      assert_equal [ "active" ], DashboardRollup.where(user: user, dimension: "project").pluck(:bucket_value)
+      assert_equal({ "active" => 60, nil => 120 }, DashboardRollup.where(user: user, dimension: "project").to_h { |row| [ row.bucket, row.total_seconds ] })
       assert_equal [ "go", "ruby" ], DashboardRollup.where(user: user, dimension: "language").order(:bucket_value).pluck(:bucket_value)
     end
   end

--- a/test/services/dashboard_stats_test.rb
+++ b/test/services/dashboard_stats_test.rb
@@ -38,23 +38,34 @@ class DashboardStatsTest < ActiveSupport::TestCase
   test "project grouped durations preserve nil project values" do
     user = create(:user)
     stats = build_stats(user)
+    [ nil, "alpha", nil, "alpha" ].each_with_index do |project, index|
+      create(:heartbeat, user:, project:, time: Time.utc(2026, 4, 14, 10).to_i + index * 60, source_type: :test_entry)
+    end
+    assert_equal({ nil => 60, "alpha" => 120 }, stats.project_grouped_durations(user.heartbeats))
+  end
 
-    create(:heartbeat,
-      user: user, time: Time.current.to_f - 60, project: nil,
-      language: "ruby", editor: "vscode", operating_system: "macos",
-      category: "coding", source_type: :test_entry
-    )
-    create(:heartbeat,
-      user: user, time: Time.current.to_f, project: nil,
-      language: "ruby", editor: "vscode", operating_system: "macos",
-      category: "coding", source_type: :test_entry
-    )
-    create_heartbeat(user, project: "alpha", language: "ruby", editor: "vscode", operating_system: "macos", category: "coding")
-    create_heartbeat(user, project: "alpha", language: "ruby", editor: "vscode", operating_system: "macos", category: "coding")
-
-    scope = user.heartbeats
-
-    assert_equal scope.group(:project).duration_seconds, stats.project_grouped_durations(scope)
+  test "project attribution agrees across live filtered weekly details and rollup results" do
+    travel_to Time.utc(2026, 4, 14, 12) do
+      user = create(:user)
+      [ "alpha", "beta", "alpha", "beta" ].each_with_index do |project, index|
+        create(:heartbeat, user:, project:, time: Time.current.to_i - 300 + index * 60, source_type: :test_entry)
+      end
+      live = build_stats(user).build_filterable_dashboard_data("today")
+      filtered = build_stats(user, params: { project: "alpha,beta" }).build_filterable_dashboard_data("today")
+      [ live, filtered ].each do |result|
+        assert_equal 180, result[:total_time]
+        assert_equal({ "alpha" => 60, "beta" => 120 }, result[:project_durations])
+        assert_equal result[:project_durations], result[:weekly_project_stats].fetch("2026-04-13")
+      end
+      details = ProjectStatsQuery.new(user:, params: {}).project_details(names: [ "alpha" ])
+      assert_equal 60, details.first[:total_seconds]
+      DashboardRollupRefreshService.new(user:).call
+      assert_equal live[:project_durations], build_stats(user).filterable_dashboard_data[:project_durations]
+      assert_not DashboardRollup.dirty?(user.id)
+      total = DashboardRollup.find_by!(user:, dimension: "total")
+      total.update!(payload: total.payload.except("attribution_version"))
+      assert DashboardRollup.dirty?(user.id)
+    end
   end
 
   test "all-time dashboard data can be served from rollups" do
@@ -595,8 +606,8 @@ class DashboardStatsTest < ActiveSupport::TestCase
 
         assert_equal "alpha", result["top_project"]
         assert_equal [ "alpha" ], result[:project]
-        assert_equal({ "alpha" => 60 }, result[:project_durations])
-        assert_equal({ "alpha" => 60 }, result[:weekly_project_stats].fetch("2026-04-13"))
+        assert_equal({ "alpha" => 180 }, result[:project_durations])
+        assert_equal({ "alpha" => 180 }, result[:weekly_project_stats].fetch("2026-04-13"))
       end
     end
   end


### PR DESCRIPTION
## Summary of the problem
Project buckets and ordinary stats API filters recomputed separate timelines, so their totals could disagree with the complete eligible timeline.

## Describe your changes
Attribute capped gaps to the current heartbeat before dimension filters and aggregation. Align project details, weekly buckets, dashboards and ordinary API breakdowns. Version existing rollups for refresh while retaining the explicit boundary-aware and daily-summary compatibility paths.

## Screenshots / Media
Not applicable: backend-only changes.