### PR TITLE
Fix occasional assembly mislogging

### DIFF
--- a/app/services/heartbeat_ingest.rb
+++ b/app/services/heartbeat_ingest.rb
@@ -102,9 +102,10 @@ class HeartbeatIngest
     source_type = attrs[:entity] == "test.txt" ? :test_entry : :direct_entry
     attrs[:project] = sanitize_project(attrs[:project])
 
+    language_from_placeholder = attrs[:language] == LAST_LANGUAGE_SENTINEL
     resolve_placeholders!(attrs, placeholder_state)
 
-    known_language = attrs[:language] if LanguageUtils.find_name(attrs[:language])
+    known_language = attrs[:language] if language_from_placeholder || LanguageUtils.find_name(attrs[:language])
     inferred = LanguageUtils.fill_missing_language(known_language, entity: attrs[:entity])
     attrs[:language] = inferred if inferred.present?
 

--- a/app/services/heartbeat_ingest.rb
+++ b/app/services/heartbeat_ingest.rb
@@ -104,7 +104,8 @@ class HeartbeatIngest
 
     resolve_placeholders!(attrs, placeholder_state)
 
-    inferred = LanguageUtils.fill_missing_language(attrs[:language], entity: attrs[:entity])
+    known_language = attrs[:language] if LanguageUtils.find_name(attrs[:language])
+    inferred = LanguageUtils.fill_missing_language(known_language, entity: attrs[:entity])
     attrs[:language] = inferred if inferred.present?
 
     attrs[:category] = default_category(attrs[:category], type: attrs[:type])

--- a/test/services/heartbeat_ingest_test.rb
+++ b/test/services/heartbeat_ingest_test.rb
@@ -812,6 +812,40 @@ class HeartbeatIngestTest < ActiveSupport::TestCase
     assert_equal 1, calls
   end
 
+  test "direct heartbeat ingest replaces unrecognized client languages with extension detection" do
+    user = User.create!(timezone: "UTC")
+
+    HeartbeatIngest.call(
+      user: user,
+      mode: :direct,
+      heartbeats: [ {
+        entity: "src/main.asm",
+        language: "RGBDS Assembly",
+        time: Time.current.to_f,
+        type: "file"
+      } ]
+    )
+
+    assert_equal "Assembly", user.heartbeats.sole.language
+  end
+
+  test "direct heartbeat ingest preserves recognized client languages" do
+    user = User.create!(timezone: "UTC")
+
+    HeartbeatIngest.call(
+      user: user,
+      mode: :direct,
+      heartbeats: [ {
+        entity: "src/main.asm",
+        language: "Assembly",
+        time: Time.current.to_f,
+        type: "file"
+      } ]
+    )
+
+    assert_equal "Assembly", user.heartbeats.sole.language
+  end
+
   test "import heartbeat ingest deduplicates imported heartbeats and schedules dashboard rollup refresh" do
     user = create(:user)
 

--- a/test/services/heartbeat_ingest_test.rb
+++ b/test/services/heartbeat_ingest_test.rb
@@ -429,6 +429,29 @@ class HeartbeatIngestTest < ActiveSupport::TestCase
     assert_equal [ "Python", "Python" ], heartbeats.pluck(:language)
   end
 
+  test "direct heartbeat ingest preserves an unrecognized language resolved from the last-language placeholder" do
+    user = create(:user)
+    now = Time.current.to_f
+    user.heartbeats.create!(
+      entity: "historical.asm", project: "demo", language: "RGBDS Assembly",
+      category: "coding", source_type: :direct_entry, time: now - 10, type: "file"
+    )
+
+    HeartbeatIngest.call(
+      user: user,
+      mode: :direct,
+      heartbeats: [ {
+        entity: "src/second.py",
+        project: "demo",
+        language: "<<LAST_LANGUAGE>>",
+        time: now,
+        type: "file"
+      } ]
+    )
+
+    assert_equal "RGBDS Assembly", user.heartbeats.order(:id).last.language
+  end
+
   test "direct heartbeat ingest normalizes millisecond-scaled epoch times" do
     user = create(:user)
     sane_time = Time.current.to_f
@@ -836,14 +859,14 @@ class HeartbeatIngestTest < ActiveSupport::TestCase
       user: user,
       mode: :direct,
       heartbeats: [ {
-        entity: "src/main.asm",
-        language: "Assembly",
+        entity: "src/main.rb",
+        language: "Python",
         time: Time.current.to_f,
         type: "file"
       } ]
     )
 
-    assert_equal "Assembly", user.heartbeats.sole.language
+    assert_equal "Python", user.heartbeats.sole.language
   end
 
   test "import heartbeat ingest deduplicates imported heartbeats and schedules dashboard rollup refresh" do


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->

Editors like Zed Sometimes send "RGBDS Assembly" as the language for `.asm` files. Since that string isn't in `languages.yml` or `languges_custom.yml`, it was stored as is, instead of mapping to Assembly.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

Previously, `normalize_direct_heartbeat` only fell back to extension detection when the client language was blank or unknown. Now it also falls back whenever the client language isn't recognized.

Comes with 2 tests to verify unrecognized client languages are replaced using extension detection and one to verify recognized languages are still preserved.


## Screenshots / Media
<!-- If there are any visual changes, please attach images, videos, or gifs. -->
N/A