### PR TITLE
Fix editor and OAuth documentation

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -29,7 +29,7 @@ ENCRYPTION_DETERMINISTIC_KEY=32characterrandomstring12345678902
 ENCRYPTION_KEY_DERIVATION_SALT=16charssalt1234
 ```
 
-Visit <https://hca.dinosaurbbq.org>, log in with an email address, then enable Developer Mode in HCA settings. After that, navigate to the "Developers' Corner" and "app yourself up", specifying callback URLs of `http://localhost:3000/auth/hca/callback` and `http://localhost:3000/deletion/hca/callback`, with minimum scopes of `email`, `slack_id`, and `verification_status`.
+Visit <https://hca.dinosaurbbq.org>, log in with an email address, then enable Developer Mode in HCA settings. After that, navigate to the "Developers' Corner" and "app yourself up", specifying callback URLs of `http://localhost:3000/auth/hca/callback` and `http://localhost:3000/deletion/hca/callback`, with minimum scopes of `openid`, `email`, `slack_id`, and `verification_status`.
 
 Then, fill out the following fields in your `.env` file:
 

--- a/docs/editors/aseprite.md
+++ b/docs/editors/aseprite.md
@@ -31,7 +31,7 @@ After installing, you will need to grab your Hackatime API key and manually add 
 
    ```ini
    [settings]
-   api_url = https://hackatime.hackclub.com/api
+   api_url = https://hackatime.hackclub.com/api/hackatime/v1
    api_key = YOUR_HACKATIME_API_KEY
    ```
 

--- a/docs/oauth/oauth-apps.md
+++ b/docs/oauth/oauth-apps.md
@@ -140,6 +140,8 @@ All endpoints below require a valid OAuth access token in the `Authorization: Be
 
 ### GET /api/v1/authenticated/me
 
+**Required scope:** `profile`
+
 Returns information about the authenticated user.
 
 **Response:**
@@ -158,6 +160,8 @@ Returns information about the authenticated user.
 ```
 
 ### GET /api/v1/authenticated/hours
+
+**Required scope:** `read`
 
 Returns total coding time for a date range.
 
@@ -180,6 +184,8 @@ Returns total coding time for a date range.
 
 ### GET /api/v1/authenticated/streak
 
+**Required scope:** `read`
+
 Returns the user's current coding streak.
 
 **Response:**
@@ -191,6 +197,8 @@ Returns the user's current coding streak.
 ```
 
 ### GET /api/v1/authenticated/projects
+
+**Required scope:** `read`
 
 Returns the user's projects with time totals.
 
@@ -217,6 +225,8 @@ Returns the user's projects with time totals.
 ```
 
 ### GET /api/v1/authenticated/heartbeats/latest
+
+**Required scope:** `read`
 
 Returns the user's most recent heartbeat.
 
@@ -246,6 +256,8 @@ If the user has no heartbeats (excluding setup test entries), the endpoint retur
 ```
 
 ### GET /api/v1/authenticated/api_keys
+
+This endpoint does not require a specific OAuth scope beyond a valid access token.
 
 Returns the user's Hackatime API key (creates one if none exists).
 


### PR DESCRIPTION
## Summary of the problem

Setup documentation omitted required HCA and OAuth scope details, and the Aseprite configuration used an incomplete Hackatime API base URL.

## Describe your changes

- Document the complete Aseprite WakaTime API base URL.
- Include the `openid` HCA scope for the deletion callback.
- Describe OAuth scopes required by each authenticated endpoint, including that API key retrieval has no endpoint-specific scope.

## Screenshots / Media

Not applicable. Documentation-only changes.